### PR TITLE
fix(cli): use compatible version range for SDK dependency

### DIFF
--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 dependencies = [
     # Framework
-    "bog-agents==0.5.0",
+    "bog-agents>=0.5.0,<1.0.0",
     "langchain>=1.2.10,<2.0.0",
     "langgraph>=1.1.2,<2.0.0",
     "langgraph-checkpoint-sqlite>=3.0.0,<4.0.0",


### PR DESCRIPTION
The exact pin bog-agents==0.5.0 breaks when the SDK is released at a different version. Use >=0.5.0,<1.0.0 so the CLI accepts any compatible SDK release.