### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "libs/bog-agents": "0.7.4",
-  "libs/cli": "0.7.4",
-  "libs/daemon": "0.7.4"
+  "libs/bog-agents": "0.7.5",
+  "libs/cli": "0.7.5",
+  "libs/daemon": "0.7.5"
 }

--- a/libs/bog-agents/CHANGELOG.md
+++ b/libs/bog-agents/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.7.5](https://github.com/bogware/bog-agents/compare/bog-agents==0.7.4...bog-agents==0.7.5) (2026-05-01)
+
+
+* **bog-agents:** Synchronize bog-agents-monorepo versions
+
 ## [0.7.4](https://github.com/bogware/bog-agents/compare/bog-agents==0.7.3...bog-agents==0.7.4) (2026-04-30)
 
 

--- a/libs/bog-agents/bog_agents/_version.py
+++ b/libs/bog-agents/bog_agents/_version.py
@@ -1,3 +1,3 @@
 """Version information for `bog-agents` (SDK)."""
 
-__version__ = "0.7.4"  # x-release-please-version
+__version__ = "0.7.5"  # x-release-please-version

--- a/libs/bog-agents/pyproject.toml
+++ b/libs/bog-agents/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bog-agents"
-version = "0.7.4"
+version = "0.7.5"
 
 description = "Bog Agents - batteries-included agent harness for building AI agents. Supports any major provider (Anthropic, OpenAI, AWS Bedrock, Google, etc.) and local models via Ollama. Built on LangGraph."
 readme = "README.md"

--- a/libs/bog-agents/uv.lock
+++ b/libs/bog-agents/uv.lock
@@ -252,7 +252,7 @@ wheels = [
 
 [[package]]
 name = "bog-agents"
-version = "0.7.4"
+version = "0.7.5"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },

--- a/libs/cli/CHANGELOG.md
+++ b/libs/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.7.5](https://github.com/bogware/bog-agents/compare/bog-agents-cli==0.7.4...bog-agents-cli==0.7.5) (2026-05-01)
+
+
+### Bug Fixes
+
+* **cli:** survive ReadTimeout from langgraph SSE stream ([#58](https://github.com/bogware/bog-agents/issues/58)) ([233ae54](https://github.com/bogware/bog-agents/commit/233ae54ef8aab22f2d25a7a5296c8822791146ed))
+
 ## [0.7.4](https://github.com/bogware/bog-agents/compare/bog-agents-cli==0.7.3...bog-agents-cli==0.7.4) (2026-04-30)
 
 

--- a/libs/cli/bog_agents_cli/_version.py
+++ b/libs/cli/bog_agents_cli/_version.py
@@ -1,3 +1,3 @@
 """Version information for `bog-agents-cli`."""
 
-__version__ = "0.7.4"  # x-release-please-version
+__version__ = "0.7.5"  # x-release-please-version

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 dependencies = [
     # Framework
-    "bog-agents==0.7.4",
+    "bog-agents==0.7.5",
     "langchain>=1.2.10,<2.0.0",
     "langgraph>=1.1.2,<2.0.0",
     "langgraph-checkpoint-sqlite>=3.0.0,<4.0.0",

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bog-agents-cli"
-version = "0.7.4"
+version = "0.7.5"
 description = "A coding agent in your terminal. 50+ commands, any LLM provider, persistent memory, git workflow, code review, plan mode, remote sandboxes, and CI/CD automation. One install, no code required."
 readme = "README.md"
 license = { text = "MIT" }

--- a/libs/cli/uv.lock
+++ b/libs/cli/uv.lock
@@ -317,7 +317,7 @@ wheels = [
 
 [[package]]
 name = "bog-agents"
-version = "0.7.4"
+version = "0.7.5"
 source = { editable = "../bog-agents" }
 dependencies = [
     { name = "anyio" },
@@ -416,7 +416,7 @@ test = [
 
 [[package]]
 name = "bog-agents-cli"
-version = "0.7.4"
+version = "0.7.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/libs/daemon/CHANGELOG.md
+++ b/libs/daemon/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.7.5](https://github.com/bogware/bog-agents/compare/bog-agents-daemon==0.7.4...bog-agents-daemon==0.7.5) (2026-05-01)
+
+
+* **bog-agents-daemon:** Synchronize bog-agents-monorepo versions
+
 ## [0.7.4](https://github.com/bogware/bog-agents/compare/bog-agents-daemon==0.7.3...bog-agents-daemon==0.7.4) (2026-04-30)
 
 

--- a/libs/daemon/bog_agents_daemon/__init__.py
+++ b/libs/daemon/bog_agents_daemon/__init__.py
@@ -1,3 +1,3 @@
 """Bog Agents Daemon — ambient agent service."""
 
-__version__ = "0.7.4"
+__version__ = "0.7.5"

--- a/libs/daemon/pyproject.toml
+++ b/libs/daemon/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bog-agents-daemon"
-version = "0.7.4"
+version = "0.7.5"
 description = "Ambient agent daemon for bog-agents — run agents on schedules, file-change triggers, webhooks, and git pushes"
 readme = "README.md"
 license = { text = "MIT" }

--- a/libs/daemon/uv.lock
+++ b/libs/daemon/uv.lock
@@ -274,7 +274,7 @@ wheels = [
 
 [[package]]
 name = "bog-agents"
-version = "0.7.4"
+version = "0.7.5"
 source = { editable = "../bog-agents" }
 dependencies = [
     { name = "anyio" },
@@ -373,7 +373,7 @@ test = [
 
 [[package]]
 name = "bog-agents-daemon"
-version = "0.7.4"
+version = "0.7.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
> [!CAUTION]
> Merging this PR will automatically publish to **PyPI** and create a **GitHub release**.

For the full release process, see [`.github/RELEASING.md`](https://github.com/bogware/bog-agents/blob/main/.github/RELEASING.md).

---

_Everything below this line will be the GitHub release body._

---


<details><summary>bog-agents: 0.7.5</summary>

## [0.7.5](https://github.com/bogware/bog-agents/compare/bog-agents==0.7.4...bog-agents==0.7.5) (2026-05-01)


* **bog-agents:** Synchronize bog-agents-monorepo versions
</details>

<details><summary>bog-agents-cli: 0.7.5</summary>

## [0.7.5](https://github.com/bogware/bog-agents/compare/bog-agents-cli==0.7.4...bog-agents-cli==0.7.5) (2026-05-01)


### Bug Fixes

* **cli:** survive ReadTimeout from langgraph SSE stream ([#58](https://github.com/bogware/bog-agents/issues/58)) ([233ae54](https://github.com/bogware/bog-agents/commit/233ae54ef8aab22f2d25a7a5296c8822791146ed))
</details>

<details><summary>bog-agents-daemon: 0.7.5</summary>

## [0.7.5](https://github.com/bogware/bog-agents/compare/bog-agents-daemon==0.7.4...bog-agents-daemon==0.7.5) (2026-05-01)


* **bog-agents-daemon:** Synchronize bog-agents-monorepo versions
</details>

---

_Everything above this line will be the GitHub release body._
