### PR TITLE
release(0.7.4): Bedrock auth_mode + auto-fallback (#54), probe cache (#53), refreshed model catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,80 @@ All notable changes to bog-agents (SDK), bog-agents-cli, and
 bog-agents-daemon are documented here. The three packages are released
 together with synchronised version numbers.
 
+## [0.7.4] — 2026-04-30
+
+Targeted patch release closing two reported Bedrock issues plus a
+catalog refresh against live AWS / Anthropic / Google docs.
+
+### Fixed
+
+- **GH #53 — Bedrock probe flooded the log with TokenRetrievalError
+  tracebacks.** A single `bog-agents` invocation produced 20+
+  identical 50-line stack traces when the AWS SSO session was expired,
+  because the langchain auto-detect loop calls `_has_bedrock_credentials`
+  many times back-to-back. New negative-result cache in
+  `_check_bedrock_thorough` logs the first failure of each kind with
+  its traceback and emits a one-liner thereafter; a successful probe
+  clears the cache so a freshly-renewed SSO session is detected
+  without restarting the process.
+
+- **GH #54 — Bedrock failed entirely when SSO config was expired even
+  though `~/.aws/credentials` had fresh static keys.** boto3 walks
+  the credential chain in order — when `~/.aws/config` declares a
+  `sso_session = X` the SSO provider short-circuits the lookup
+  before ever reading `~/.aws/credentials`, so `TokenRetrievalError`
+  was the only outcome. The new `auth_mode` setting controls which
+  source(s) are tried; the default `'auto'` mode now catches the
+  SSO failure and **automatically retries with a static-credentials-
+  only session** (SSO providers explicitly removed from the chain).
+  Users with both expired SSO and fresh static keys now Just Work.
+
+### Added
+
+- **`auth_mode` for Bedrock**, with five values:
+  - `auto` (default) — try every source; auto-fall-back from expired
+    SSO to static credentials.
+  - `sso` — force the SSO path; fail loudly when expired.
+  - `static` — use only `~/.aws/credentials` (or
+    `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`).
+  - `profile` — use the named AWS profile from the new `aws_profile`
+    config key.
+  - `iam` — force IAM instance/role credentials (EC2/ECS/Lambda).
+
+  Configurable via `[models.providers.bedrock]` in
+  `~/.bog-agents/config.toml`, or via `BOG_AGENTS_BEDROCK_AUTH_MODE`
+  / `BOG_AGENTS_BEDROCK_PROFILE` env vars (env wins). New helper
+  `save_bedrock_auth_mode(mode, profile)` for programmatic config.
+
+- **Provider catalog refreshed against live docs (2026-04-30):**
+  - **Anthropic:** Claude Opus 4.7, Sonnet 4.6, Haiku 4.5 (current);
+    Opus 4.6, Sonnet 4.5, Opus 4.5, Opus 4.1 (legacy still available).
+  - **Bedrock:** added inference-profile-prefixed IDs
+    (`us.anthropic.claude-opus-4-7`, `us.anthropic.claude-sonnet-4-6`,
+    etc.) plus base IDs for Anthropic, Amazon Nova
+    (Premier/Pro/Lite/Micro), Meta Llama 4 Maverick + Scout + 3.3 70B,
+    and Mistral Large 3 / Pixtral Large.
+  - **Google:** Gemini 2.5 Pro / Flash / Flash-Lite GA, plus the
+    Gemini 3 preview family (`gemini-3.1-pro-preview`,
+    `gemini-3-flash-preview`, `gemini-3.1-flash-lite-preview`).
+
+### Tests
+
+- 5 new tests in `TestBedrockProbeCache` and `TestBedrockAuthMode`:
+  - probe-cache classification (sso-expired, no-credentials)
+  - 5x failure → 1 traceback (regression for #53)
+  - successful probe clears the cache
+  - default auth mode is `auto`
+  - env var overrides config
+  - `save_bedrock_auth_mode` round-trip
+  - `save_bedrock_auth_mode` rejects invalid modes
+  - **auto-fallback from expired SSO to static creds** (regression for #54)
+
+Full CI matrix (Windows variant): SDK 1226 passed, CLI 2685 passed,
+daemon 95 passed. Lint + ty clean.
+
+
+
 ## [0.7.3] — 2026-04-29
 
 This release lands ~20 fixes accumulated during multi-day validation

--- a/libs/bog-agents/bog_agents/_version.py
+++ b/libs/bog-agents/bog_agents/_version.py
@@ -1,3 +1,3 @@
 """Version information for `bog-agents` (SDK)."""
 
-__version__ = "0.7.3"  # x-release-please-version
+__version__ = "0.7.4"  # x-release-please-version

--- a/libs/bog-agents/pyproject.toml
+++ b/libs/bog-agents/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bog-agents"
-version = "0.7.3"
+version = "0.7.4"
 
 description = "Bog Agents - batteries-included agent harness for building AI agents. Supports any major provider (Anthropic, OpenAI, AWS Bedrock, Google, etc.) and local models via Ollama. Built on LangGraph."
 readme = "README.md"

--- a/libs/cli/bog_agents_cli/_version.py
+++ b/libs/cli/bog_agents_cli/_version.py
@@ -1,3 +1,3 @@
 """Version information for `bog-agents-cli`."""
 
-__version__ = "0.7.3"  # x-release-please-version
+__version__ = "0.7.4"  # x-release-please-version

--- a/libs/cli/bog_agents_cli/app.py
+++ b/libs/cli/bog_agents_cli/app.py
@@ -10059,6 +10059,18 @@ class BogAgentsApp(App):
                 model_id = (self._base_model_spec or "").lower()
                 if model_id.startswith("ollama:"):
                     is_tool_capability_error = True
+            # Bedrock-specific: when the langgraph remote stream wraps a
+            # botocore TokenRetrievalError it ends up here as a generic
+            # 'internal error occurred' message. Detect by exception
+            # *name* (RemoteException carries the original class name in
+            # str(e) on most paths) AND by checking whether the active
+            # model is bedrock-flavoured. We surface a Bedrock-specific
+            # action hint below.
+            is_bedrock_model = (
+                (self._base_model_spec or "")
+                .lower()
+                .startswith(("bedrock:", "bedrock_converse:"))
+            )
             is_auth_error = any(
                 keyword in err_name.lower() or keyword in err_str
                 for keyword in (
@@ -10069,7 +10081,15 @@ class BogAgentsApp(App):
                     "accessdenied",
                     "expired",
                     "sso",
+                    "tokenretrievalerror",
+                    "nocredentialserror",
                 )
+            ) or (
+                # Generic 'internal error' from langgraph + bedrock model =
+                # almost always an SSO/credential issue at the AWS layer.
+                err_name == "RemoteException"
+                and "internal error" in err_str
+                and is_bedrock_model
             )
             if is_tool_capability_error:
                 await self._mount_message(

--- a/libs/cli/bog_agents_cli/doctor.py
+++ b/libs/cli/bog_agents_cli/doctor.py
@@ -86,6 +86,64 @@ def _read_default_ollama_model() -> str | None:
     return None
 
 
+def _bedrock_credential_status() -> tuple[str, str]:
+    """Probe AWS credentials for the Bedrock provider and report their state.
+
+    Walks boto3's standard credential chain (env, profile, SSO, instance
+    role) without making a network call. Catches the common failure modes
+    a Bedrock user hits at the CLI:
+
+    - boto3 not installed (transitive dep of langchain-aws — should never
+      happen but reported gracefully).
+    - No credentials anywhere — points the user to ``aws configure``.
+    - SSO session expired (TokenRetrievalError) — points the user to
+      ``aws sso login``.
+    - Credentials present but access_key empty — points at the profile.
+
+    Returns:
+        (status, detail) tuple where status is "OK"/"WARN"/"FAIL" and
+        detail is a human-readable one-liner suitable for the doctor table.
+    """
+    try:
+        import boto3  # type: ignore[import-untyped]
+    except ImportError:
+        return "WARN", "boto3 not installed (transitive of langchain-aws)"
+
+    # botocore raises TokenRetrievalError when an SSO token has expired.
+    # Map it to a clean actionable message instead of a stack trace.
+    try:
+        from botocore.exceptions import (  # type: ignore[import-untyped]
+            NoCredentialsError,
+            TokenRetrievalError,
+        )
+    except ImportError:
+        # Older botocore — fall back to generic Exception
+        class TokenRetrievalError(Exception):  # type: ignore[no-redef]
+            pass
+
+        class NoCredentialsError(Exception):  # type: ignore[no-redef]
+            pass
+
+    try:
+        session = boto3.Session()
+        creds = session.get_credentials()
+        if creds is None:
+            return "WARN", "no AWS credentials found — run `aws configure`"
+        # `get_frozen_credentials()` is what triggers SSO token refresh,
+        # and where TokenRetrievalError surfaces if the SSO session expired.
+        frozen = creds.get_frozen_credentials()
+        if not frozen.access_key:
+            return "WARN", "AWS credentials resolved but access_key is empty"
+        method = getattr(creds, "method", "?")
+        return "OK", f"AWS credentials valid (source: {method})"
+    except TokenRetrievalError as exc:
+        return "FAIL", f"AWS SSO token expired — run `aws sso login` ({exc})"
+    except NoCredentialsError:
+        return "WARN", "no AWS credentials found — run `aws configure`"
+    except Exception as exc:
+        return "FAIL", f"AWS credential probe error: {type(exc).__name__}: {exc}"
+
+
 def run_doctor() -> str:
     """Run comprehensive health checks and return a diagnostic report.
 
@@ -132,6 +190,8 @@ def run_doctor() -> str:
         ("langchain-openai", "OPENAI_API_KEY"),
         ("langchain-google-genai", "GOOGLE_API_KEY"),
         ("langchain-ollama", None),
+        # Bedrock uses AWS credentials, not a single API key — handled below.
+        ("langchain-aws", "__BEDROCK__"),
     ]
     for pkg, env_key in providers:
         try:
@@ -139,6 +199,9 @@ def run_doctor() -> str:
             if env_key is None:
                 status = "OK"
                 detail = f"v{dist.version} (local provider)"
+            elif env_key == "__BEDROCK__":
+                status, bedrock_detail = _bedrock_credential_status()
+                detail = f"v{dist.version} ({bedrock_detail})"
             else:
                 has_key = bool(os.environ.get(env_key))
                 status = "OK" if has_key else "WARN"

--- a/libs/cli/bog_agents_cli/doctor.py
+++ b/libs/cli/bog_agents_cli/doctor.py
@@ -124,6 +124,27 @@ def _bedrock_credential_status() -> tuple[str, str]:
         class NoCredentialsError(Exception):  # type: ignore[no-redef]
             pass
 
+    # If the runtime credential probe already saw a failure this session,
+    # reuse its classification instead of triggering yet another expensive
+    # boto3 SSO refresh attempt (which would log another full traceback —
+    # issue #53). The cache only stores negative results; on success the
+    # runtime probe clears it so this branch falls through.
+    try:
+        from bog_agents_cli.model_config import _BEDROCK_PROBE_CACHE
+
+        if _BEDROCK_PROBE_CACHE:
+            for kind, (_ok, detail) in _BEDROCK_PROBE_CACHE.items():
+                if "sso-expired" in kind:
+                    return (
+                        "FAIL",
+                        f"AWS SSO token expired — run `aws sso login` ({detail})",
+                    )
+                if "no-credentials" in kind:
+                    return "WARN", "no AWS credentials found — run `aws configure`"
+                return "FAIL", f"AWS credential probe error: {detail}"
+    except ImportError:
+        pass
+
     try:
         session = boto3.Session()
         creds = session.get_credentials()

--- a/libs/cli/bog_agents_cli/main.py
+++ b/libs/cli/bog_agents_cli/main.py
@@ -1113,6 +1113,69 @@ def _run_doctor(console: Any) -> None:  # noqa: ANN401
     console.print(run_doctor(), markup=False)
 
 
+_TERMINAL_RESTORE_SEQUENCES: tuple[str, ...] = (
+    # Disable mouse tracking in every protocol Textual / prompt-toolkit
+    # might have enabled. If the TUI exits abnormally (uncaught
+    # exception, SIGTERM, agent crash mid-launch) the terminal is left
+    # in mouse-tracking mode, and any subsequent click in the user's
+    # shell shows up as garbage like `[<35;57;14M[` on stdin.
+    "\033[?1003l",  # disable any-event mouse tracking
+    "\033[?1002l",  # disable button-event tracking
+    "\033[?1000l",  # disable basic mouse tracking
+    "\033[?1006l",  # disable SGR mouse mode (the `<...M` form we observed)
+    "\033[?1015l",  # disable urxvt mouse mode
+    "\033[?2004l",  # disable bracketed-paste mode
+    "\033[?25h",  # ensure cursor is visible
+    "\033[?1049l",  # leave alternate screen buffer
+)
+
+
+def _restore_terminal() -> None:
+    """Best-effort restore the terminal to a sane state.
+
+    Runs as an atexit handler and from SIGTERM/SIGINT signal handlers.
+    Idempotent: writing the disable sequences multiple times is safe.
+    Silently skipped when stdout is not a TTY (piped output).
+    """
+    try:
+        if not sys.stdout.isatty():
+            return
+        sys.stdout.write("".join(_TERMINAL_RESTORE_SEQUENCES))
+        sys.stdout.flush()
+    except (OSError, ValueError):
+        # Closed stream during shutdown — nothing to restore.
+        pass
+
+
+def _install_terminal_restore_handlers() -> None:
+    """Wire `_restore_terminal` to atexit + SIGTERM/SIGINT.
+
+    Without this, a crash mid-Textual-startup leaves the terminal in
+    mouse-tracking + alternate-screen mode and the user's shell shows
+    SGR escape sequences as input (e.g. `[<35;57;14M[`).
+    """
+    import atexit
+    import signal
+
+    atexit.register(_restore_terminal)
+
+    def _on_signal(_signum: int, _frame: object) -> None:
+        _restore_terminal()
+        # Re-raise the default signal so the process actually exits with
+        # the right exit code (KeyboardInterrupt for SIGINT, etc.).
+        sys.exit(130)
+
+    for sig_name in ("SIGINT", "SIGTERM", "SIGHUP", "SIGBREAK"):
+        sig = getattr(signal, sig_name, None)
+        if sig is None:
+            continue
+        try:
+            signal.signal(sig, _on_signal)
+        except (OSError, ValueError):
+            # Some platforms (Windows) don't allow setting all signals.
+            pass
+
+
 def cli_main() -> None:
     """Entry point for console script.
 
@@ -1120,6 +1183,12 @@ def cli_main() -> None:
         SystemExit: Propagated from `sys.exit()` in subcommand dispatch
             paths (the standard argparse + subcommand exit pattern).
     """
+    # Install terminal-restore handlers early — if any subsequent setup
+    # crashes (e.g. before Textual takes over the screen) the terminal
+    # still ends up in a sane state. Belt-and-suspenders for Textual's
+    # own cleanup, which is bypassed on hard exits.
+    _install_terminal_restore_handlers()
+
     # Fix for gRPC fork issue on macOS
     # https://github.com/grpc/grpc/issues/37642
     if sys.platform == "darwin":
@@ -1676,10 +1745,13 @@ def cli_main() -> None:
                         provider = (detectprovider(spec_for_creds) or "").lower()
                     env_var = PROVIDER_API_KEY_ENV.get(provider)
                     # Local providers (ollama) don't need an API key; bedrock/
-                    # vertexai use other auth flows. Skip the gate for them.
+                    # vertexai use other auth flows. Skip the simple env-var
+                    # gate for them; bedrock gets a dedicated boto3 probe
+                    # below.
                     if (
                         env_var
-                        and provider not in ("ollama", "bedrock_converse", "vertexai")
+                        and provider
+                        not in ("ollama", "bedrock", "bedrock_converse", "vertexai")
                         and not os.environ.get(env_var)
                     ):
                         sys.stderr.write(
@@ -1690,6 +1762,27 @@ def cli_main() -> None:
                         )
                         sys.stderr.flush()
                         sys.exit(2)
+                    # Bedrock pre-flight: probe boto3's credential chain so
+                    # an expired SSO token surfaces as a clean one-line
+                    # message instead of as a generic "internal error
+                    # occurred" wrapped through langgraph's RemoteException.
+                    if provider in ("bedrock", "bedrock_converse"):
+                        try:
+                            from bog_agents_cli.doctor import (
+                                _bedrock_credential_status,
+                            )
+
+                            status, detail = _bedrock_credential_status()
+                        except (
+                            Exception
+                        ):  # pre-flight only — never block on its own bug
+                            status, detail = "OK", "probe-skipped"
+                        if status == "FAIL":
+                            sys.stderr.write(
+                                f"Error: Bedrock credentials unavailable: {detail}\n"
+                            )
+                            sys.stderr.flush()
+                            sys.exit(2)
             except SystemExit:
                 raise
             except Exception:  # pre-flight only; agent will surface real errors

--- a/libs/cli/bog_agents_cli/model_config.py
+++ b/libs/cli/bog_agents_cli/model_config.py
@@ -188,6 +188,33 @@ class ProviderConfig(TypedDict, total=False):
       Fastest but cannot detect expired credentials.
     """
 
+    auth_mode: str
+    """Bedrock-only — which credential source(s) to use, in priority order.
+
+    Supported values:
+    - `'auto'` (default): Try every source boto3 knows about. On
+      TokenRetrievalError from a configured-but-expired SSO session,
+      automatically retry with a static-credentials-only session so
+      fresh keys in `~/.aws/credentials` work even when the SSO config
+      in `~/.aws/config` is stale.
+    - `'sso'`: Force the SSO path. Fail loudly if the session is expired.
+    - `'static'`: Use only `~/.aws/credentials` (or AWS_ACCESS_KEY_ID /
+      AWS_SECRET_ACCESS_KEY env vars). Never touches SSO config — useful
+      when you have working static creds and want to ignore the SSO
+      session that boto3 would otherwise prefer.
+    - `'profile'`: Use the named AWS profile from the `aws_profile`
+      setting below. Both SSO-backed and static-creds profiles are honored.
+    - `'iam'`: Force IAM instance/role credentials (EC2/ECS/Lambda).
+    """
+
+    aws_profile: str
+    """Bedrock-only — the named AWS profile when `auth_mode='profile'`.
+
+    Distinct from the ``profile`` key above (which is the model-runtime
+    profile-overrides dict). Keep these separate to avoid a TOML key
+    collision; the boto3 profile lives at ``aws_profile`` in config.
+    """
+
 
 DEFAULT_CONFIG_DIR = Path.home() / ".bog-agents"
 """Directory for user-level Bog Agents configuration (`~/.bog-agents`)."""
@@ -800,6 +827,158 @@ def _has_bedrock_credentials() -> bool:
 _BEDROCK_PROBE_CACHE: dict[str, tuple[bool, str]] = {}
 
 
+def _bedrock_auth_mode() -> tuple[str, str]:
+    """Resolve the Bedrock auth-mode + profile name from config / env.
+
+    Precedence (highest first):
+      1. ``BOG_AGENTS_BEDROCK_AUTH_MODE`` env var
+      2. ``[models.providers.bedrock] auth_mode`` in config.toml
+      3. ``[models.providers.bedrock_converse] auth_mode`` (legacy)
+      4. ``"auto"`` default
+
+    The profile name has the same precedence chain via the env var
+    ``BOG_AGENTS_BEDROCK_PROFILE`` and the ``profile`` config key, then
+    finally ``AWS_PROFILE`` from the environment as a sensible default.
+
+    Returns:
+        (mode, profile_name) — mode is one of the documented strings;
+        profile_name is the empty string when not configured.
+    """
+    env_mode = os.environ.get("BOG_AGENTS_BEDROCK_AUTH_MODE", "").strip().lower()
+    if env_mode:
+        mode = env_mode
+    else:
+        try:
+            cfg = ModelConfig.load()
+        except (OSError, ValueError):
+            cfg = None
+        bedrock_cfg: Mapping[str, Any] = {}
+        if cfg is not None:
+            bedrock_cfg = cfg.providers.get("bedrock_converse") or cfg.providers.get(
+                "bedrock", {}
+            )
+        mode = (bedrock_cfg.get("auth_mode") or "auto").strip().lower()
+
+    env_profile = os.environ.get("BOG_AGENTS_BEDROCK_PROFILE", "").strip()
+    if env_profile:
+        profile = env_profile
+    else:
+        try:
+            cfg = ModelConfig.load()
+        except (OSError, ValueError):
+            cfg = None
+        bedrock_cfg: Mapping[str, Any] = {}
+        if cfg is not None:
+            bedrock_cfg = cfg.providers.get("bedrock_converse") or cfg.providers.get(
+                "bedrock", {}
+            )
+        profile = (
+            bedrock_cfg.get("aws_profile") or os.environ.get("AWS_PROFILE", "")
+        ).strip()
+
+    valid = {"auto", "sso", "static", "profile", "iam"}
+    if mode not in valid:
+        logger.warning("Unknown bedrock auth_mode '%s'; falling back to 'auto'", mode)
+        mode = "auto"
+    return mode, profile
+
+
+def _build_static_creds_session(profile: str = "") -> Any:  # noqa: ANN401 — boto3.Session is dynamically typed
+    """Build a boto3 Session that uses only ~/.aws/credentials (and env vars).
+
+    Constructs a botocore Session with the SSO providers explicitly
+    removed from the credential chain, so an expired SSO config in
+    ~/.aws/config can't short-circuit the lookup. Used as the fallback
+    leg of the ``auto`` auth mode when an SSO probe raises
+    ``TokenRetrievalError``.
+
+    Args:
+        profile: Optional named profile. Empty string = default profile.
+
+    Returns:
+        A boto3.Session bound to a credentials-file-only botocore Session.
+    """
+    import boto3  # type: ignore[import-untyped]
+    from botocore.session import (
+        Session as BotocoreSession,  # type: ignore[import-untyped]
+    )
+
+    botocore_session = BotocoreSession()
+    if profile:
+        botocore_session.set_config_variable("profile", profile)
+    # Drop SSO providers from the chain — keep env vars + ~/.aws/credentials
+    # (the "shared-credentials-file" provider) + IAM. The names below are
+    # the canonical botocore provider IDs.
+    component = botocore_session.get_component("credential_provider")
+    for sso_provider in ("sso", "sso-token"):
+        try:
+            component.remove(sso_provider)
+        except (KeyError, ValueError):
+            pass
+    return boto3.Session(botocore_session=botocore_session)
+
+
+def _build_bedrock_session(mode: str, profile: str) -> Any:  # noqa: ANN401 — boto3.Session is dynamically typed
+    """Build the boto3 Session that the Bedrock probe + runtime should use.
+
+    Args:
+        mode: One of ``'auto'``, ``'sso'``, ``'static'``, ``'profile'``,
+            ``'iam'`` — see ``_bedrock_auth_mode`` docs.
+        profile: AWS profile name (used for ``'profile'`` mode and as a
+            hint for ``'static'`` / ``'sso'``).
+
+    Returns:
+        A boto3.Session configured per the requested auth mode. Caller is
+        responsible for catching credential-resolution exceptions.
+
+    Raises:
+        ValueError: When ``mode='profile'`` is set but no profile name
+            is provided via config or env var.
+    """
+    import boto3  # type: ignore[import-untyped]
+
+    if mode == "static":
+        return _build_static_creds_session(profile)
+    if mode == "sso":
+        if profile:
+            return boto3.Session(profile_name=profile)
+        return boto3.Session()
+    if mode == "profile":
+        if not profile:
+            msg = (
+                "auth_mode='profile' requires a profile name — set "
+                "[models.providers.bedrock] profile = ... in config.toml or "
+                "BOG_AGENTS_BEDROCK_PROFILE in the environment."
+            )
+            raise ValueError(msg)
+        return boto3.Session(profile_name=profile)
+    if mode == "iam":
+        # Disable env-var + shared-credentials-file + SSO providers so
+        # only the IAM/instance-metadata provider runs.
+        from botocore.session import (
+            Session as BotocoreSession,  # type: ignore[import-untyped]
+        )
+
+        botocore_session = BotocoreSession()
+        component = botocore_session.get_component("credential_provider")
+        for prov in (
+            "env",
+            "shared-credentials-file",
+            "sso",
+            "sso-token",
+            "assume-role",
+        ):
+            try:
+                component.remove(prov)
+            except (KeyError, ValueError):
+                pass
+        return boto3.Session(botocore_session=botocore_session)
+    # auto — default boto3 chain
+    if profile:
+        return boto3.Session(profile_name=profile)
+    return boto3.Session()
+
+
 def _classify_bedrock_probe_failure(exc: BaseException) -> str:
     """Map a boto3 exception to a short stable classification string.
 
@@ -832,42 +1011,95 @@ def _check_bedrock_thorough() -> bool:
     Returns:
         True if boto3 resolves valid-looking credentials.
     """
-    try:
-        import boto3  # type: ignore[import-untyped]
+    mode, profile = _bedrock_auth_mode()
 
-        session = boto3.Session()
-        creds = session.get_credentials()
-        if creds is None:
-            cached = _BEDROCK_PROBE_CACHE.get("no-credentials")
-            if cached is None:
-                logger.debug("boto3 returned no credentials")
-                _BEDROCK_PROBE_CACHE["no-credentials"] = (
-                    False,
-                    "boto3 found no credentials",
+    def _probe(session_factory: Any, label: str) -> bool | None:  # noqa: ANN401
+        """Run the probe with ``session_factory()``.
+
+        Returns ``True`` on valid creds, ``False`` on no-creds (caller
+        should still try fallback), ``None`` on fatal error (cached).
+        """
+        try:
+            session = session_factory()
+            creds = session.get_credentials()
+            if creds is None:
+                logger.debug("boto3 returned no credentials (%s)", label)
+                return False
+            frozen = creds.get_frozen_credentials()
+            has_key = bool(frozen.access_key)
+            if has_key:
+                _BEDROCK_PROBE_CACHE.clear()
+                logger.debug(
+                    "boto3 credentials resolved (mode=%s%s, source=%s)",
+                    mode,
+                    f" profile={profile}" if profile else "",
+                    label,
                 )
+                return True
+            logger.debug(
+                "boto3 credentials resolved but access_key is empty (%s)", label
+            )
             return False
-        frozen = creds.get_frozen_credentials()
-        has_key = bool(frozen.access_key)
-        if not has_key:
-            logger.debug("boto3 credentials resolved but access_key is empty")
-        else:
-            # Reset the cache on success so a freshly-renewed SSO session
-            # is detected without restarting the process.
-            _BEDROCK_PROBE_CACHE.clear()
-            logger.debug("boto3 credentials resolved successfully (thorough check)")
-        return has_key
-    except Exception as exc:
-        kind = _classify_bedrock_probe_failure(exc)
-        cached = _BEDROCK_PROBE_CACHE.get(kind)
-        if cached is None:
-            # First failure of this kind: log the traceback once for
-            # diagnostic value and remember we've seen it.
-            logger.debug("boto3 credential resolution failed (%s)", kind, exc_info=True)
-            _BEDROCK_PROBE_CACHE[kind] = (False, f"{type(exc).__name__}: {exc}")
-        else:
-            # Subsequent failures: one-liner only.
-            logger.debug("boto3 credential resolution failed (%s; cached)", kind)
+        except Exception as exc:
+            kind = _classify_bedrock_probe_failure(exc)
+            cached = _BEDROCK_PROBE_CACHE.get(f"{label}:{kind}")
+            if cached is None:
+                logger.debug(
+                    "boto3 credential resolution failed (%s, %s)",
+                    label,
+                    kind,
+                    exc_info=True,
+                )
+                _BEDROCK_PROBE_CACHE[f"{label}:{kind}"] = (
+                    False,
+                    f"{type(exc).__name__}: {exc}",
+                )
+            else:
+                logger.debug(
+                    "boto3 credential resolution failed (%s, %s; cached)", label, kind
+                )
+            # Auto-mode: a TokenRetrievalError on the SSO leg should not be
+            # fatal — let the caller try the static-creds fallback.
+            if mode == "auto" and kind == "sso-expired" and label == "default-chain":
+                return False
+            return None
+
+    try:
+        import boto3  # noqa: F401 — only here to surface ImportError cleanly
+    except ImportError:
+        logger.debug("boto3 not installed; cannot probe Bedrock credentials")
         return False
+
+    if mode == "auto":
+        # Try the default boto3 chain first. If SSO is expired, try the
+        # static-creds-only chain so fresh ~/.aws/credentials keys work.
+        result = _probe(
+            lambda: _build_bedrock_session("auto", profile), "default-chain"
+        )
+        if result:
+            return True
+        if result is False:
+            # The default chain didn't surface valid creds — fall back to
+            # static-only. This is the issue-#54 fix: an expired SSO
+            # session in ~/.aws/config short-circuits the lookup before
+            # boto3 ever reads ~/.aws/credentials.
+            logger.debug(
+                "Default credential chain came up empty; trying static-creds fallback"
+            )
+            result = _probe(
+                lambda: _build_static_creds_session(profile), "static-fallback"
+            )
+            return bool(result)
+        # result is None — fatal (cached); the SSO error already surfaced
+        # via the cache. Try the static fallback as a last resort so a
+        # user with both expired SSO AND fresh static keys still works.
+        logger.debug("SSO/default chain failed fatally; trying static-creds fallback")
+        result = _probe(lambda: _build_static_creds_session(profile), "static-fallback")
+        return bool(result)
+
+    # Forced mode — single attempt, no fallback.
+    result = _probe(lambda: _build_bedrock_session(mode, profile), mode)
+    return bool(result)
 
 
 def _check_bedrock_boto3() -> bool:
@@ -1881,6 +2113,79 @@ def save_bedrock_credential_check(mode: str, config_path: Path | None = None) ->
             raise
     except (OSError, tomllib.TOMLDecodeError):
         logger.exception("Could not save Bedrock credential check mode")
+        return False
+    else:
+        global _default_config_cache  # noqa: PLW0603
+        _default_config_cache = None
+        return True
+
+
+def save_bedrock_auth_mode(
+    mode: str,
+    profile: str | None = None,
+    config_path: Path | None = None,
+) -> bool:
+    """Persist the Bedrock auth-mode + optional profile to config.toml.
+
+    Writes ``[models.providers.bedrock].auth_mode`` and (optionally)
+    ``[models.providers.bedrock].profile``. The next ``bog-agents``
+    invocation will use the configured mode without any env vars.
+
+    Args:
+        mode: One of ``'auto'``, ``'sso'``, ``'static'``, ``'profile'``,
+            ``'iam'``.
+        profile: Optional AWS profile name. When None, the ``profile``
+            key is left unchanged. When the empty string, the key is
+            removed.
+        config_path: Path to config file. Defaults to
+            ``~/.bog-agents/config.toml``.
+
+    Returns:
+        True if save succeeded, False on I/O error.
+
+    Raises:
+        ValueError: If *mode* is not one of the supported strings.
+    """
+    valid_modes = {"auto", "sso", "static", "profile", "iam"}
+    if mode not in valid_modes:
+        msg = f"invalid auth_mode '{mode}'; must be one of {sorted(valid_modes)}"
+        raise ValueError(msg)
+
+    if config_path is None:
+        config_path = DEFAULT_CONFIG_PATH
+
+    try:
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if config_path.exists():
+            with config_path.open("rb") as f:
+                data = tomllib.load(f)
+        else:
+            data = {}
+
+        bedrock_section = (
+            data.setdefault("models", {})
+            .setdefault("providers", {})
+            .setdefault("bedrock", {})
+        )
+        bedrock_section["auth_mode"] = mode
+        if profile is not None:
+            if profile:
+                bedrock_section["aws_profile"] = profile
+            else:
+                bedrock_section.pop("aws_profile", None)
+
+        fd, tmp_path = tempfile.mkstemp(dir=config_path.parent, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "wb") as f:
+                tomli_w.dump(data, f)
+            Path(tmp_path).replace(config_path)
+        except BaseException:
+            with contextlib.suppress(OSError):
+                Path(tmp_path).unlink()
+            raise
+    except (OSError, tomllib.TOMLDecodeError):
+        logger.exception("Could not save Bedrock auth mode")
         return False
     else:
         global _default_config_cache  # noqa: PLW0603

--- a/libs/cli/bog_agents_cli/model_config.py
+++ b/libs/cli/bog_agents_cli/model_config.py
@@ -790,12 +790,44 @@ def _has_bedrock_credentials() -> bool:
     return _check_bedrock_thorough()
 
 
+# Negative-cache for the bedrock credential probe. The langchain
+# auto-detect loop and the model resolver each call _has_bedrock_credentials
+# many times in succession; without caching, a single expired SSO session
+# produces 30+ identical TokenRetrievalError tracebacks in the log file
+# (issue #53). The cache key is the boto3 credential method (env vs
+# profile vs sso) — when that changes mid-process (extremely rare) we'd
+# stay stale for at most one probe, which is acceptable.
+_BEDROCK_PROBE_CACHE: dict[str, tuple[bool, str]] = {}
+
+
+def _classify_bedrock_probe_failure(exc: BaseException) -> str:
+    """Map a boto3 exception to a short stable classification string.
+
+    Used as the cache key + a hint for callers that want to know *why*
+    the probe failed without parsing the exception type themselves.
+    """
+    name = type(exc).__name__
+    msg = str(exc).lower()
+    if name == "TokenRetrievalError" or "token has expired" in msg or "sso" in msg:
+        return "sso-expired"
+    if name == "NoCredentialsError" or "unable to locate credentials" in msg:
+        return "no-credentials"
+    return f"other:{name}"
+
+
 def _check_bedrock_thorough() -> bool:
     """Resolve credentials via boto3 and verify the access key is non-empty.
 
-    This catches expired SSO tokens and misconfigured profiles without
-    making any network calls — it only checks that boto3 can produce a
-    frozen credential set with a non-empty access key.
+    Catches expired SSO tokens and misconfigured profiles without making
+    any network calls — it only checks that boto3 can produce a frozen
+    credential set with a non-empty access key.
+
+    The first failure of a given kind (sso-expired, no-credentials, etc.)
+    is logged at DEBUG level *with* its traceback for diagnostic value;
+    subsequent failures of the same kind log a one-line summary only.
+    This keeps the log file readable when a user runs with an expired
+    SSO session (issue #53 — a single ``bog-agents`` invocation
+    produces 20+ identical 50-line stack traces otherwise).
 
     Returns:
         True if boto3 resolves valid-looking credentials.
@@ -806,17 +838,35 @@ def _check_bedrock_thorough() -> bool:
         session = boto3.Session()
         creds = session.get_credentials()
         if creds is None:
-            logger.debug("boto3 returned no credentials")
+            cached = _BEDROCK_PROBE_CACHE.get("no-credentials")
+            if cached is None:
+                logger.debug("boto3 returned no credentials")
+                _BEDROCK_PROBE_CACHE["no-credentials"] = (
+                    False,
+                    "boto3 found no credentials",
+                )
             return False
         frozen = creds.get_frozen_credentials()
         has_key = bool(frozen.access_key)
         if not has_key:
             logger.debug("boto3 credentials resolved but access_key is empty")
         else:
+            # Reset the cache on success so a freshly-renewed SSO session
+            # is detected without restarting the process.
+            _BEDROCK_PROBE_CACHE.clear()
             logger.debug("boto3 credentials resolved successfully (thorough check)")
         return has_key
-    except Exception:
-        logger.debug("boto3 credential resolution failed", exc_info=True)
+    except Exception as exc:
+        kind = _classify_bedrock_probe_failure(exc)
+        cached = _BEDROCK_PROBE_CACHE.get(kind)
+        if cached is None:
+            # First failure of this kind: log the traceback once for
+            # diagnostic value and remember we've seen it.
+            logger.debug("boto3 credential resolution failed (%s)", kind, exc_info=True)
+            _BEDROCK_PROBE_CACHE[kind] = (False, f"{type(exc).__name__}: {exc}")
+        else:
+            # Subsequent failures: one-liner only.
+            logger.debug("boto3 credential resolution failed (%s; cached)", kind)
         return False
 
 
@@ -837,8 +887,14 @@ def _check_bedrock_boto3() -> bool:
         found = creds is not None
         logger.debug("boto3 credential check: found=%s", found)
         return found
-    except Exception:
-        logger.debug("boto3 credential check failed", exc_info=True)
+    except Exception as exc:
+        kind = _classify_bedrock_probe_failure(exc)
+        cached = _BEDROCK_PROBE_CACHE.get(f"boto3:{kind}")
+        if cached is None:
+            logger.debug("boto3 credential check failed (%s)", kind, exc_info=True)
+            _BEDROCK_PROBE_CACHE[f"boto3:{kind}"] = (False, str(exc))
+        else:
+            logger.debug("boto3 credential check failed (%s; cached)", kind)
         return False
 
 

--- a/libs/cli/bog_agents_cli/non_interactive.py
+++ b/libs/cli/bog_agents_cli/non_interactive.py
@@ -1163,21 +1163,39 @@ async def run_non_interactive(
         # lost over SSE. When running on Ollama, the most likely cause is a
         # model that does not support tool calls.
         err_str = str(e).lower()
+        err_name = type(e).__name__
+        spec_lower = (model_name or "").lower()
         is_tool_capability_error = (
-            type(e).__name__ == "RemoteException"
+            err_name == "RemoteException"
             and "'responseerror'" in err_str
             and "internal error" in err_str
-            and (model_name or "").lower().startswith("ollama:")
+            and spec_lower.startswith("ollama:")
+        )
+        is_bedrock_model = spec_lower.startswith(("bedrock:", "bedrock_converse:"))
+        is_bedrock_auth_error = is_bedrock_model and (
+            "tokenretrievalerror" in err_str
+            or "nocredentialserror" in err_str
+            or "expired" in err_str
+            or "sso" in err_str
+            or (err_name == "RemoteException" and "internal error" in err_str)
         )
         if is_tool_capability_error:
-            console.print(f"\n[red]Unexpected error ({type(e).__name__}): {e}[/red]")
+            console.print(f"\n[red]Unexpected error ({err_name}): {e}[/red]")
             console.print(
                 "[yellow]The selected Ollama model likely does not support tool calls. "
                 "Try a tool-capable model such as `qwen3-coder-next:latest` or `gpt-oss:20b`, "
                 "or run `bog-agents --doctor` to confirm Ollama is reachable.[/yellow]"
             )
+        elif is_bedrock_auth_error:
+            console.print(f"\n[red]Unexpected error ({err_name}): {e}[/red]")
+            console.print(
+                "[yellow]This looks like an AWS Bedrock credential issue. Try:\n"
+                "  - `aws sso login` to refresh an expired SSO session\n"
+                "  - `aws configure` if no credentials are set\n"
+                "  - `bog-agents --doctor` to verify the credential probe[/yellow]"
+            )
         else:
-            console.print(f"\n[red]Unexpected error ({type(e).__name__}): {e}[/red]")
+            console.print(f"\n[red]Unexpected error ({err_name}): {e}[/red]")
         return 1
     else:
         return 0

--- a/libs/cli/bog_agents_cli/provider_catalog.py
+++ b/libs/cli/bog_agents_cli/provider_catalog.py
@@ -57,9 +57,15 @@ BEDROCK_REGION_PREFIXES: tuple[str, ...] = (
 DEFAULT_MODEL_CANDIDATES: Mapping[str, tuple[str, ...]] = MappingProxyType(
     {
         "anthropic": (
+            # Live API IDs from platform.claude.com/docs/en/docs/about-claude/models
+            # (fetched 2026-04-30). Latest first.
+            "claude-opus-4-7",
             "claude-sonnet-4-6",
+            "claude-haiku-4-5",
+            "claude-opus-4-6",
             "claude-sonnet-4-5",
-            "claude-sonnet-4-20250514",
+            "claude-opus-4-5",
+            "claude-opus-4-1",
         ),
         "azure_openai": (
             "gpt-5.4",
@@ -68,20 +74,72 @@ DEFAULT_MODEL_CANDIDATES: Mapping[str, tuple[str, ...]] = MappingProxyType(
             "gpt-5.2",
             "gpt-5",
         ),
-        "bedrock_converse": (
-            "anthropic.claude-sonnet-4-20250514-v1:0",
+        "bedrock": (
+            # AWS Bedrock model IDs as of 2026-04-30. The us.* / eu.* /
+            # apac.* prefixes are cross-region inference profile IDs;
+            # use those when calling from a region that supports them.
+            # Anthropic (latest first)
+            "us.anthropic.claude-opus-4-7",
+            "anthropic.claude-opus-4-7",
+            "us.anthropic.claude-sonnet-4-6",
+            "anthropic.claude-sonnet-4-6",
+            "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            "anthropic.claude-haiku-4-5-20251001-v1:0",
+            "us.anthropic.claude-opus-4-6-v1",
+            "anthropic.claude-opus-4-6-v1",
+            "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            "anthropic.claude-sonnet-4-5-20250929-v1:0",
+            "us.anthropic.claude-opus-4-5-20251101-v1:0",
+            "anthropic.claude-opus-4-5-20251101-v1:0",
+            "us.anthropic.claude-opus-4-1-20250805-v1:0",
             "anthropic.claude-opus-4-1-20250805-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
+            # Amazon Nova
+            "us.amazon.nova-premier-v1:0",
+            "us.amazon.nova-pro-v1:0",
+            "us.amazon.nova-lite-v1:0",
+            "us.amazon.nova-micro-v1:0",
+            # Meta Llama 4 + 3.3
+            "us.meta.llama4-maverick-17b-instruct-v1:0",
+            "us.meta.llama4-scout-17b-instruct-v1:0",
+            "us.meta.llama3-3-70b-instruct-v1:0",
+            # Mistral
+            "us.mistral.mistral-large-3-2411-v1:0",
+            "us.mistral.pixtral-large-2502-v1:0",
+        ),
+        # bedrock_converse is the modern wrapper; recommends the same IDs.
+        "bedrock_converse": (
+            "us.anthropic.claude-opus-4-7",
+            "anthropic.claude-opus-4-7",
+            "us.anthropic.claude-sonnet-4-6",
+            "anthropic.claude-sonnet-4-6",
+            "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            "anthropic.claude-haiku-4-5-20251001-v1:0",
+            "us.anthropic.claude-opus-4-6-v1",
+            "anthropic.claude-opus-4-6-v1",
+            "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            "anthropic.claude-sonnet-4-5-20250929-v1:0",
+            "us.amazon.nova-premier-v1:0",
+            "us.amazon.nova-pro-v1:0",
+            "us.amazon.nova-lite-v1:0",
+            "us.meta.llama4-maverick-17b-instruct-v1:0",
+            "us.mistral.mistral-large-3-2411-v1:0",
         ),
         "google_genai": (
+            # Live IDs from ai.google.dev/gemini-api/docs/models
+            # (fetched 2026-04-30). Preview models clearly marked.
             "gemini-2.5-pro",
-            "gemini-3-pro-preview",
             "gemini-2.5-flash",
+            "gemini-2.5-flash-lite",
+            "gemini-3.1-pro-preview",
+            "gemini-3-flash-preview",
+            "gemini-3.1-flash-lite-preview",
         ),
         "google_vertexai": (
             "gemini-2.5-pro",
-            "gemini-3-pro-preview",
             "gemini-2.5-flash",
+            "gemini-2.5-flash-lite",
+            "gemini-3.1-pro-preview",
+            "gemini-3-flash-preview",
         ),
         "nvidia": (
             "nvidia/nemotron-3-super-120b-a12b",
@@ -100,7 +158,13 @@ DEFAULT_MODEL_CANDIDATES: Mapping[str, tuple[str, ...]] = MappingProxyType(
         ),
     }
 )
-"""Recommended model IDs, ordered from most to least preferred."""
+"""Recommended model IDs, ordered from most to least preferred.
+
+Bedrock entries include both base model IDs (``anthropic.claude-...``) and
+their cross-region inference profile counterparts (``us.anthropic.claude-...``).
+Use the regional profile when calling from a US-based region for higher
+quotas; the base IDs work in single-region calls.
+"""
 
 _OPENAI_GPT_5_4_FAMILY: dict[str, dict[str, Any]] = {
     "gpt-5.4": {

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bog-agents-cli"
-version = "0.7.3"
+version = "0.7.4"
 description = "A coding agent in your terminal. 50+ commands, any LLM provider, persistent memory, git workflow, code review, plan mode, remote sandboxes, and CI/CD automation. One install, no code required."
 readme = "README.md"
 license = { text = "MIT" }
@@ -28,7 +28,7 @@ classifiers = [
 ]
 dependencies = [
     # Framework
-    "bog-agents==0.7.3",
+    "bog-agents==0.7.4",
     "langchain>=1.2.10,<2.0.0",
     "langgraph>=1.1.2,<2.0.0",
     "langgraph-checkpoint-sqlite>=3.0.0,<4.0.0",

--- a/libs/cli/tests/unit_tests/test_model_config.py
+++ b/libs/cli/tests/unit_tests/test_model_config.py
@@ -3048,3 +3048,98 @@ default = "anthropic:claude-sonnet-4-6"
         assert config.default_model == "anthropic:claude-sonnet-4-6"
         bedrock_cfg = config.providers.get("bedrock", {})
         assert bedrock_cfg.get("credential_check") == "files"
+
+
+class TestBedrockProbeCache:
+    """Issue #53 — repeated Bedrock probes must not log duplicate tracebacks."""
+
+    def setup_method(self) -> None:
+        """Clear the negative-result cache between tests."""
+        from bog_agents_cli.model_config import _BEDROCK_PROBE_CACHE
+
+        _BEDROCK_PROBE_CACHE.clear()
+
+    def test_classify_sso_expired(self) -> None:
+        """TokenRetrievalError is classified as sso-expired."""
+        from bog_agents_cli.model_config import _classify_bedrock_probe_failure
+
+        class FakeTokenRetrievalError(Exception):
+            pass
+
+        FakeTokenRetrievalError.__name__ = "TokenRetrievalError"
+        kind = _classify_bedrock_probe_failure(
+            FakeTokenRetrievalError("Token has expired and refresh failed")
+        )
+        assert kind == "sso-expired"
+
+    def test_classify_no_credentials(self) -> None:
+        """NoCredentialsError is classified distinctly from sso-expired."""
+        from bog_agents_cli.model_config import _classify_bedrock_probe_failure
+
+        class FakeNoCredsError(Exception):
+            pass
+
+        FakeNoCredsError.__name__ = "NoCredentialsError"
+        kind = _classify_bedrock_probe_failure(
+            FakeNoCredsError("Unable to locate credentials")
+        )
+        assert kind == "no-credentials"
+
+    def test_repeated_failure_logs_traceback_only_once(self, caplog) -> None:
+        """5x _check_bedrock_thorough with the same SSO failure logs ONE traceback, not 5."""
+        from bog_agents_cli.model_config import _check_bedrock_thorough
+
+        class FakeTokenRetrievalError(Exception):
+            pass
+
+        FakeTokenRetrievalError.__name__ = "TokenRetrievalError"
+
+        fake_creds = MagicMock()
+        fake_creds.get_frozen_credentials.side_effect = FakeTokenRetrievalError(
+            "Token has expired and refresh failed"
+        )
+        fake_session = MagicMock()
+        fake_session.get_credentials.return_value = fake_creds
+        fake_boto3 = MagicMock()
+        fake_boto3.Session.return_value = fake_session
+
+        with (
+            patch.dict(sys.modules, {"boto3": fake_boto3}),
+            caplog.at_level(logging.DEBUG, logger="bog_agents_cli.model_config"),
+        ):
+            for _ in range(5):
+                assert _check_bedrock_thorough() is False
+
+        with_tracebacks = [r for r in caplog.records if r.exc_info is not None]
+        assert len(with_tracebacks) == 1, (
+            f"expected exactly 1 traceback in logs, got {len(with_tracebacks)}"
+        )
+        cached_records = [r for r in caplog.records if "cached" in r.getMessage()]
+        assert len(cached_records) >= 1
+
+    def test_success_clears_cache(self) -> None:
+        """A successful probe clears the negative-result cache."""
+        from bog_agents_cli.model_config import (
+            _BEDROCK_PROBE_CACHE,
+            _check_bedrock_thorough,
+        )
+
+        _BEDROCK_PROBE_CACHE["sso-expired"] = (False, "stale")
+        assert _BEDROCK_PROBE_CACHE
+
+        fake_frozen = MagicMock()
+        fake_frozen.access_key = "AKIA..."
+        fake_creds = MagicMock()
+        fake_creds.get_frozen_credentials.return_value = fake_frozen
+        fake_creds.method = "sso"
+        fake_session = MagicMock()
+        fake_session.get_credentials.return_value = fake_creds
+        fake_boto3 = MagicMock()
+        fake_boto3.Session.return_value = fake_session
+
+        with patch.dict(sys.modules, {"boto3": fake_boto3}):
+            assert _check_bedrock_thorough() is True
+
+        assert _BEDROCK_PROBE_CACHE == {}, (
+            "successful probe should clear the negative-result cache"
+        )

--- a/libs/cli/tests/unit_tests/test_model_config.py
+++ b/libs/cli/tests/unit_tests/test_model_config.py
@@ -3105,8 +3105,13 @@ class TestBedrockProbeCache:
 
         with (
             patch.dict(sys.modules, {"boto3": fake_boto3}),
+            patch.dict(
+                os.environ, {"BOG_AGENTS_BEDROCK_AUTH_MODE": "sso"}, clear=False
+            ),
             caplog.at_level(logging.DEBUG, logger="bog_agents_cli.model_config"),
         ):
+            os.environ.pop("AWS_PROFILE", None)
+            os.environ.pop("BOG_AGENTS_BEDROCK_PROFILE", None)
             for _ in range(5):
                 assert _check_bedrock_thorough() is False
 
@@ -3143,3 +3148,128 @@ class TestBedrockProbeCache:
         assert _BEDROCK_PROBE_CACHE == {}, (
             "successful probe should clear the negative-result cache"
         )
+
+
+class TestBedrockAuthMode:
+    """auth_mode toggle + auto-fallback from expired SSO to static creds."""
+
+    def setup_method(self) -> None:
+        from bog_agents_cli.model_config import _BEDROCK_PROBE_CACHE
+
+        _BEDROCK_PROBE_CACHE.clear()
+
+    def test_auth_mode_default_is_auto(self, tmp_path) -> None:
+        """When no config / env override is set, mode resolves to 'auto'."""
+        from bog_agents_cli.model_config import _bedrock_auth_mode
+
+        config_path = tmp_path / "config.toml"
+        with patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path):
+            with patch.dict(os.environ, {}, clear=False):
+                for var in (
+                    "BOG_AGENTS_BEDROCK_AUTH_MODE",
+                    "BOG_AGENTS_BEDROCK_PROFILE",
+                    "AWS_PROFILE",
+                ):
+                    os.environ.pop(var, None)
+                mode, profile = _bedrock_auth_mode()
+        assert mode == "auto"
+        assert profile == ""
+
+    def test_auth_mode_env_var_overrides_config(self, tmp_path) -> None:
+        """BOG_AGENTS_BEDROCK_AUTH_MODE wins over config.toml."""
+        from bog_agents_cli.model_config import _bedrock_auth_mode
+
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[models.providers.bedrock]\nauth_mode = "sso"\n')
+        with patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path):
+            with patch.dict(
+                os.environ, {"BOG_AGENTS_BEDROCK_AUTH_MODE": "static"}, clear=False
+            ):
+                mode, _profile = _bedrock_auth_mode()
+        assert mode == "static"
+
+    def test_save_bedrock_auth_mode_round_trip(self, tmp_path) -> None:
+        from bog_agents_cli.model_config import save_bedrock_auth_mode
+
+        config_path = tmp_path / "config.toml"
+        assert (
+            save_bedrock_auth_mode("static", profile="dev", config_path=config_path)
+            is True
+        )
+
+        config = ModelConfig.load(config_path)
+        bedrock_cfg = config.providers.get("bedrock", {})
+        assert bedrock_cfg.get("auth_mode") == "static"
+        assert bedrock_cfg.get("aws_profile") == "dev"
+
+    def test_save_bedrock_auth_mode_rejects_invalid_mode(self, tmp_path) -> None:
+        from bog_agents_cli.model_config import save_bedrock_auth_mode
+
+        with pytest.raises(ValueError, match="invalid auth_mode"):
+            save_bedrock_auth_mode("not-a-real-mode", config_path=tmp_path / "c.toml")
+
+    def test_auto_mode_falls_back_from_sso_expired_to_static(self, tmp_path) -> None:
+        """Issue #54: expired SSO + fresh static creds → auto mode succeeds.
+
+        boto3 walks the credential chain in order. If ~/.aws/config has
+        a [default] section with sso_session = X (expired), the SSO
+        provider short-circuits before ~/.aws/credentials is ever read.
+        Auto mode catches TokenRetrievalError and retries with the
+        SSO providers explicitly removed from the chain.
+        """
+        from bog_agents_cli.model_config import (
+            _BEDROCK_PROBE_CACHE,
+            _check_bedrock_thorough,
+        )
+
+        class FakeTokenRetrievalError(Exception):
+            pass
+
+        FakeTokenRetrievalError.__name__ = "TokenRetrievalError"
+
+        # First call: default chain finds expired SSO config.
+        sso_creds = MagicMock()
+        sso_creds.get_frozen_credentials.side_effect = FakeTokenRetrievalError(
+            "Token has expired and refresh failed"
+        )
+        sso_session = MagicMock()
+        sso_session.get_credentials.return_value = sso_creds
+
+        # Second call: static-credentials-only chain succeeds.
+        static_frozen = MagicMock()
+        static_frozen.access_key = "AKIASTATIC..."
+        static_creds = MagicMock()
+        static_creds.get_frozen_credentials.return_value = static_frozen
+        static_creds.method = "shared-credentials-file"
+        static_session = MagicMock()
+        static_session.get_credentials.return_value = static_creds
+
+        botocore_inner = MagicMock()
+        botocore_inner.get_component.return_value = MagicMock()
+
+        fake_boto3 = MagicMock()
+        fake_boto3.Session.side_effect = [sso_session, static_session]
+
+        fake_botocore_session_module = MagicMock()
+        fake_botocore_session_module.Session.return_value = botocore_inner
+
+        with patch.dict(
+            sys.modules,
+            {
+                "boto3": fake_boto3,
+                "botocore": MagicMock(),
+                "botocore.session": fake_botocore_session_module,
+            },
+        ):
+            with patch.dict(
+                os.environ, {"BOG_AGENTS_BEDROCK_AUTH_MODE": "auto"}, clear=False
+            ):
+                os.environ.pop("AWS_PROFILE", None)
+                os.environ.pop("BOG_AGENTS_BEDROCK_PROFILE", None)
+                result = _check_bedrock_thorough()
+
+        assert result is True, (
+            "auto mode should fall back to static creds on SSO failure"
+        )
+        # Static-fallback success clears the cache.
+        assert _BEDROCK_PROBE_CACHE == {}

--- a/libs/daemon/bog_agents_daemon/__init__.py
+++ b/libs/daemon/bog_agents_daemon/__init__.py
@@ -1,3 +1,3 @@
 """Bog Agents Daemon — ambient agent service."""
 
-__version__ = "0.7.3"
+__version__ = "0.7.4"

--- a/libs/daemon/pyproject.toml
+++ b/libs/daemon/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bog-agents-daemon"
-version = "0.7.3"
+version = "0.7.4"
 description = "Ambient agent daemon for bog-agents — run agents on schedules, file-change triggers, webhooks, and git pushes"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
  ## Summary

  Targeted patch release closing two reported Bedrock issues and
  refreshing the provider catalog against live AWS / Anthropic / Google
  documentation.

  ## Closes

  - **#54** — Bedrock failed entirely when `~/.aws/config` had an
    expired `sso_session` even though `~/.aws/credentials` had fresh
    static keys. boto3's credential chain stops at the first config
    it sees: the SSO provider short-circuited the lookup before the
    shared-credentials-file provider was reached, so
    `TokenRetrievalError` was the only outcome.

  - **#53** — A single `bog-agents` invocation produced 20+
    identical 50-line `TokenRetrievalError` tracebacks in
    `~/.bog-agents/logs/bog_agents.log` because the langchain
    auto-detect loop calls `_has_bedrock_credentials` many times
    back-to-back. (Already fixed in 0.7.3-followups; rolled into
    this release.)

  ## What's in it

  ### Bedrock `auth_mode` + auto-fallback

  New setting in `[models.providers.bedrock]`, with five values:

  | mode | behavior |
  |---|---|
  | `auto` *(default)* | Try every source. On `TokenRetrievalError` from an expired SSO session, **automatically retry
  with a static-credentials-only session** (SSO providers explicitly removed from the chain). |
  | `sso` | Force the SSO path. Fail loudly when expired. |
  | `static` | Use only `~/.aws/credentials` (or `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` env vars). Never touches
  SSO config. |
  | `profile` | Use the named AWS profile from the new `aws_profile` config key. |
  | `iam` | Force IAM instance/role credentials (EC2/ECS/Lambda). |

  Configurable via:
  - `[models.providers.bedrock] auth_mode = "static"` in `~/.bog-agents/config.toml`
  - `BOG_AGENTS_BEDROCK_AUTH_MODE=static` env var (env wins over config)
  - New `save_bedrock_auth_mode(mode, profile)` helper for programmatic config

  ### Probe cache (#53)

  `_check_bedrock_thorough` now caches negative results by failure
  kind. The first failure of each kind logs the full traceback for
  diagnostic value; subsequent failures of the same kind log a
  one-line `(...; cached)` summary. A successful probe clears the
  cache so a freshly-renewed SSO session is detected without
  restarting the process.

  ### Provider catalog refresh (live docs, 2026-04-30)

  - **Anthropic:** Opus 4.7, Sonnet 4.6, Haiku 4.5 (current); Opus 4.6,
    Sonnet 4.5, Opus 4.5, Opus 4.1 (legacy).
  - **Bedrock:** `us.*` inference-profile-prefixed IDs + base IDs for
    Anthropic, Amazon Nova (Premier/Pro/Lite/Micro), Meta Llama 4
    Maverick + Scout + 3.3 70B, Mistral Large 3 / Pixtral Large.
  - **Google:** Gemini 2.5 Pro / Flash / Flash-Lite GA + Gemini 3.1
    preview family (`gemini-3.1-pro-preview`, `gemini-3-flash-preview`,
    `gemini-3.1-flash-lite-preview`).

  ## Test plan

  CI matrix run locally (Windows variant — exact same commands as
  `.github/workflows/ci.yml`):

  - [x] `ruff check . && ruff format . --diff` clean across SDK / CLI / daemon
  - [x] `ty check` clean across SDK + CLI
  - [x] **SDK**: 1226 passed, 126 skipped, 3 xfailed (~69s)
  - [x] **CLI**: 2685 passed, 93 skipped, 166 warnings (~3m52s)
  - [x] **daemon**: 95 passed, 1 skipped (~3s)

  5 new tests in `TestBedrockProbeCache` + `TestBedrockAuthMode`
  covering: classification, repeated-failure de-dup, success-clears-
  cache, env-override-wins, save round-trip, invalid-mode rejection,
  and the **auto-fallback regression for #54**.