### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "libs/bog-agents": "0.7.2",
-  "libs/cli": "0.7.2",
-  "libs/daemon": "0.7.2"
+  "libs/bog-agents": "0.7.3",
+  "libs/cli": "0.7.3",
+  "libs/daemon": "0.7.3"
 }

--- a/libs/bog-agents/CHANGELOG.md
+++ b/libs/bog-agents/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.7.3](https://github.com/bogware/bog-agents/compare/bog-agents==0.7.2...bog-agents==0.7.3) (2026-04-29)
+
+
+### Features
+
+* verify/call subcommands, shell reliability, cross-platform hardening, 12 CVEs closed ([#51](https://github.com/bogware/bog-agents/issues/51)) ([5f13fb4](https://github.com/bogware/bog-agents/commit/5f13fb4de5aa7cb50731b634796f0732a8a25f65))
+
 ## [0.7.2](https://github.com/bogware/bog-agents/compare/bog-agents==0.7.1...bog-agents==0.7.2) (2026-04-25)
 
 

--- a/libs/cli/CHANGELOG.md
+++ b/libs/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.7.3](https://github.com/bogware/bog-agents/compare/bog-agents-cli==0.7.2...bog-agents-cli==0.7.3) (2026-04-29)
+
+
+### Features
+
+* verify/call subcommands, shell reliability, cross-platform hardening, 12 CVEs closed ([#51](https://github.com/bogware/bog-agents/issues/51)) ([5f13fb4](https://github.com/bogware/bog-agents/commit/5f13fb4de5aa7cb50731b634796f0732a8a25f65))
+
 ## [0.7.2](https://github.com/bogware/bog-agents/compare/bog-agents-cli==0.7.1...bog-agents-cli==0.7.2) (2026-04-25)
 
 

--- a/libs/daemon/CHANGELOG.md
+++ b/libs/daemon/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.7.3](https://github.com/bogware/bog-agents/compare/bog-agents-daemon==0.7.2...bog-agents-daemon==0.7.3) (2026-04-29)
+
+
+### Features
+
+* verify/call subcommands, shell reliability, cross-platform hardening, 12 CVEs closed ([#51](https://github.com/bogware/bog-agents/issues/51)) ([5f13fb4](https://github.com/bogware/bog-agents/commit/5f13fb4de5aa7cb50731b634796f0732a8a25f65))
+
 ## [0.7.1](https://github.com/bogware/bog-agents/compare/bog-agents-daemon==0.7.0...bog-agents-daemon==0.7.1) (2026-04-20)
 
 


### PR DESCRIPTION
> [!CAUTION]
> Merging this PR will automatically publish to **PyPI** and create a **GitHub release**.

For the full release process, see [`.github/RELEASING.md`](https://github.com/bogware/bog-agents/blob/main/.github/RELEASING.md).

---

_Everything below this line will be the GitHub release body._

---


<details><summary>bog-agents: 0.7.3</summary>

## [0.7.3](https://github.com/bogware/bog-agents/compare/bog-agents==0.7.2...bog-agents==0.7.3) (2026-04-29)


### Features

* verify/call subcommands, shell reliability, cross-platform hardening, 12 CVEs closed ([#51](https://github.com/bogware/bog-agents/issues/51)) ([5f13fb4](https://github.com/bogware/bog-agents/commit/5f13fb4de5aa7cb50731b634796f0732a8a25f65))
</details>

<details><summary>bog-agents-cli: 0.7.3</summary>

## [0.7.3](https://github.com/bogware/bog-agents/compare/bog-agents-cli==0.7.2...bog-agents-cli==0.7.3) (2026-04-29)


### Features

* verify/call subcommands, shell reliability, cross-platform hardening, 12 CVEs closed ([#51](https://github.com/bogware/bog-agents/issues/51)) ([5f13fb4](https://github.com/bogware/bog-agents/commit/5f13fb4de5aa7cb50731b634796f0732a8a25f65))
</details>

<details><summary>bog-agents-daemon: 0.7.3</summary>

## [0.7.3](https://github.com/bogware/bog-agents/compare/bog-agents-daemon==0.7.2...bog-agents-daemon==0.7.3) (2026-04-29)


### Features

* verify/call subcommands, shell reliability, cross-platform hardening, 12 CVEs closed ([#51](https://github.com/bogware/bog-agents/issues/51)) ([5f13fb4](https://github.com/bogware/bog-agents/commit/5f13fb4de5aa7cb50731b634796f0732a8a25f65))
</details>

---

_Everything above this line will be the GitHub release body._
