### PR TITLE
chore(sdk,cli): bump version to 0.6.1 for PyPI release

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "libs/bog-agents": "0.6.0",
-  "libs/cli": "0.6.0"
+  "libs/bog-agents": "0.6.1",
+  "libs/cli": "0.6.1"
 }

--- a/libs/bog-agents/bog_agents/_version.py
+++ b/libs/bog-agents/bog_agents/_version.py
@@ -1,3 +1,3 @@
 """Version information for `bog-agents` (SDK)."""
 
-__version__ = "0.6.0"  # x-release-please-version
+__version__ = "0.6.1"  # x-release-please-version

--- a/libs/bog-agents/pyproject.toml
+++ b/libs/bog-agents/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bog-agents"
-version = "0.6.0"
+version = "0.6.1"
 
 description = "Bog Agents - batteries-included agent harness for building AI agents. Supports any major provider (Anthropic, OpenAI, AWS Bedrock, Google, etc.) and local models via Ollama. Built on LangGraph."
 readme = "README.md"

--- a/libs/bog-agents/uv.lock
+++ b/libs/bog-agents/uv.lock
@@ -238,7 +238,7 @@ wheels = [
 
 [[package]]
 name = "bog-agents"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "langchain" },

--- a/libs/cli/bog_agents_cli/_version.py
+++ b/libs/cli/bog_agents_cli/_version.py
@@ -1,3 +1,3 @@
 """Version information for `bog-agents-cli`."""
 
-__version__ = "0.6.0"  # x-release-please-version
+__version__ = "0.6.1"  # x-release-please-version

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bog-agents-cli"
-version = "0.6.0"
+version = "0.6.1"
 description = "A coding agent in your terminal. 50+ commands, any LLM provider, persistent memory, git workflow, code review, plan mode, remote sandboxes, and CI/CD automation. One install, no code required."
 readme = "README.md"
 license = { text = "MIT" }

--- a/libs/cli/uv.lock
+++ b/libs/cli/uv.lock
@@ -303,7 +303,7 @@ wheels = [
 
 [[package]]
 name = "bog-agents"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "../bog-agents" }
 dependencies = [
     { name = "langchain" },
@@ -392,7 +392,7 @@ test = [
 
 [[package]]
 name = "bog-agents-cli"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
0.6.0 was already published; bump to 0.6.1 so manual release workflow can publish the latest fixes.