### PR TITLE
fix(ci): prepare release pipeline for first publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -72,7 +72,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add "*/uv.lock"
-          git diff --staged --quiet || git commit -m "chore: update lockfiles" && git push
+          if ! git diff --staged --quiet; then
+            git commit -m "chore: update lockfiles"
+            git push
+          fi
 
   release-sdk:
     needs: release-please

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "skip-github-release": true,
-  "draft-pull-request": true,
+  "draft-pull-request": false,
   "changelog-sections": [
     {
       "type": "feat",
@@ -64,7 +64,8 @@
         "pyproject.toml",
         "bog_agents/_version.py"
       ],
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "bootstrap-sha": "1b917cac5edd46287bc2a42914cbeefb6d48ff6f"
     },
     "libs/cli": {
       "release-type": "python",
@@ -76,7 +77,8 @@
         "pyproject.toml",
         "bog_agents_cli/_version.py"
       ],
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "bootstrap-sha": "1b917cac5edd46287bc2a42914cbeefb6d48ff6f"
     }
   },
   "tag-separator": "==",


### PR DESCRIPTION
- Disable draft PRs so release PRs are immediately mergeable
- Add bootstrap-sha to both packages so release-please has a clean starting point without needing pre-existing GitHub releases
- Fix bash operator precedence bug in lockfile commit step