### PR TITLE
chore(ci): link bog-agents, bog-agents-cli, and bog-agents-daemon ver…

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -93,6 +93,17 @@
       "last-release-sha": "5483f3b0000000000000000000000000000000000"
     }
   },
+  "plugins": [
+    {
+      "type": "linked-versions",
+      "groupName": "bog-agents-monorepo",
+      "components": [
+        "bog-agents",
+        "bog-agents-cli",
+        "bog-agents-daemon"
+      ]
+    }
+  ],
   "tag-separator": "==",
   "include-component-in-tag": true,
   "include-v-in-tag": false


### PR DESCRIPTION
…sions

Adds release-please's linked-versions plugin so all three packages bump together on every release. Going forward, any conventional commit scoped (sdk), (cli), or (daemon) triggers a coordinated release across the trio at the same version.

Activated after the asymmetric 0.7.2 catch-up so the daemon could reach version parity with the SDK and CLI before linkage took effect; from 0.7.3 onward the three packages stay in lockstep.