### PR TITLE
fix(ci): remove skip-github-release to unblock release-please

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,3 +170,4 @@ jobs:
           commit: ${{ github.sha }}
           generateReleaseNotes: true
           draft: false
+          allowUpdates: true

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "skip-github-release": true,
   "draft-pull-request": false,
   "changelog-sections": [
     {


### PR DESCRIPTION
skip-github-release prevents release-please from transitioning the autorelease label from pending to tagged, permanently blocking future releases. Remove it so the full release cycle completes. Add allowUpdates to ncipollo/release-action to handle the case where release-please already created the GitHub release.