### PR TITLE
chore(ci): set last-release-sha for release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -65,7 +65,7 @@
         "bog_agents/_version.py"
       ],
       "changelog-path": "CHANGELOG.md",
-      "bootstrap-sha": "1b917cac5edd46287bc2a42914cbeefb6d48ff6f"
+      "last-release-sha": "89c07173c63cd019b2d2dc0fa25f78e14c81945e"
     },
     "libs/cli": {
       "release-type": "python",
@@ -78,7 +78,7 @@
         "bog_agents_cli/_version.py"
       ],
       "changelog-path": "CHANGELOG.md",
-      "bootstrap-sha": "1b917cac5edd46287bc2a42914cbeefb6d48ff6f"
+      "last-release-sha": "d47f743d6607a95a01bfe82aade6fdc642977c87"
     }
   },
   "tag-separator": "==",


### PR DESCRIPTION
Replace bootstrap-sha with last-release-sha pointing to the 0.6.2 tag commits. This tells release-please to only scan commits after those points, avoiding the "untagged merged release PRs outstanding" abort caused by legacy PRs #10 and #11.