### PR TITLE
chore: release 0.7.4 — sync per-package CHANGELOGs + manifest

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "libs/bog-agents": "0.7.3",
-  "libs/cli": "0.7.3",
-  "libs/daemon": "0.7.3"
+  "libs/bog-agents": "0.7.4",
+  "libs/cli": "0.7.4",
+  "libs/daemon": "0.7.4"
 }

--- a/libs/bog-agents/CHANGELOG.md
+++ b/libs/bog-agents/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.7.4](https://github.com/bogware/bog-agents/compare/bog-agents==0.7.3...bog-agents==0.7.4) (2026-04-30)
+
+
+### Bug Fixes
+
+* version-sync release alongside bog-agents-cli and bog-agents-daemon 0.7.4. No SDK code changes; published to keep linked versions in lockstep with the CLI's Bedrock auth_mode + auto-fallback fixes for [#54](https://github.com/bogware/bog-agents/issues/54) and the probe-cache fix for [#53](https://github.com/bogware/bog-agents/issues/53). ([fef8228](https://github.com/bogware/bog-agents/commit/fef82283e9fc07f5d286a26eea093e68d28cdb42))
+
 ## [0.7.3](https://github.com/bogware/bog-agents/compare/bog-agents==0.7.2...bog-agents==0.7.3) (2026-04-29)
 
 

--- a/libs/bog-agents/README.md
+++ b/libs/bog-agents/README.md
@@ -1,12 +1,14 @@
 # Bog Agents
 
-A production-grade Python SDK for building LangGraph-based AI agents. One `create_agent()` call gets you a compiled graph with file/shell/git tools, sub-agents, plan mode, auto-quality checks, and 80+ composable middleware. Pluggable backends (local, sandbox, composite). Works with any tool-calling LLM.
+The Python SDK underneath [`bog-agents-cli`](https://pypi.org/project/bog-agents-cli/) and [`bog-agents-daemon`](https://pypi.org/project/bog-agents-daemon/). One `create_agent()` call gets you a compiled LangGraph agent with file tools, a shell, git, sub-agents, plan mode, auto-quality checks, and 80-some composable middleware. Pluggable backends. Any tool-calling LLM.
 
 [![PyPI](https://img.shields.io/pypi/v/bog-agents)](https://pypi.org/project/bog-agents/)
 [![License](https://img.shields.io/pypi/l/bog-agents)](https://opensource.org/licenses/MIT)
 [![Downloads](https://img.shields.io/pepy/dt/bog-agents)](https://pypistats.org/packages/bog-agents)
 
-## Quick Install
+---
+
+## Install
 
 ```bash
 pip install bog-agents
@@ -14,99 +16,54 @@ pip install bog-agents
 uv add bog-agents
 ```
 
-## Getting Started
+Python 3.11 or better. Bring your own provider package — Anthropic, OpenAI, AWS, Google,
+local Ollama, doesn't matter. Pick one or pick all of them.
 
-1. **Set your API key** (the default model uses Anthropic):
+---
 
-```bash
-export ANTHROPIC_API_KEY="sk-ant-..."
-```
-
-Or for OpenAI, Google, etc.:
-
-```bash
-export OPENAI_API_KEY="sk-..."
-export GOOGLE_API_KEY="AI..."
-```
-
-2. **Create and run an agent**:
+## First run
 
 ```python
 from bog_agents import create_agent
 
-# Uses Claude Sonnet by default (needs ANTHROPIC_API_KEY)
-agent = create_agent()
+agent = create_agent()  # default: anthropic:claude-sonnet-4-6
 
-# Or specify a different provider
-agent = create_agent(model="openai:gpt-4o")
-agent = create_agent(model="google_genai:gemini-2.0-flash")
-
-# Run the agent
 result = agent.invoke(
     {"messages": [{"role": "user", "content": "Hello!"}]},
     config={"configurable": {"thread_id": "my-thread"}},
 )
 ```
 
-3. **Run as an HTTP server** (optional):
-
-```bash
-pip install 'bog-agents[serve]'
-```
+Pick whatever model you've got the keys for:
 
 ```python
-from bog_agents import create_agent
-from bog_agents.serve import AgentServer
-
-agent = create_agent()
-server = AgentServer(agent)
-server.run()  # Starts on http://127.0.0.1:8420
+agent = create_agent(model="openai:gpt-5.4")
+agent = create_agent(model="bedrock_converse:us.anthropic.claude-sonnet-4-6")
+agent = create_agent(model="google_genai:gemini-2.5-pro")
+agent = create_agent(model="ollama:gpt-oss:20b")  # local, free
 ```
 
-## What Is This?
+---
 
-Using an LLM to call tools in a loop is the simplest form of an agent. This architecture, however, can yield agents that are "shallow" and fail to plan and act over longer, more complex tasks.
+## What it does
 
-Applications like "Deep Research", "Manus", and "Claude Code" have gotten around this limitation by implementing a combination of four things: a **planning tool**, **sub agents**, access to a **file system**, and a **detailed prompt**.
+**Builds the agent.** `create_agent()` returns a compiled LangGraph graph wired with whatever middleware stack you ask for. Default is sensible. Power users override every piece.
 
-`bog-agents` is a Python package that implements these in a general purpose way so that you can easily create a Bog Agents for your application. For a full overview and quickstart of Bog Agents, the best resource is our [docs](https://github.com/bogware/bog-agents).
+**Talks to anything.** Anthropic, OpenAI, AWS Bedrock, Google AI / Vertex AI, DeepSeek, Mistral, Groq, NVIDIA, Ollama, Cohere, xAI, Perplexity, Fireworks, OpenRouter, Together, HuggingFace — anything LangChain knows about, this handles.
 
-**Acknowledgements: This project was primarily inspired by Claude Code, and initially was largely an attempt to see what made Claude Code general purpose, and make it even more so.**
+**Reads, writes, edits, runs, commits.** Filesystem tools, shell tools, git tools — all pluggable. Local backend by default; swap in a remote sandbox (Modal, Daytona, Runloop, LangSmith) when you want isolation.
 
-## Features
+**Sub-agents.** Spawn child agents to parallelize work that doesn't need to share state.
 
-### Core Agent
-- **LangGraph-powered** — composable agent with middleware architecture
-- **Multi-model** — works with Anthropic, OpenAI, Google, DeepSeek, and any LangChain-compatible LLM
-- **Sub-agents** — spawn isolated sub-agents for complex tasks
-- **File system** — read, write, edit, search files with pluggable backends
-- **Planning** — built-in todo list and plan mode for structured task execution
+**Plan mode and checkpoints.** Read-only plan mode for scouting; git-based snapshots before mutations so you can roll back without thinking about it.
 
-### Middleware (Pluggable)
+**Production hooks.** `bog_agents.serve.AgentServer` exposes a REST + SSE API. `bog-agents-daemon` schedules ambient runs on cron, file-change, webhook, and git-push triggers. Built for the long haul, not just a demo.
 
-| Middleware | Description |
-|-----------|-------------|
-| `FilesystemMiddleware` | File read/write/edit/search + multi-edit and batch read |
-| `GitToolsMiddleware` | 9 git tools: status, diff, log, commit, add, branch, stash, blame, show |
-| `RepoMapMiddleware` | Structural code map with symbol extraction (Python, JS, TS, Rust, Go, Java) |
-| `CheckpointingMiddleware` | Git-based snapshots before mutations, with undo/diff |
-| `CostTrackerMiddleware` | Token usage, cost estimation, budget enforcement, effort levels |
-| `PlanModeMiddleware` | Read-only mode that blocks mutating tools |
-| `AutoQualityMiddleware` | Auto-lint/test after edits with project detection |
-| `ArchitectMiddleware` | Dual-model architect/reviewer with cross-model consultation |
-| `ParallelAgentsMiddleware` | Concurrent sub-agent task execution |
-| `LifecycleHooksMiddleware` | 15 event types for external tool integration |
-| `ContextPackingMiddleware` | Smart structured context compression |
-| `SummarizationMiddleware` | Auto-summarization when context window fills |
-| `MemoryMiddleware` | Persistent AGENTS.md memory across sessions |
-| `SkillsMiddleware` | Custom skill/instruction loading |
-| `SafeToolsConfig` | Per-tool auto-approval rules |
+---
 
-### Security
-- **OS-level sandbox** — bubblewrap (Linux), seatbelt (macOS), landlock isolation
-- **Human-in-the-loop** — configurable tool approval with interrupt handling
+## A loaded example
 
-## Quick Start
+When you want the whole posse:
 
 ```python
 from bog_agents import create_agent
@@ -122,25 +79,109 @@ agent = create_agent(
     working_dir="/path/to/project",
 )
 
-# Run the agent
 result = await agent.ainvoke(
     {"messages": [{"role": "user", "content": "Fix the failing tests"}]},
     config={"configurable": {"thread_id": "my-session"}},
 )
 ```
 
+---
+
+## Middleware
+
+Eighty-some pieces in the stack. Mix what you need; leave the rest in the wagon.
+
+| Middleware | What it does |
+|-----------|-------------|
+| `FilesystemMiddleware` | read / write / edit / multi-edit / glob / grep |
+| `GitToolsMiddleware` | status, diff, log, commit, add, branch, stash, blame, show |
+| `RepoMapMiddleware` | symbol-extracted code map (Python, JS, TS, Rust, Go, Java) |
+| `CheckpointingMiddleware` | git-based snapshot before mutations + diff/undo |
+| `CostTrackerMiddleware` | tokens, cost, budgets, effort levels |
+| `PlanModeMiddleware` | read-only mode that blocks mutating tools |
+| `AutoQualityMiddleware` | auto-lint / auto-test after edits with project detection |
+| `ArchitectMiddleware` | dual-model architect ↔ reviewer cross-talk |
+| `ParallelAgentsMiddleware` | concurrent sub-agent execution |
+| `LifecycleHooksMiddleware` | 15 event types for external tool integration |
+| `ContextPackingMiddleware` | structured context compression |
+| `SummarizationMiddleware` | auto-summarize when the context window fills |
+| `MemoryMiddleware` | persistent `AGENTS.md` memory across sessions |
+| `SkillsMiddleware` | custom skill / instruction loading |
+| `SafeToolsConfig` | per-tool auto-approval rules |
+
+---
+
+## Run as an HTTP server
+
+For when something else needs to drive.
+
+```bash
+pip install 'bog-agents[serve]'
+```
+
+```python
+from bog_agents import create_agent
+from bog_agents.serve import AgentServer
+
+agent = create_agent()
+server = AgentServer(agent)
+server.run()  # http://127.0.0.1:8420
+```
+
+Endpoints out of the box:
+
+```
+GET  /health
+GET  /info
+GET  /openapi.json     <-- hand-rolled OpenAPI 3.0 schema; Swagger UI works
+POST /invoke
+POST /stream            <-- Server-Sent Events
+POST /threads
+GET  /threads
+POST /threads/{id}/messages
+GET  /threads/{id}/history
+```
+
+---
+
+## Companion packages
+
+| Package | What it's for |
+|---------|---------------|
+| **[`bog-agents-cli`](https://pypi.org/project/bog-agents-cli/)** | TUI and non-interactive CLI. Drives an agent from your terminal. |
+| **[`bog-agents-daemon`](https://pypi.org/project/bog-agents-daemon/)** | Ambient agent scheduler. Cron, file-watch, webhooks, git push. |
+
+All three release together with the same version number.
+
+---
+
+## Security model
+
+`LocalShellBackend.execute()` runs commands on the host with `shell=True`. **No sandbox. No process isolation.** That's by design — when you're in your own checkout you don't want a wall in the way. When you're running someone else's input, set up a remote sandbox backend (`ModalBackend`, `DaytonaBackend`, `RunloopBackend`, `LangSmithBackend`) and route the same agent through it.
+
+The shell decodes child output as UTF-8 with `errors='replace'`, so output containing checkmarks, ANSI escapes, or box-drawing characters never trips the Windows cp1252 reader. Recurring fix across 0.7.3.
+
+For Bedrock specifically, the SDK's credential probe falls back from an expired SSO session to static `~/.aws/credentials` keys automatically — see `[models.providers.bedrock] auth_mode` in the CLI's `config.toml`, or set `BOG_AGENTS_BEDROCK_AUTH_MODE`. New in 0.7.4.
+
+---
+
 ## Resources
 
-- **[Documentation](https://github.com/bogware/bog-agents)** — Full documentation
-- **[API Reference](https://github.com/bogware/bog-agents)** — Full SDK reference documentation
-- **[Chat LangChain](https://chat.langchain.com)** - Chat interactively with the docs
+- [Repository + issue tracker](https://github.com/bogware/bog-agents)
+- [Releases](https://github.com/bogware/bog-agents/releases) — synced notes for SDK, CLI, and daemon
 
-## Releases & Versioning
-
-See our [Releases](https://github.com/bogware/bog-agents/releases) and [Versioning](https://github.com/bogware/bog-agents/blob/main/CONTRIBUTING.md#versioning) policies.
+---
 
 ## Contributing
 
-As an open-source project in a rapidly developing field, we are extremely open to contributions, whether it be in the form of a new feature, improved infrastructure, or better documentation.
+[Contributing Guide](https://github.com/bogware/bog-agents/blob/main/CONTRIBUTING.md). Conventional Commits required (`feat:`, `fix:`, etc.). 150-char line length. ruff + ty clean. Full test suite green per package, no fork-of-fork lineage drift.
 
-For detailed information on how to contribute, see the [Contributing Guide](https://github.com/bogware/bog-agents/blob/main/CONTRIBUTING.md).
+---
+
+## License
+
+MIT.
+
+---
+
+*Saddle up.*

--- a/libs/bog-agents/uv.lock
+++ b/libs/bog-agents/uv.lock
@@ -252,7 +252,7 @@ wheels = [
 
 [[package]]
 name = "bog-agents"
-version = "0.7.3"
+version = "0.7.4"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },

--- a/libs/cli/CHANGELOG.md
+++ b/libs/cli/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.7.4](https://github.com/bogware/bog-agents/compare/bog-agents-cli==0.7.3...bog-agents-cli==0.7.4) (2026-04-30)
+
+
+### Bug Fixes
+
+* **bedrock:** add `auth_mode` toggle (`auto`/`sso`/`static`/`profile`/`iam`) plus auto-fallback from expired SSO to static credentials when `~/.aws/config` short-circuits the credential chain ([#54](https://github.com/bogware/bog-agents/issues/54)) ([fef8228](https://github.com/bogware/bog-agents/commit/fef82283e9fc07f5d286a26eea093e68d28cdb42))
+* **bedrock:** cache probe failures so a single expired SSO session no longer logs 20+ identical TokenRetrievalError tracebacks ([#53](https://github.com/bogware/bog-agents/issues/53)) ([fef8228](https://github.com/bogware/bog-agents/commit/fef82283e9fc07f5d286a26eea093e68d28cdb42))
+* **bedrock:** add `langchain-aws` + AWS credential probe to `--doctor`; pre-flight credential check in `-n` mode surfaces SSO-expired errors as a clean stderr line instead of a wrapped RemoteException ([fef8228](https://github.com/bogware/bog-agents/commit/fef82283e9fc07f5d286a26eea093e68d28cdb42))
+* **cli:** install atexit + signal handlers in `cli_main()` to emit terminal-restore sequences (disable mouse tracking, leave alternate screen, show cursor) so a Textual crash mid-launch no longer leaves SGR mouse-protocol garbage like `[<35;57;14M[` in the user's shell input line ([fef8228](https://github.com/bogware/bog-agents/commit/fef82283e9fc07f5d286a26eea093e68d28cdb42))
+
+
+### Catalog
+
+* refresh provider model lists against live docs (2026-04-30): Anthropic Opus 4.7 / Sonnet 4.6 / Haiku 4.5 + legacy 4.6/4.5/4.1; Bedrock `us.*` inference-profile IDs + base IDs for Anthropic + Amazon Nova (Premier/Pro/Lite/Micro) + Meta Llama 4 Maverick/Scout + 3.3 + Mistral Large 3 / Pixtral Large; Google Gemini 2.5 Pro/Flash/Flash-Lite + Gemini 3.1 preview family ([fef8228](https://github.com/bogware/bog-agents/commit/fef82283e9fc07f5d286a26eea093e68d28cdb42))
+
 ## [0.7.3](https://github.com/bogware/bog-agents/compare/bog-agents-cli==0.7.2...bog-agents-cli==0.7.3) (2026-04-29)
 
 

--- a/libs/cli/README.md
+++ b/libs/cli/README.md
@@ -44,9 +44,9 @@ the introductions in about thirty seconds.
 
 ```bash
 bog-agents -M claude-sonnet-4-6
-bog-agents -M gpt-4o
-bog-agents -M ollama:llama3              # local, free
-bog-agents -M bedrock_converse:anthropic.claude-sonnet-4-6
+bog-agents -M openai:gpt-5.4
+bog-agents -M ollama:gpt-oss:20b                          # local, free, tool-capable
+bog-agents -M bedrock_converse:us.anthropic.claude-sonnet-4-6
 ```
 
 Something feeling off? Ask it.
@@ -319,15 +319,15 @@ Use `provider:model` format. Any LangChain-compatible chat model works.
 | Provider | Extra | Example |
 |----------|--------------|---------|
 | Anthropic | `anthropic` | `anthropic:claude-sonnet-4-6` |
-| OpenAI | *(included)* | `openai:gpt-4o` |
-| AWS Bedrock | `bedrock` | `bedrock_converse:anthropic.claude-sonnet-4-6` |
+| OpenAI | *(included)* | `openai:gpt-5.4` |
+| AWS Bedrock | `bedrock` | `bedrock_converse:us.anthropic.claude-sonnet-4-6` |
 | Google AI | `google-genai` | `google_genai:gemini-2.5-pro` |
 | Vertex AI | `vertexai` | `google_vertexai:gemini-2.5-pro` |
-| Ollama | `ollama` | `ollama:llama3` |
+| Ollama | `ollama` | `ollama:gpt-oss:20b` |
 | Groq | `groq` | `groq:llama-3.3-70b` |
 | DeepSeek | `deepseek` | `deepseek:deepseek-chat` |
 | Fireworks | `fireworks` | `fireworks:llama-v3p3-70b` |
-| Mistral | `mistralai` | `mistralai:mistral-large` |
+| Mistral | `mistralai` | `mistralai:mistral-large-3-2411` |
 | NVIDIA | `nvidia` | `nvidia:nemotron-70b` |
 | OpenRouter | `openrouter` | `openrouter:meta-llama/llama-3` |
 | Perplexity | `perplexity` | `perplexity:sonar-pro` |
@@ -336,6 +336,26 @@ Use `provider:model` format. Any LangChain-compatible chat model works.
 | Together | *(via litellm)* | `litellm:together/llama-3-70b` |
 | HuggingFace | `huggingface` | `huggingface:meta-llama/Llama-3` |
 | Azure OpenAI | *(via openai)* | `azure_openai:gpt-4o` |
+
+### AWS Bedrock: pick how you authenticate
+
+boto3's credential chain stops at the first config it sees. If `~/.aws/config`
+declares an SSO session that's expired but `~/.aws/credentials` has fresh static
+keys, the SSO leg short-circuits and the static keys never get a turn. The CLI
+handles this in `auto` mode (default) by retrying with a credentials-file-only
+session when the SSO probe fails.
+
+Force a specific path when you need to. Either set
+`BOG_AGENTS_BEDROCK_AUTH_MODE` in the env, or write to `~/.bog-agents/config.toml`:
+
+```toml
+[models.providers.bedrock]
+auth_mode = "static"            # auto | sso | static | profile | iam
+aws_profile = "dev"             # only when auth_mode = "profile"
+```
+
+`bog-agents --doctor` shows you which mode resolved and whether the credentials
+came back valid. New in 0.7.4.
 
 ### Local Ollama: which model to use
 
@@ -417,6 +437,9 @@ Commands:
   reset                         Reset an agent's prompt
   skills                        Manage skills (list/create/info/delete)
   threads                       Manage threads (list/delete)
+  daemon                        Manage the ambient daemon (start/stop/jobs/...)
+  verify                        Run typecheck + lint + tests; write verification_summary.md
+  call MESSAGE                  Talk to a running --serve instance (thin HTTP client)
 
 Core:
   -M, --model MODEL             Model to use

--- a/libs/cli/uv.lock
+++ b/libs/cli/uv.lock
@@ -317,7 +317,7 @@ wheels = [
 
 [[package]]
 name = "bog-agents"
-version = "0.7.3"
+version = "0.7.4"
 source = { editable = "../bog-agents" }
 dependencies = [
     { name = "anyio" },
@@ -416,7 +416,7 @@ test = [
 
 [[package]]
 name = "bog-agents-cli"
-version = "0.7.3"
+version = "0.7.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/libs/daemon/CHANGELOG.md
+++ b/libs/daemon/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.7.4](https://github.com/bogware/bog-agents/compare/bog-agents-daemon==0.7.3...bog-agents-daemon==0.7.4) (2026-04-30)
+
+
+### Bug Fixes
+
+* version-sync release alongside bog-agents-cli and bog-agents 0.7.4. No daemon code changes; published to keep linked versions in lockstep with the CLI's Bedrock auth_mode + auto-fallback fixes for [#54](https://github.com/bogware/bog-agents/issues/54) and the probe-cache fix for [#53](https://github.com/bogware/bog-agents/issues/53). ([fef8228](https://github.com/bogware/bog-agents/commit/fef82283e9fc07f5d286a26eea093e68d28cdb42))
+
 ## [0.7.3](https://github.com/bogware/bog-agents/compare/bog-agents-daemon==0.7.2...bog-agents-daemon==0.7.3) (2026-04-29)
 
 

--- a/libs/daemon/README.md
+++ b/libs/daemon/README.md
@@ -1,11 +1,15 @@
 # bog-agents-daemon
 
-Ambient agent daemon for [Bog Agents](https://github.com/bogware/bog-agents). Run AI agents on schedules, file-change triggers, webhooks, and git pushes — without keeping a terminal open.
+Quiet ambient runner for [`bog-agents`](https://github.com/bogware/bog-agents). Schedules. File watches. Inbound webhooks. Git pushes. Sits in the background, fires the agent when something happens, writes the result wherever you point it.
+
+No terminal needed. No hand-holding. Goes the distance.
 
 [![PyPI](https://img.shields.io/pypi/v/bog-agents-daemon)](https://pypi.org/project/bog-agents-daemon/)
 [![License](https://img.shields.io/pypi/l/bog-agents-daemon)](https://opensource.org/licenses/MIT)
 
-Five trigger types. Seven output targets. A small authenticated REST API. Cross-platform (POSIX + Windows), HMAC-validated inbound webhooks, and `os.fsync()`-durable job persistence so a hard kill never loses a freshly-created job.
+Five trigger types. Seven output targets. A small authenticated REST API. POSIX
+and Windows. HMAC-validated inbound webhooks. `os.fsync()`-durable job
+persistence so a hard kill never loses a freshly-created job.
 
 **Triggers:** `cron` · `interval` · `file_change` · `webhook` · `git_push`
 **Outputs:** `log` · `stdout` · `file` · `slack` · `webhook` · `email` · `github_comment`
@@ -94,7 +98,14 @@ bog-agents daemon install
 
 ## REST API
 
-The daemon exposes a REST API on `http://127.0.0.1:7391` (localhost only). All endpoints except `/ready` require the `X-Daemon-Token` header.
+The daemon exposes a REST API on `http://127.0.0.1:7391` (localhost only).
+Most endpoints require the `X-Daemon-Token` header. Two exceptions:
+
+- `/ready` — readiness probe, no auth.
+- `/webhooks/{path}` — inbound from external services. Auth is the per-trigger
+  `webhook_secret` HMAC over `X-Hub-Signature-256` (timing-safe). The daemon
+  token also works on `/webhooks/{path}` if you happen to have it; useful for
+  local CLI tests.
 
 ```bash
 TOKEN=$(cat ~/.bog-agents/daemon/token)
@@ -104,6 +115,9 @@ curl -H "X-Daemon-Token: $TOKEN" http://localhost:7391/health
 
 # Readiness probe (no auth)
 curl http://localhost:7391/ready
+
+# OpenAPI 3.0 schema (for clients like Swagger UI)
+curl http://localhost:7391/openapi.json
 
 # List jobs
 curl -H "X-Daemon-Token: $TOKEN" http://localhost:7391/jobs
@@ -158,11 +172,21 @@ The hook POSTs `{"ref": "refs/heads/main", "new_sha": "...", "old_sha": "..."}` 
 ## Security
 
 - API binds to `127.0.0.1` (localhost only) — not reachable from the network.
-- Auth token stored at `~/.bog-agents/daemon/token` (mode `0600`).
-- Webhook secrets validated with HMAC-SHA256 (`hmac.compare_digest` — timing-safe).
-- Token comparison uses `hmac.compare_digest` to prevent timing attacks.
-- File output restricted to `$HOME` and `/tmp` (path traversal guard).
+- Auth token stored at `~/.bog-agents/daemon/token` (`0600` on POSIX; on
+  Windows the daemon also runs `icacls /inheritance:r /grant <user>:F` to
+  drop inherited ACEs).
+- Webhook secrets validated with HMAC-SHA256 via `hmac.compare_digest` —
+  timing-safe, no token leaks.
+- Daemon-token comparison also uses `hmac.compare_digest`.
+- File output restricted to `$HOME`, the system temp dir, the current
+  working directory, and the job's `working_dir` (path traversal guard).
+  Relative file paths are anchored to `working_dir`.
+- API responses redact `smtp_password`, `github_token`, and `webhook_secret`
+  to `'***'` — they're persisted in `jobs.json` for runtime use but never
+  echoed back through HTTP, even with a valid token.
 - Git hook scripts use `shlex.quote()` to prevent shell injection.
+- Job records and run records are written through `os.fsync()` before
+  atomic-rename, so a hard kill never loses a freshly-created job.
 
 ---
 

--- a/libs/daemon/uv.lock
+++ b/libs/daemon/uv.lock
@@ -274,7 +274,7 @@ wheels = [
 
 [[package]]
 name = "bog-agents"
-version = "0.7.3"
+version = "0.7.4"
 source = { editable = "../bog-agents" }
 dependencies = [
     { name = "anyio" },
@@ -373,7 +373,7 @@ test = [
 
 [[package]]
 name = "bog-agents-daemon"
-version = "0.7.3"
+version = "0.7.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
  ## Why

  The merged 0.7.4 release-please PR bumped the three pyproject.toml versions but the publish-gates in
  .github/workflows/release-please.yml skipped all three publishes because:

  1. `.release-please-manifest.json` stayed at 0.7.3, so release-please saw no advance.
  2. The previous PR wrote a root-level CHANGELOG.md instead of per-package `libs/<pkg>/CHANGELOG.md` entries, so the
  gate `git diff HEAD~1 HEAD | grep "^libs/<pkg>/CHANGELOG.md$"` returned empty for every package.

  Result: pyproject = 0.7.4, PyPI = 0.7.3.

  ## What this PR does

  - Bumps `.release-please-manifest.json` to 0.7.4 across all three packages.
  - Adds proper 0.7.4 entries to `libs/bog-agents/CHANGELOG.md`, `libs/cli/CHANGELOG.md`, `libs/daemon/CHANGELOG.md`.
  - Refreshes the three published READMEs (drop fork-of-Claude-Code framing, update model IDs to 0.7.4 surfaces, add
  Bedrock auth_mode docs).
  - Syncs the three uv.lock files to 0.7.4.

  ## Expected behavior on merge

  `.github/workflows/release-please.yml` runs. Each of the three publish-gate jobs sees a CHANGELOG diff for its package
   and flips `is-release=true`. Three release.yml runs fire, one per package, and PyPI gets bog-agents 0.7.4,
  bog-agents-cli 0.7.4, bog-agents-daemon 0.7.4 with refreshed READMEs.

  ## Test plan

  - [ ] CI green (lint + tests across the matrix)
  - [ ] After merge: confirm release-please.yml job logs show is-release=true for all three packages
  - [ ] Verify PyPI shows 0.7.4 for all three packages with updated README rendering