### PR TITLE
fix(cli): survive ReadTimeout from langgraph SSE stream

### DIFF
--- a/libs/cli/bog_agents_cli/app.py
+++ b/libs/cli/bog_agents_cli/app.py
@@ -10091,6 +10091,14 @@ class BogAgentsApp(App):
                 and "internal error" in err_str
                 and is_bedrock_model
             )
+            # Network/provider read timeout — distinct from auth errors.
+            # The langgraph server forwards an upstream HTTP read timeout as
+            # `RemoteException({'error': 'ReadTimeoutError', ...})`. The
+            # thread state on the server is preserved, so the user can just
+            # send another message to continue the turn.
+            is_read_timeout = (
+                err_name == "RemoteException" and "readtimeouterror" in err_str
+            ) or "readtimeout" in err_name.lower()
             if is_tool_capability_error:
                 await self._mount_message(
                     ErrorMessage(
@@ -10099,6 +10107,20 @@ class BogAgentsApp(App):
                         "  - `/model` to switch to a tool-capable model\n"
                         "  - For local Ollama, prefer coding/chat models with tool support such as `qwen3-coder-next:latest`\n"
                         "  - Use `--doctor` to confirm Ollama is reachable and the selected model is available"
+                    )
+                )
+            elif is_read_timeout:
+                await self._mount_message(
+                    ErrorMessage(
+                        f"Agent error: {e}\n\n"
+                        "The model provider stalled past the read deadline. "
+                        "The thread state on the server is preserved — send "
+                        "another message (or just press Enter on a blank line "
+                        "to retry the last turn) to continue.\n\n"
+                        "If this keeps happening:\n"
+                        "  - Set `BOG_AGENTS_REMOTE_READ_TIMEOUT=3600` (or `none`) "
+                        "to give long turns more headroom\n"
+                        "  - `/model` to try a faster provider"
                     )
                 )
             elif is_auth_error:

--- a/libs/cli/bog_agents_cli/remote_client.py
+++ b/libs/cli/bog_agents_cli/remote_client.py
@@ -8,7 +8,9 @@ Textual adapter expects.
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import os
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -18,6 +20,70 @@ from bog_agents_cli._debug import configure_debug_logging
 
 logger = logging.getLogger(__name__)
 configure_debug_logging(logger)
+
+# Default read timeout for the langgraph SDK's underlying httpx client.
+# The SDK default is 300s, which is too tight for /review-style turns that
+# can fan out to many tool calls and span 5-20 minutes of model work.
+# Override with BOG_AGENTS_REMOTE_READ_TIMEOUT (seconds, or "none" to disable).
+_DEFAULT_READ_TIMEOUT_SECS: float = 1800.0
+
+# Number of times to re-issue an astream() call when the SSE stream raises a
+# transient error *before any events have flowed*. Once events have been
+# emitted, retrying is unsafe (the server has already mutated state).
+_PRE_FIRST_EVENT_RETRIES: int = 2
+
+# Substrings that indicate a transient (network/provider) failure worth
+# retrying when raised before the first event. Matched case-insensitively
+# against the exception's class name and string form.
+_TRANSIENT_ERROR_MARKERS: tuple[str, ...] = (
+    "readtimeout",
+    "connecttimeout",
+    "connectionerror",
+    "remoteprotocolerror",
+    "incompletewrite",
+)
+
+
+def _resolve_read_timeout() -> float | None:
+    """Resolve the SSE read timeout from env var or default.
+
+    Returns:
+        Read timeout in seconds, or `None` to disable the read deadline.
+    """
+    raw = os.environ.get("BOG_AGENTS_REMOTE_READ_TIMEOUT")
+    if raw is None:
+        return _DEFAULT_READ_TIMEOUT_SECS
+    if raw.strip().lower() in {"none", "off", "0", ""}:
+        return None
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid BOG_AGENTS_REMOTE_READ_TIMEOUT=%r, using default %ss",
+            raw,
+            _DEFAULT_READ_TIMEOUT_SECS,
+        )
+        return _DEFAULT_READ_TIMEOUT_SECS
+    if value <= 0:
+        return None
+    return value
+
+
+_DROPPED = object()
+"""Sentinel yielded by `_process_chunk` when a message failed conversion."""
+
+
+def _is_transient_stream_error(exc: BaseException) -> bool:
+    """Return True if `exc` looks like a network/provider blip worth retrying.
+
+    Args:
+        exc: Exception raised from the SSE stream.
+
+    Returns:
+        True if the exception name or message contains a transient marker.
+    """
+    haystack = f"{type(exc).__name__} {exc!s}".lower()
+    return any(marker in haystack for marker in _TRANSIENT_ERROR_MARKERS)
 
 
 def _require_thread_id(config: dict[str, Any] | None) -> str:
@@ -55,6 +121,7 @@ class RemoteAgent:
         graph_name: str = "agent",
         api_key: str | None = None,
         headers: dict[str, str] | None = None,
+        read_timeout: float | None = None,
     ) -> None:
         """Initialize the remote agent client.
 
@@ -68,27 +135,64 @@ class RemoteAgent:
                 the environment.
             headers: Extra HTTP headers to include in every request
                 (e.g. bearer tokens, proxy headers).
+            read_timeout: SSE read timeout in seconds. When `None`, the
+                value from `BOG_AGENTS_REMOTE_READ_TIMEOUT` is used,
+                falling back to `_DEFAULT_READ_TIMEOUT_SECS` (1800s) when
+                that env var is unset. Set the env var to `none`/`0` to
+                disable the read deadline entirely.
         """
         self._url = url
         self._graph_name = graph_name
         self._api_key = api_key
         self._headers = headers
+        self._read_timeout = (
+            read_timeout if read_timeout is not None else _resolve_read_timeout()
+        )
+        if self._read_timeout is not None and self._read_timeout <= 0:
+            self._read_timeout = None
         self._graph: Any = None
 
     def _get_graph(self) -> Any:  # noqa: ANN401
         """Lazily create the `RemoteGraph` instance.
 
+        The underlying httpx clients are constructed with an extended read
+        timeout so long-running review/refactor turns don't get killed by
+        the langgraph_sdk's 300s default mid-stream.
+
         Returns:
             A `RemoteGraph` connected to the server.
         """
         if self._graph is None:
+            import httpx
             from langgraph.pregel.remote import RemoteGraph
+            from langgraph_sdk.client import get_client, get_sync_client
 
+            # langgraph_sdk default is httpx.Timeout(connect=5, read=300,
+            # write=300, pool=5). Bump read+write so SSE long-polls and
+            # uploads can survive multi-minute provider stalls.
+            read = self._read_timeout
+            write = read
+            timeout = httpx.Timeout(connect=5.0, read=read, write=write, pool=5.0)
+
+            client = get_client(
+                url=self._url,
+                api_key=self._api_key,
+                headers=self._headers,
+                timeout=timeout,
+            )
+            sync_client = get_sync_client(
+                url=self._url,
+                api_key=self._api_key,
+                headers=self._headers,
+                timeout=timeout,
+            )
             self._graph = RemoteGraph(
                 self._graph_name,
                 url=self._url,
                 api_key=self._api_key,
                 headers=self._headers,
+                client=client,
+                sync_client=sync_client,
             )
         return self._graph
 
@@ -131,50 +235,108 @@ class RemoteAgent:
         config = _prepare_config(config)
         dropped_count = 0
 
-        async for ns, mode, data in graph.astream(
-            input,
-            stream_mode=stream_mode or ["messages", "updates"],
-            subgraphs=subgraphs,
-            config=config,
-            context=context,
-        ):
-            logger.debug("RemoteGraph event mode=%s ns=%s", mode, ns)
+        modes = stream_mode or ["messages", "updates"]
+        first_event_seen = False
+        attempt = 0
+        max_attempts = 1 + _PRE_FIRST_EVENT_RETRIES
 
-            if mode == "messages":
-                msg_dict, meta = data
-                if isinstance(msg_dict, dict):
-                    msg_obj = _convert_message_data(msg_dict)
-                    if msg_obj is not None:
-                        yield (ns, "messages", (msg_obj, meta or {}))
-                    else:
-                        dropped_count += 1
-                elif isinstance(msg_dict, BaseMessage):
-                    # Already a LangChain message object (pre-deserialized)
-                    yield (ns, "messages", (msg_dict, meta or {}))
-                else:
+        while True:
+            attempt += 1
+            try:
+                async for ns, mode, data in graph.astream(
+                    input,
+                    stream_mode=modes,
+                    subgraphs=subgraphs,
+                    config=config,
+                    context=context,
+                ):
+                    first_event_seen = True
+                    async for converted in RemoteAgent._process_chunk(
+                        ns, mode, data, BaseMessage
+                    ):
+                        if converted is _DROPPED:
+                            dropped_count += 1
+                        else:
+                            yield converted
+                break
+            except Exception as exc:
+                if (
+                    not first_event_seen
+                    and attempt < max_attempts
+                    and _is_transient_stream_error(exc)
+                ):
+                    backoff = min(2 ** (attempt - 1), 8)
                     logger.warning(
-                        "Unexpected message data type in stream: %s",
-                        type(msg_dict).__name__,
+                        "Transient %s before first stream event "
+                        "(attempt %d/%d); retrying in %.1fs",
+                        type(exc).__name__,
+                        attempt,
+                        max_attempts,
+                        backoff,
                     )
-                continue
-
-            if mode == "updates" and isinstance(data, dict):
-                update_data = data
-                if "__interrupt__" in data:
-                    update_data = {
-                        **data,
-                        "__interrupt__": _convert_interrupts(data["__interrupt__"]),
-                    }
-                yield (ns, "updates", update_data)
-                continue
-
-            yield (ns, mode, data)
+                    await asyncio.sleep(backoff)
+                    continue
+                raise
 
         if dropped_count:
             logger.warning(
                 "Dropped %d message(s) during stream due to conversion failures",
                 dropped_count,
             )
+
+    @staticmethod
+    async def _process_chunk(
+        ns: tuple[str, ...],
+        mode: str,
+        data: Any,  # noqa: ANN401
+        base_message_cls: type,
+    ) -> AsyncIterator[Any]:
+        """Convert a single RemoteGraph chunk into adapter-ready events.
+
+        Yields adapter-format 3-tuples, or the `_DROPPED` sentinel when a
+        message could not be deserialized.
+
+        Args:
+            ns: Namespace tuple from RemoteGraph.
+            mode: Stream mode (`messages`, `updates`, etc.).
+            data: Raw event payload.
+            base_message_cls: `langchain_core.messages.BaseMessage` (passed
+                in to avoid re-importing on every chunk).
+
+        Yields:
+            Either a fully-converted 3-tuple ready for the adapter, or the
+            `_DROPPED` sentinel for messages that failed conversion.
+        """
+        logger.debug("RemoteGraph event mode=%s ns=%s", mode, ns)
+
+        if mode == "messages":
+            msg_dict, meta = data
+            if isinstance(msg_dict, dict):
+                msg_obj = _convert_message_data(msg_dict)
+                if msg_obj is not None:
+                    yield (ns, "messages", (msg_obj, meta or {}))
+                else:
+                    yield _DROPPED
+            elif isinstance(msg_dict, base_message_cls):
+                yield (ns, "messages", (msg_dict, meta or {}))
+            else:
+                logger.warning(
+                    "Unexpected message data type in stream: %s",
+                    type(msg_dict).__name__,
+                )
+            return
+
+        if mode == "updates" and isinstance(data, dict):
+            update_data = data
+            if "__interrupt__" in data:
+                update_data = {
+                    **data,
+                    "__interrupt__": _convert_interrupts(data["__interrupt__"]),
+                }
+            yield (ns, "updates", update_data)
+            return
+
+        yield (ns, mode, data)
 
     async def aget_state(
         self,

--- a/libs/cli/tests/unit_tests/test_remote_client.py
+++ b/libs/cli/tests/unit_tests/test_remote_client.py
@@ -563,12 +563,13 @@ class TestRemoteAgentInit:
         )
         with patch("langgraph.pregel.remote.RemoteGraph") as mock_cls:
             agent._get_graph()
-            mock_cls.assert_called_once_with(
-                "agent",
-                url="http://localhost:8123",
-                api_key="sk-test-123",
-                headers=None,
-            )
+            args, kwargs = mock_cls.call_args
+            assert args == ("agent",)
+            assert kwargs["url"] == "http://localhost:8123"
+            assert kwargs["api_key"] == "sk-test-123"
+            assert kwargs["headers"] is None
+            assert kwargs["client"] is not None
+            assert kwargs["sync_client"] is not None
 
     def test_headers_passed_to_remote_graph(self) -> None:
         """Headers kwarg is forwarded to RemoteGraph."""
@@ -580,24 +581,17 @@ class TestRemoteAgentInit:
         )
         with patch("langgraph.pregel.remote.RemoteGraph") as mock_cls:
             agent._get_graph()
-            mock_cls.assert_called_once_with(
-                "agent",
-                url="http://localhost:8123",
-                api_key=None,
-                headers=hdrs,
-            )
+            _, kwargs = mock_cls.call_args
+            assert kwargs["headers"] == hdrs
 
     def test_defaults_no_auth(self) -> None:
         """Default construction passes None for api_key and headers."""
         agent = RemoteAgent(url="http://localhost:8123")
         with patch("langgraph.pregel.remote.RemoteGraph") as mock_cls:
             agent._get_graph()
-            mock_cls.assert_called_once_with(
-                "agent",
-                url="http://localhost:8123",
-                api_key=None,
-                headers=None,
-            )
+            _, kwargs = mock_cls.call_args
+            assert kwargs["api_key"] is None
+            assert kwargs["headers"] is None
 
     def test_graph_lazy_singleton(self) -> None:
         """_get_graph creates RemoteGraph once and caches it."""
@@ -608,8 +602,151 @@ class TestRemoteAgentInit:
             assert g1 is g2
             mock_cls.assert_called_once()
 
+    def test_extended_read_timeout_applied_to_clients(self) -> None:
+        """Default 1800s read timeout is configured on the underlying httpx clients.
+
+        The langgraph_sdk default is 300s; we extend it so /review-style turns
+        don't get killed mid-stream by the default deadline.
+        """
+        agent = RemoteAgent(url="http://localhost:8123")
+        with (
+            patch("langgraph.pregel.remote.RemoteGraph"),
+            patch("langgraph_sdk.client.get_client") as mock_async,
+            patch("langgraph_sdk.client.get_sync_client") as mock_sync,
+        ):
+            agent._get_graph()
+            for mock in (mock_async, mock_sync):
+                _, kwargs = mock.call_args
+                timeout = kwargs.get("timeout")
+                assert timeout is not None
+                assert timeout.read == 1800.0
+
+    def test_read_timeout_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """BOG_AGENTS_REMOTE_READ_TIMEOUT overrides the default."""
+        monkeypatch.setenv("BOG_AGENTS_REMOTE_READ_TIMEOUT", "60")
+        agent = RemoteAgent(url="http://localhost:8123")
+        with (
+            patch("langgraph.pregel.remote.RemoteGraph"),
+            patch("langgraph_sdk.client.get_client") as mock_async,
+            patch("langgraph_sdk.client.get_sync_client"),
+        ):
+            agent._get_graph()
+            _, kwargs = mock_async.call_args
+            assert kwargs["timeout"].read == 60.0
+
+    def test_read_timeout_env_disable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """`none` in BOG_AGENTS_REMOTE_READ_TIMEOUT disables the deadline."""
+        monkeypatch.setenv("BOG_AGENTS_REMOTE_READ_TIMEOUT", "none")
+        agent = RemoteAgent(url="http://localhost:8123")
+        with (
+            patch("langgraph.pregel.remote.RemoteGraph"),
+            patch("langgraph_sdk.client.get_client") as mock_async,
+            patch("langgraph_sdk.client.get_sync_client"),
+        ):
+            agent._get_graph()
+            _, kwargs = mock_async.call_args
+            assert kwargs["timeout"].read is None
+
 
 class TestRemoteAgentWithConfig:
     def test_returns_self(self) -> None:
         agent = RemoteAgent(url="http://localhost:8123", graph_name="agent")
         assert agent.with_config({"configurable": {}}) is agent
+
+
+class TestRemoteAgentTransientRetry:
+    """Pre-first-event retry on ReadTimeoutError / transient SSE errors.
+
+    Once events have flowed, retrying is unsafe; the stream must propagate.
+    Before first event, we re-issue the call up to `_PRE_FIRST_EVENT_RETRIES`
+    times since the server hasn't begun mutating thread state.
+    """
+
+    @pytest.mark.asyncio
+    async def test_retries_then_succeeds_when_first_attempt_times_out(self) -> None:
+        from bog_agents_cli import remote_client as rc
+
+        calls: list[int] = []
+
+        async def _gen(*_a: Any, **_kw: Any):  # noqa: RUF029  # async generator
+            calls.append(1)
+            if len(calls) == 1:
+                msg = "ReadTimeoutError mid-handshake"
+                raise TimeoutError(msg)
+            yield ((), "updates", {"ok": True})
+
+        config = {"configurable": {"thread_id": _TEST_THREAD_ID}}
+        agent = RemoteAgent(url="http://localhost:8123", graph_name="agent")
+        mock_graph = MagicMock()
+        mock_graph.astream = _gen
+        agent._graph = mock_graph
+
+        with patch.object(rc.asyncio, "sleep", AsyncMock()):
+            events = [chunk async for chunk in agent.astream({}, config=config)]
+
+        assert len(calls) == 2
+        assert events == [((), "updates", {"ok": True})]
+
+    @pytest.mark.asyncio
+    async def test_does_not_retry_after_first_event_emitted(self) -> None:
+        from bog_agents_cli import remote_client as rc
+
+        async def _gen(*_a: Any, **_kw: Any):  # noqa: RUF029  # async generator
+            yield ((), "updates", {"started": True})
+            msg = "ReadTimeoutError partway through"
+            raise TimeoutError(msg)
+
+        config = {"configurable": {"thread_id": _TEST_THREAD_ID}}
+        agent = RemoteAgent(url="http://localhost:8123", graph_name="agent")
+        mock_graph = MagicMock()
+        mock_graph.astream = _gen
+        agent._graph = mock_graph
+
+        with (
+            patch.object(rc.asyncio, "sleep", AsyncMock()),
+            pytest.raises(TimeoutError),
+        ):
+            async for _ in agent.astream({}, config=config):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_non_transient_error_propagates_immediately(self) -> None:
+        from bog_agents_cli import remote_client as rc
+
+        async def _gen(*_a: Any, **_kw: Any):  # noqa: RUF029  # async generator
+            msg = "bad input"
+            raise ValueError(msg)
+            yield  # pragma: no cover  # makes this a generator
+
+        config = {"configurable": {"thread_id": _TEST_THREAD_ID}}
+        agent = RemoteAgent(url="http://localhost:8123", graph_name="agent")
+        mock_graph = MagicMock()
+        mock_graph.astream = _gen
+        agent._graph = mock_graph
+
+        with (
+            patch.object(rc.asyncio, "sleep", AsyncMock()),
+            pytest.raises(ValueError, match="bad input"),
+        ):
+            async for _ in agent.astream({}, config=config):
+                pass
+
+
+class TestTransientErrorClassifier:
+    def test_readtimeout_is_transient(self) -> None:
+        from bog_agents_cli.remote_client import _is_transient_stream_error
+
+        assert _is_transient_stream_error(TimeoutError("ReadTimeoutError sock"))
+        assert _is_transient_stream_error(
+            RuntimeError("RemoteException: ReadTimeoutError")
+        )
+
+    def test_connecterror_is_transient(self) -> None:
+        from bog_agents_cli.remote_client import _is_transient_stream_error
+
+        assert _is_transient_stream_error(ConnectionError("network blip"))
+
+    def test_value_error_is_not_transient(self) -> None:
+        from bog_agents_cli.remote_client import _is_transient_stream_error
+
+        assert not _is_transient_stream_error(ValueError("schema mismatch"))

--- a/libs/cli/tests/unit_tests/test_thread_selector.py
+++ b/libs/cli/tests/unit_tests/test_thread_selector.py
@@ -82,6 +82,32 @@ async def _wait_for_widget(pilot: Any, query_fn: Any) -> Any:  # noqa: ANN401
     return query_fn()
 
 
+async def _wait_for_threads_loaded(
+    pilot: Any,  # noqa: ANN401
+    screen: Any,  # noqa: ANN401
+    expected_count: int,
+) -> None:
+    """Poll up to 5 s until `screen._filtered_threads` has `expected_count` items.
+
+    The thread list is populated by a background `run_worker(_load_threads)`
+    that finishes asynchronously. On Linux Python 3.12 two `pilot.pause()`
+    calls are not always enough to drive the worker to completion, so this
+    helper polls until the list reflects the patched data.
+    """
+    import time
+
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        if len(screen._filtered_threads) == expected_count:
+            return
+        await pilot.pause()
+    msg = (
+        f"Threads not loaded after 5s: expected {expected_count}, "
+        f"got {len(screen._filtered_threads)}"
+    )
+    raise AssertionError(msg)
+
+
 def _patch_columns(columns: dict[str, bool] | None = None) -> Any:  # noqa: ANN401
     """Patch thread config loaders for tests."""
     import contextlib
@@ -1905,7 +1931,7 @@ class TestThreadSelectorDelete:
 
                 screen = app.screen
                 assert isinstance(screen, ThreadSelectorScreen)
-                assert len(screen._filtered_threads) == 1
+                await _wait_for_threads_loaded(pilot, screen, expected_count=1)
 
                 await pilot.press("ctrl+d")
                 await pilot.pause()

--- a/libs/cli/tests/unit_tests/test_thread_selector.py
+++ b/libs/cli/tests/unit_tests/test_thread_selector.py
@@ -1816,6 +1816,7 @@ class TestThreadSelectorDelete:
 
                 screen = app.screen
                 assert isinstance(screen, ThreadSelectorScreen)
+                await _wait_for_threads_loaded(pilot, screen, expected_count=3)
                 assert screen._confirming_delete is False
 
                 await pilot.press("ctrl+d")
@@ -1835,6 +1836,7 @@ class TestThreadSelectorDelete:
 
                 screen = app.screen
                 assert isinstance(screen, ThreadSelectorScreen)
+                await _wait_for_threads_loaded(pilot, screen, expected_count=3)
 
                 await pilot.press("ctrl+d")
                 await pilot.pause()
@@ -1853,6 +1855,7 @@ class TestThreadSelectorDelete:
 
                 screen = app.screen
                 assert isinstance(screen, ThreadSelectorScreen)
+                await _wait_for_threads_loaded(pilot, screen, expected_count=3)
 
                 await pilot.press("ctrl+d")
                 await pilot.pause()
@@ -1886,6 +1889,7 @@ class TestThreadSelectorDelete:
 
                 screen = app.screen
                 assert isinstance(screen, ThreadSelectorScreen)
+                await _wait_for_threads_loaded(pilot, screen, expected_count=3)
 
                 await pilot.press("down")
                 await pilot.pause()
@@ -1964,6 +1968,7 @@ class TestThreadSelectorDelete:
 
                 screen = app.screen
                 assert isinstance(screen, ThreadSelectorScreen)
+                await _wait_for_threads_loaded(pilot, screen, expected_count=3)
                 last_index = len(screen._filtered_threads) - 1
 
                 for _ in range(last_index):
@@ -2002,6 +2007,7 @@ class TestThreadSelectorDelete:
 
                 screen = app.screen
                 assert isinstance(screen, ThreadSelectorScreen)
+                await _wait_for_threads_loaded(pilot, screen, expected_count=3)
                 original_count = len(screen._filtered_threads)
 
                 await pilot.press("ctrl+d")


### PR DESCRIPTION
A `/review` turn (or any long agent run) could die mid-stream when the langgraph server's upstream HTTP call to the model provider hit a read deadline. The server forwarded the failure as
`RemoteException({'error': 'ReadTimeoutError', ...})`, the CLI's outer exception handler classified it as a generic "Agent error", and the user lost the turn with no clear hint that thread state was preserved.

Three changes:

1. `RemoteAgent` now constructs the underlying httpx clients with a 1800s read+write timeout (langgraph_sdk default is 300s, too tight for review-style turns that fan out to many tool calls). Override via `BOG_AGENTS_REMOTE_READ_TIMEOUT` (seconds, or `none` to disable).

2. `RemoteAgent.astream` retries up to twice (with exponential backoff) when a transient error — `ReadTimeoutError`, `ConnectError`, `RemoteProtocolError`, etc. — is raised *before any events have flowed*. Pre-first-event retries are safe because the server has not yet begun mutating thread state. Mid-stream failures still propagate so callers can decide.

3. `_run_agent_task` classifies `RemoteException` carrying `ReadTimeoutError` distinctly from auth errors, telling the user the thread state is preserved and offering a concrete tunable.

