### PR TITLE
chore(release): bump bog-agents-daemon to 0.7.2

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "libs/bog-agents": "0.7.2",
   "libs/cli": "0.7.2",
-  "libs/daemon": "0.7.1"
+  "libs/daemon": "0.7.2"
 }

--- a/libs/daemon/bog_agents_daemon/__init__.py
+++ b/libs/daemon/bog_agents_daemon/__init__.py
@@ -1,3 +1,3 @@
 """Bog Agents Daemon — ambient agent service."""
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"

--- a/libs/daemon/pyproject.toml
+++ b/libs/daemon/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bog-agents-daemon"
-version = "0.7.1"
+version = "0.7.2"
 description = "Ambient agent daemon for bog-agents — run agents on schedules, file-change triggers, webhooks, and git pushes"
 readme = "README.md"
 license = { text = "MIT" }

--- a/libs/daemon/uv.lock
+++ b/libs/daemon/uv.lock
@@ -138,7 +138,7 @@ test = [
 
 [[package]]
 name = "bog-agents-daemon"
-version = "0.7.1"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Aligns the daemon with bog-agents and bog-agents-cli, both already published at 0.7.2 on PyPI. No daemon code changes — version-only bump for monorepo coherence so all three packages share a tag.