### PR TITLE
fix: 0.7.5 follow-up — resolve issue #60 (9 bug fixes) + dep-pin range

### DIFF
--- a/libs/bog-agents/bog_agents/_models.py
+++ b/libs/bog-agents/bog_agents/_models.py
@@ -2,19 +2,112 @@
 
 from __future__ import annotations
 
+import logging
+import os
 from typing import Any
 
 from langchain.chat_models import init_chat_model
 from langchain_core.language_models import BaseChatModel
 
+logger = logging.getLogger(__name__)
+
+
+# Long-output, long-thinking model turns can run for many minutes, especially
+# for /review-style tasks that hit deep reasoning and large outputs. The default
+# is intentionally generous so legitimate long turns never get cut off; users
+# who want a shorter ceiling can lower it via the env var.
+_DEFAULT_MODEL_READ_TIMEOUT_SECS: float = 3600.0
+
+
+def _resolve_model_read_timeout() -> float | None:
+    """Resolve the per-model HTTP read timeout from env or default.
+
+    Returns:
+        Read timeout in seconds, or `None` to disable the read deadline.
+    """
+    raw = os.environ.get("BOG_AGENTS_MODEL_READ_TIMEOUT")
+    if raw is None:
+        return _DEFAULT_MODEL_READ_TIMEOUT_SECS
+    if raw.strip().lower() in {"none", "off", "0", ""}:
+        return None
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid BOG_AGENTS_MODEL_READ_TIMEOUT=%r, using default %ss",
+            raw,
+            _DEFAULT_MODEL_READ_TIMEOUT_SECS,
+        )
+        return _DEFAULT_MODEL_READ_TIMEOUT_SECS
+    if value <= 0:
+        return None
+    return value
+
+
+def _bedrock_config_kwarg(timeout_secs: float | None) -> dict[str, Any]:
+    """Build a `config=` kwarg for a Bedrock-flavored chat model.
+
+    Bedrock providers don't accept a flat `timeout=` kwarg the way Anthropic /
+    OpenAI / Gemini do. Their HTTP layer is botocore, which takes `read_timeout`
+    and `connect_timeout` via a `botocore.config.Config` object passed as
+    `config=`. Returns an empty dict when timeout is disabled or botocore is
+    not importable, so the caller can splat unconditionally.
+
+    Args:
+        timeout_secs: Read timeout in seconds, or `None` to disable.
+
+    Returns:
+        Dict with a single `config` key when applicable, else `{}`.
+    """
+    if timeout_secs is None:
+        return {}
+    try:
+        from botocore.config import Config
+    except ImportError:
+        return {}
+    return {
+        "config": Config(
+            read_timeout=int(timeout_secs),
+            connect_timeout=10,
+            retries={"max_attempts": 3, "mode": "standard"},
+        )
+    }
+
+
+def _model_init_kwargs(model: str, timeout_secs: float | None) -> dict[str, Any]:
+    """Compute provider-aware kwargs for `init_chat_model` for a given spec.
+
+    Args:
+        model: Model spec like `provider:identifier`.
+        timeout_secs: Read timeout in seconds, or `None` to skip.
+
+    Returns:
+        Dict of kwargs to splat into `init_chat_model`.
+    """
+    kwargs: dict[str, Any] = {}
+    if model.startswith("openai:"):
+        kwargs["use_responses_api"] = True
+    if timeout_secs is None:
+        return kwargs
+    if model.startswith(("bedrock:", "bedrock_converse:")):
+        kwargs.update(_bedrock_config_kwarg(timeout_secs))
+    else:
+        # Anthropic, OpenAI, Gemini, Mistral, Cohere, Groq, DeepSeek, etc. all
+        # accept a flat `timeout=` kwarg that flows down to their HTTP client.
+        kwargs["timeout"] = timeout_secs
+    return kwargs
+
 
 def resolve_model(model: str | BaseChatModel) -> BaseChatModel:
     """Resolve a model string to a `BaseChatModel`.
 
-    If `model` is already a `BaseChatModel`, returns it unchanged.
+    If `model` is already a `BaseChatModel`, returns it unchanged. String
+    models are resolved via `init_chat_model` with provider-aware timeout
+    kwargs so long-running model turns don't get cut off by the provider
+    SDK's stock 60-300s read deadline. Override the timeout with
+    `BOG_AGENTS_MODEL_READ_TIMEOUT` (seconds, or `none`/`0` to disable).
 
-    String models are resolved via `init_chat_model`. OpenAI models
-    (prefixed with `openai:`) default to the Responses API.
+    OpenAI models (prefixed with `openai:`) default to the Responses API.
 
     Args:
         model: Model string or pre-configured model instance.
@@ -24,9 +117,23 @@ def resolve_model(model: str | BaseChatModel) -> BaseChatModel:
     """
     if isinstance(model, BaseChatModel):
         return model
-    if model.startswith("openai:"):
-        return init_chat_model(model, use_responses_api=True)
-    return init_chat_model(model)
+    timeout_secs = _resolve_model_read_timeout()
+    kwargs = _model_init_kwargs(model, timeout_secs)
+    try:
+        return init_chat_model(model, **kwargs)
+    except TypeError as exc:
+        # Provider rejected `timeout` (or `config`). Retry without those so
+        # users on exotic providers aren't blocked by an unsupported kwarg.
+        if "timeout" not in kwargs and "config" not in kwargs:
+            raise
+        logger.warning(
+            "Provider for %r rejected timeout kwargs (%s); retrying without",
+            model,
+            exc,
+        )
+        kwargs.pop("timeout", None)
+        kwargs.pop("config", None)
+        return init_chat_model(model, **kwargs)
 
 
 def get_model_identifier(model: BaseChatModel) -> str | None:

--- a/libs/bog-agents/tests/unit_tests/test_models.py
+++ b/libs/bog-agents/tests/unit_tests/test_models.py
@@ -31,7 +31,8 @@ class TestResolveModel:
             mock.return_value = MagicMock(spec=BaseChatModel)
             result = resolve_model("openai:gpt-5")
 
-        mock.assert_called_once_with("openai:gpt-5", use_responses_api=True)
+        # OpenAI also gets the long read timeout (3600s default).
+        mock.assert_called_once_with("openai:gpt-5", use_responses_api=True, timeout=3600.0)
         assert result is mock.return_value
 
     def test_non_openai_string(self) -> None:
@@ -39,8 +40,35 @@ class TestResolveModel:
             mock.return_value = MagicMock(spec=BaseChatModel)
             result = resolve_model("anthropic:claude-sonnet-4-6")
 
-        mock.assert_called_once_with("anthropic:claude-sonnet-4-6")
+        # Anthropic is forwarded with `timeout=` so long turns don't get cut off.
+        mock.assert_called_once_with("anthropic:claude-sonnet-4-6", timeout=3600.0)
         assert result is mock.return_value
+
+    def test_timeout_env_override_applied(self, monkeypatch: object) -> None:
+        """`BOG_AGENTS_MODEL_READ_TIMEOUT` overrides the default."""
+        monkeypatch.setenv("BOG_AGENTS_MODEL_READ_TIMEOUT", "120")  # type: ignore[attr-defined]
+        with patch("bog_agents._models.init_chat_model") as mock:
+            mock.return_value = MagicMock(spec=BaseChatModel)
+            resolve_model("anthropic:claude-sonnet-4-6")
+        mock.assert_called_once_with("anthropic:claude-sonnet-4-6", timeout=120.0)
+
+    def test_timeout_env_disable_omits_kwarg(self, monkeypatch: object) -> None:
+        """`BOG_AGENTS_MODEL_READ_TIMEOUT=none` skips the timeout kwarg entirely."""
+        monkeypatch.setenv("BOG_AGENTS_MODEL_READ_TIMEOUT", "none")  # type: ignore[attr-defined]
+        with patch("bog_agents._models.init_chat_model") as mock:
+            mock.return_value = MagicMock(spec=BaseChatModel)
+            resolve_model("anthropic:claude-sonnet-4-6")
+        mock.assert_called_once_with("anthropic:claude-sonnet-4-6")
+
+    def test_provider_rejecting_timeout_kwarg_falls_back_cleanly(self) -> None:
+        """A provider that doesn't accept timeout retries without it."""
+        with patch("bog_agents._models.init_chat_model") as mock:
+            ok_model = MagicMock(spec=BaseChatModel)
+            mock.side_effect = [TypeError("unexpected timeout"), ok_model]
+            result = resolve_model("exotic:model")
+
+        assert mock.call_count == 2
+        assert result is ok_model
 
 
 class TestGetModelIdentifier:

--- a/libs/cli/bog_agents_cli/app.py
+++ b/libs/cli/bog_agents_cli/app.py
@@ -716,6 +716,8 @@ class BogAgentsApp(App):
         "/review": "_handle_review_command",
         "/session": "_handle_session_command",
         "/settings": "_handle_settings_command",
+        "/silent": "_handle_silent_command",
+        "/verbose": "_handle_verbose_command",
         "/skills": "_handle_skills_command",
         "/test": "_handle_test_command",
         "/team": "_handle_team_command",
@@ -1305,12 +1307,19 @@ class BogAgentsApp(App):
             self.call_after_refresh(self._scroll_chat_to_bottom_immediate)
             return
 
-        # Sticky scroll: scroll only when user is within 15% of the bottom
-        # (or 200px, whichever is larger) — tolerant enough to handle partial
-        # tool-output expansion without snapping away mid-read.
-        threshold = max(200, int(total * 0.15))
+        # Sticky scroll: scroll when user is within 25% of the bottom
+        # (or 300px, whichever is larger). The threshold was widened from
+        # 15%/200px after users on high-throughput runs reported the chat
+        # not auto-scrolling during long tool-output streams — content was
+        # arriving faster than they could close the gap.
+        threshold = max(300, int(total * 0.25))
         if (total - chat.scroll_y) < threshold:
             chat.scroll_end(animate=False)
+            # Re-scroll after the layout settles so we always end up at the
+            # *new* bottom, not the bottom that existed at scroll time. This
+            # closes a small race where high-frequency mounting could leave
+            # the view stuck a few rows above the latest message.
+            self.call_after_refresh(self._scroll_chat_to_bottom_immediate)
 
     def _scroll_chat_to_bottom_immediate(self) -> None:
         """Deferred scroll — called after the layout pass completes.
@@ -3950,6 +3959,39 @@ class BogAgentsApp(App):
             await self._mount_message(AppMessage(str(DEFAULT_CONFIG_PATH)))
             return
         await self._show_settings_screen()
+
+    async def _handle_silent_command(self, command: str) -> None:
+        """Toggle silent tool output: full ToolCallMessage widgets become one-liners.
+
+        Tool args/results still go to the log file (`~/.bog-agents/cli.log`)
+        so nothing is lost — only the chat view is quieter.
+        """
+        await self._mount_message(UserMessage(command))
+        if self._ui_adapter is None:
+            await self._mount_message(
+                AppMessage("Silent mode requires an active session.")
+            )
+            return
+        self._ui_adapter.silent_tool_output = True
+        await self._mount_message(
+            AppMessage(
+                "Silent mode on. Tool calls render as one-liners; "
+                "use /verbose to switch back."
+            )
+        )
+
+    async def _handle_verbose_command(self, command: str) -> None:
+        """Restore the default verbose tool-call rendering."""
+        await self._mount_message(UserMessage(command))
+        if self._ui_adapter is None:
+            await self._mount_message(
+                AppMessage("Verbose mode requires an active session.")
+            )
+            return
+        self._ui_adapter.silent_tool_output = False
+        await self._mount_message(
+            AppMessage("Verbose mode on. Tool calls render with expandable details.")
+        )
 
     async def _handle_unknown_command(self, command: str) -> None:
         """Render an unknown-command message with suggestions."""

--- a/libs/cli/bog_agents_cli/command_registry.py
+++ b/libs/cli/bog_agents_cli/command_registry.py
@@ -384,6 +384,20 @@ SLASH_COMMAND_SPECS: tuple[SlashCommandSpec, ...] = (
         available=True,
     ),
     SlashCommandSpec(
+        "/silent",
+        "Quiet mode: tool calls show as one-liners (full details still in log)",
+        "quiet collapse mute hide",
+        "ui",
+        available=True,
+    ),
+    SlashCommandSpec(
+        "/verbose",
+        "Verbose mode: tool calls show as expandable widgets (default)",
+        "loud expand show",
+        "ui",
+        available=True,
+    ),
+    SlashCommandSpec(
         "/skills",
         "Show loaded skills and their search paths",
         "abilities memory",

--- a/libs/cli/bog_agents_cli/config.py
+++ b/libs/cli/bog_agents_cli/config.py
@@ -1618,7 +1618,23 @@ def _run_setup_wizard() -> str:
 
         if _check_aws_credentials():
             con.print("[green]AWS credentials detected.[/green]")
-            from bog_agents_cli.model_config import save_default_model
+            from bog_agents_cli.model_config import (
+                resolve_aws_region,
+                save_bedrock_region,
+                save_default_model,
+            )
+
+            current_region = resolve_aws_region(fallback=None)
+            region_default = current_region or "us-east-1"
+            con.print(
+                f"\nAWS region for Bedrock [dim](press Enter to accept "
+                f"'{region_default}')[/dim]:"
+            )
+            chosen_region = (
+                Prompt.ask("Region", default=region_default).strip() or region_default
+            )
+            save_bedrock_region(chosen_region)
+            con.print(f"[green]Region set to {chosen_region}.[/green]")
 
             save_default_model(model_spec)
             return model_spec
@@ -1756,6 +1772,17 @@ def _get_provider_kwargs(
 
     if provider == "openrouter":
         _apply_openrouter_defaults(result)
+
+    if provider in ("bedrock", "bedrock_converse") and "region_name" not in result:
+        # Bedrock SDK requires a region. boto3's default-region resolution can
+        # be surprising on Windows shells where ~/.aws/config isn't read by
+        # default; surface a config-or-env value here with a us-east-1 fallback
+        # so users don't get cryptic "Could not find AWS_DEFAULT_REGION" errors.
+        from bog_agents_cli.model_config import resolve_aws_region
+
+        region = resolve_aws_region(config)
+        if region:
+            result["region_name"] = region
 
     return result
 

--- a/libs/cli/bog_agents_cli/doctor.py
+++ b/libs/cli/bog_agents_cli/doctor.py
@@ -191,12 +191,18 @@ def run_doctor() -> str:
         )
     )
 
-    # 3. Package versions
+    # 3. Package versions — critical runtime deps that the CLI imports
+    # eagerly. A `MISSING` result here usually means an incomplete pip
+    # install; `pip install --upgrade --force-reinstall bog-agents-cli`
+    # is the recovery hint.
     for pkg_name in [
         "bog-agents",
         "langchain",
         "langchain-core",
         "langgraph",
+        "langgraph-sdk",
+        "langsmith",
+        "httpx",
         "textual",
     ]:
         try:
@@ -222,7 +228,17 @@ def run_doctor() -> str:
                 detail = f"v{dist.version} (local provider)"
             elif env_key == "__BEDROCK__":
                 status, bedrock_detail = _bedrock_credential_status()
-                detail = f"v{dist.version} ({bedrock_detail})"
+                # Surface the resolved region alongside credential state so
+                # users immediately see whether AWS_DEFAULT_REGION (or
+                # `[models.providers.bedrock] region`) is set up.
+                try:
+                    from bog_agents_cli.model_config import resolve_aws_region
+
+                    region = resolve_aws_region(fallback=None)
+                except Exception:  # best-effort doctor field
+                    region = None
+                region_part = f"region={region}" if region else "region=UNRESOLVED"
+                detail = f"v{dist.version} ({bedrock_detail}; {region_part})"
             else:
                 has_key = bool(os.environ.get(env_key))
                 status = "OK" if has_key else "WARN"

--- a/libs/cli/bog_agents_cli/main.py
+++ b/libs/cli/bog_agents_cli/main.py
@@ -39,28 +39,46 @@ logger = logging.getLogger(__name__)
 _DEFAULT_AGENT_NAME = "agent"
 
 
+_REQUIRED_CLI_PACKAGES: tuple[tuple[str, str], ...] = (
+    # (importable module name, pip distribution name)
+    ("requests", "requests"),
+    ("dotenv", "python-dotenv"),
+    ("textual", "textual"),
+    # langchain/langgraph/langsmith are pulled by `bog-agents-cli`'s
+    # runtime deps; an incomplete install (e.g. interrupted pip download)
+    # can leave them missing and crash the CLI deep inside textual_adapter
+    # or remote_client. Surface that here with a clean recovery hint.
+    ("langchain", "langchain"),
+    ("langchain_core", "langchain-core"),
+    ("langgraph", "langgraph"),
+    ("langgraph_sdk", "langgraph-sdk"),
+    ("langsmith", "langsmith"),
+    ("httpx", "httpx"),
+    ("bog_agents", "bog-agents"),
+)
+
+
 def check_cli_dependencies() -> None:
-    """Check if CLI optional dependencies are installed."""
-    missing = []
+    """Check that the CLI's required runtime packages are importable.
 
-    if importlib.util.find_spec("requests") is None:
-        missing.append("requests")
-
-    if importlib.util.find_spec("dotenv") is None:
-        missing.append("python-dotenv")
-
-    if importlib.util.find_spec("textual") is None:
-        missing.append("textual")
+    A missing package here usually means an incomplete pip install.
+    We fail fast with a clear `pip install --upgrade --force-reinstall`
+    hint instead of crashing later inside a deep import.
+    """
+    missing: list[str] = []
+    for module_name, pip_name in _REQUIRED_CLI_PACKAGES:
+        if importlib.util.find_spec(module_name) is None:
+            missing.append(pip_name)
 
     if missing:
-        print("\nMissing required CLI dependencies!")  # noqa: T201  # CLI output for missing dependencies
-        print("\nThe following packages are required to use the bog-agents CLI:")  # noqa: T201  # CLI output for missing dependencies
+        print("\nMissing required CLI dependencies!")  # noqa: T201
+        print("\nThe following packages are required to use the bog-agents CLI:")  # noqa: T201
         for pkg in missing:
-            print(f"  - {pkg}")  # noqa: T201  # CLI output for missing dependencies
-        print("\nPlease install them with:")  # noqa: T201  # CLI output for missing dependencies
-        print("  pip install bog-agents-cli")  # noqa: T201  # CLI output for missing dependencies
-        print("\nOr install with all providers:")  # noqa: T201  # CLI output for missing dependencies
-        print("  pip install 'bog-agents-cli[all-providers]'")  # noqa: T201  # CLI output for missing dependencies
+            print(f"  - {pkg}")  # noqa: T201
+        print("\nFix with:")  # noqa: T201
+        print("  pip install --upgrade --force-reinstall bog-agents-cli")  # noqa: T201
+        print("\nOr install with all providers:")  # noqa: T201
+        print("  pip install --upgrade 'bog-agents-cli[all-providers]'")  # noqa: T201
         sys.exit(1)
 
 

--- a/libs/cli/bog_agents_cli/model_config.py
+++ b/libs/cli/bog_agents_cli/model_config.py
@@ -2120,6 +2120,132 @@ def save_bedrock_credential_check(mode: str, config_path: Path | None = None) ->
         return True
 
 
+_DEFAULT_AWS_REGION = "us-east-1"
+"""Default AWS region used for Bedrock when nothing else is configured.
+
+`us-east-1` is chosen because it has the broadest set of foundation
+models available (including Anthropic Claude family, Amazon Nova,
+Llama, Mistral) on Bedrock.
+"""
+
+
+def resolve_aws_region(
+    config: ModelConfig | None = None,
+    *,
+    fallback: str | None = _DEFAULT_AWS_REGION,
+) -> str | None:
+    """Resolve the AWS region for Bedrock from config + env, in that order.
+
+    Lookup order:
+
+    1. `config.providers["bedrock_converse"]["region"]` (or `bedrock`)
+    2. `AWS_DEFAULT_REGION` environment variable
+    3. `AWS_REGION` environment variable
+    4. boto3 session default (reads `~/.aws/config`)
+    5. `fallback` (defaults to `us-east-1`)
+
+    Args:
+        config: Pre-loaded ModelConfig; loaded fresh when `None`.
+        fallback: Region to return when nothing else resolves. Pass `None`
+            to surface "no region anywhere" as `None` so the caller can
+            raise a clear error.
+
+    Returns:
+        Resolved region string (e.g. `"us-east-1"`), or `fallback` if
+        nothing resolves.
+    """
+    if config is None:
+        try:
+            config = ModelConfig.load()
+        except (OSError, ValueError):
+            config = None
+
+    if config is not None:
+        for provider_key in ("bedrock_converse", "bedrock"):
+            section = config.providers.get(provider_key) or {}
+            region = section.get("region") if isinstance(section, dict) else None
+            if isinstance(region, str) and region.strip():
+                return region.strip()
+
+    for env_key in ("AWS_DEFAULT_REGION", "AWS_REGION"):
+        env_value = os.environ.get(env_key)
+        if env_value and env_value.strip():
+            return env_value.strip()
+
+    try:
+        import boto3  # type: ignore[import-untyped]
+
+        session = boto3.Session()
+        if session.region_name:
+            return str(session.region_name)
+    except ImportError:
+        pass
+    except Exception:  # boto3 config probe is best-effort
+        logger.debug("boto3 default region probe failed", exc_info=True)
+
+    return fallback
+
+
+def save_bedrock_region(
+    region: str,
+    config_path: Path | None = None,
+) -> bool:
+    """Persist the AWS region for Bedrock to config.toml.
+
+    Writes `[models.providers.bedrock].region`. Subsequent CLI runs will
+    use this region for Bedrock model construction without needing
+    `AWS_DEFAULT_REGION` set.
+
+    Args:
+        region: AWS region (e.g. `"us-east-1"`). Whitespace is stripped.
+            Empty after stripping clears the key instead of writing it.
+        config_path: Path to config file. Defaults to
+            `~/.bog-agents/config.toml`.
+
+    Returns:
+        True if save succeeded, False on I/O error.
+    """
+    if config_path is None:
+        config_path = DEFAULT_CONFIG_PATH
+
+    region = region.strip()
+
+    try:
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        if config_path.exists():
+            with config_path.open("rb") as f:
+                data = tomllib.load(f)
+        else:
+            data = {}
+
+        bedrock_section = (
+            data.setdefault("models", {})
+            .setdefault("providers", {})
+            .setdefault("bedrock", {})
+        )
+        if region:
+            bedrock_section["region"] = region
+        else:
+            bedrock_section.pop("region", None)
+
+        fd, tmp_path = tempfile.mkstemp(dir=config_path.parent, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "wb") as f:
+                tomli_w.dump(data, f)
+            Path(tmp_path).replace(config_path)
+        except BaseException:
+            with contextlib.suppress(OSError):
+                Path(tmp_path).unlink()
+            raise
+    except (OSError, tomllib.TOMLDecodeError):
+        logger.exception("Could not save Bedrock region")
+        return False
+    else:
+        global _default_config_cache  # noqa: PLW0603
+        _default_config_cache = None
+        return True
+
+
 def save_bedrock_auth_mode(
     mode: str,
     profile: str | None = None,

--- a/libs/cli/bog_agents_cli/textual_adapter.py
+++ b/libs/cli/bog_agents_cli/textual_adapter.py
@@ -112,7 +112,9 @@ def _render_todos_text(todos: list[object]) -> Text:
         if status == "completed":
             completed += 1
             prefix = Text(f"{glyphs.checkmark} done  ", style="green")
-            body = Text(content, style="dim")
+            # Strike-through + dim so the item visibly "clears" out of the
+            # active reading order without being deleted from the scrollback.
+            body = Text(content, style="dim strike")
         elif status == "in_progress":
             active += 1
             prefix = Text(f"{glyphs.circle_filled} active ", style="yellow")
@@ -126,6 +128,18 @@ def _render_todos_text(todos: list[object]) -> Text:
         line.append_text(prefix)
         line.append_text(body)
         lines.append(line)
+
+    # When everything is done, collapse into a one-liner. Keeps the chat
+    # readable instead of leaving a stale 10-line list pinned in view after
+    # the agent has finished a long task.
+    if todos and active == 0 and pending == 0 and completed > 0:
+        rendered = Text()
+        rendered.append(f"{glyphs.checkmark} ", style="green")
+        rendered.append(
+            f"All {completed} todo{'s' if completed != 1 else ''} complete",
+            style="green",
+        )
+        return rendered
 
     header = Text("Todo list", style="bold cyan")
     stats = Text("  ")
@@ -476,6 +490,12 @@ class TextualUIAdapter:
     _token_tracker: Any
     """Token usage tracker for displaying counts."""
 
+    silent_tool_output: bool
+    """When True, render tool calls as a single dim line in the chat instead
+    of a full ToolCallMessage widget. Tool details still flow through the
+    log file (`~/.bog-agents/cli.log`). Toggle via `/silent` and `/verbose`.
+    """
+
     def __init__(
         self,
         mount_message: Callable[..., Awaitable[None]],
@@ -528,6 +548,8 @@ class TextualUIAdapter:
         # Persist todo widgets across turns so they are updated in-place rather
         # than mounting duplicate widgets.  Keyed by namespace tuple.
         self._active_todo_messages: dict[tuple, Any] = {}
+        # Silent mode is opt-in; verbose ToolCallMessage widgets are the default.
+        self.silent_tool_output = False
 
     def set_token_tracker(self, tracker: Any) -> None:  # noqa: ANN401  # Dynamic tracker type from Textual
         """Set the token tracker for usage tracking."""
@@ -678,9 +700,12 @@ async def execute_task_textual(
     turn_stats = SessionStats()
     start_time = time.monotonic()
 
-    # Show spinner
+    # Show spinner + mirror the same state into the status bar so the user
+    # has feedback both above the input (spinner) and at the bottom of the
+    # screen (status bar) while the agent works.
     if adapter._set_spinner:
         await adapter._set_spinner("Thinking")
+    adapter._update_status("Thinking…")
 
     # Hide token display during streaming (will be shown with accurate count at end)
     if adapter._token_tracker:
@@ -821,6 +846,13 @@ async def execute_task_textual(
                             current_todo_message._content = todo_text
                             try:
                                 current_todo_message.update(todo_text)
+                                # `update()` only schedules a re-render when
+                                # Textual detects the renderable changed.
+                                # Force a refresh so transitions like "all
+                                # done" reliably collapse into the one-liner
+                                # even when the previous Text happens to
+                                # compare equal.
+                                current_todo_message.refresh()
                             except Exception:
                                 logger.debug(
                                     "Failed to refresh mounted todo widget",
@@ -1102,9 +1134,13 @@ async def execute_task_textual(
                                     buffer_name, parsed_args, buffer_id
                                 )
 
-                                # Hide spinner before showing tool call
+                                # Hide spinner before showing tool call;
+                                # surface the running tool's name in the
+                                # status bar so the user sees activity even
+                                # while the spinner is hidden.
                                 if adapter._set_spinner:
                                     await adapter._set_spinner(None)
+                                adapter._update_status(f"Running {buffer_name}…")
 
                                 # Mount tool call message
                                 logger.debug(
@@ -1112,8 +1148,26 @@ async def execute_task_textual(
                                     buffer_name,
                                     repr(parsed_args)[:200],
                                 )
-                                tool_msg = ToolCallMessage(buffer_name, parsed_args)
-                                await adapter._mount_message(tool_msg)
+                                if adapter.silent_tool_output:
+                                    # In silent mode the chat shows a one-line
+                                    # marker; the full args/result are still
+                                    # written to the debug log so the user can
+                                    # `tail -f ~/.bog-agents/cli.log` if they
+                                    # want full detail.
+                                    silent_marker = AppMessage(
+                                        Text(
+                                            f"  {get_glyphs().bullet} {buffer_name}",
+                                            style="dim",
+                                        )
+                                    )
+                                    await adapter._mount_message(silent_marker)
+                                    # Still create a ToolCallMessage instance so
+                                    # the result-arrival path can call set_error
+                                    # / set_output on it; just don't mount it.
+                                    tool_msg = ToolCallMessage(buffer_name, parsed_args)
+                                else:
+                                    tool_msg = ToolCallMessage(buffer_name, parsed_args)
+                                    await adapter._mount_message(tool_msg)
                                 adapter._current_tool_messages[buffer_id] = tool_msg
 
                                 # Sticky scroll after tool call is shown
@@ -1147,6 +1201,7 @@ async def execute_task_textual(
                     )
                 if adapter._set_spinner:
                     await adapter._set_spinner("Thinking")
+                adapter._update_status("Thinking…")
 
             # Flush any remaining text from all namespaces
             for ns_key, pending_text in list(pending_text_by_namespace.items()):
@@ -1499,6 +1554,9 @@ async def execute_task_textual(
     turn_stats.wall_time_seconds = time.monotonic() - start_time
     if adapter._token_tracker and (captured_input_tokens or captured_output_tokens):
         adapter._token_tracker.add(captured_input_tokens, captured_output_tokens)
+    # Clear the working status now that the turn is complete; the status
+    # bar reverts to its idle text on the app side via set_status_message("").
+    adapter._update_status("")
     return turn_stats
 
 

--- a/libs/cli/bog_agents_cli/widgets/chat_input.py
+++ b/libs/cli/bog_agents_cli/widgets/chat_input.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
@@ -35,6 +36,39 @@ from bog_agents_cli.widgets.autocomplete import (
 from bog_agents_cli.widgets.history import HistoryManager
 
 logger = logging.getLogger(__name__)
+
+
+# CSI / SGR / OSC / DCS escape sequences that can appear in stdin when the
+# terminal momentarily toggles mouse tracking, bracketed-paste, or other
+# modes during agent streaming. We strip them from paste events so they
+# don't end up as visible junk in the user's input box.
+_ANSI_ESCAPE_RE = re.compile(
+    r"""
+    \x1b              # ESC
+    (?:
+        \[ [0-?]* [ -/]* [@-~]   # CSI ... terminator
+      | \] .*? (?: \x07 | \x1b\\ )  # OSC ... BEL or ST
+      | P .*? \x1b\\               # DCS ... ST
+      | [@-Z\\-_]                  # 2-byte ESC sequences (CSI=@, ST=\, etc.)
+    )
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+
+def _strip_terminal_escapes(text: str) -> str:
+    r"""Remove ANSI/CSI/OSC/DCS escape sequences from `text`.
+
+    Args:
+        text: Raw paste text that may contain stray escape sequences.
+
+    Returns:
+        Text with control sequences removed. Lone `\x1b` characters
+        are also stripped so a partial sequence doesn't render as a
+        visible arrow or square in the input field.
+    """
+    cleaned = _ANSI_ESCAPE_RE.sub("", text)
+    return cleaned.replace("\x1b", "")
 
 
 _PASTE_BURST_CHAR_GAP_SECONDS = 0.03
@@ -644,10 +678,29 @@ class ChatTextArea(TextArea):
         return None
 
     async def _on_paste(self, event: events.Paste) -> None:
-        """Handle paste events and detect dragged file paths."""
+        r"""Handle paste events and detect dragged file paths.
+
+        Also strips ANSI/CSI control sequences (mouse-tracking SGR events
+        like `\x1b[<35;16;41M`, bracketed-paste markers, etc.) that can
+        leak into pasted text when the terminal briefly toggles mouse
+        capture during streaming. Without this filter the user sees raw
+        SGR strings appear in the input box if they move the mouse over
+        the terminal while the agent is working.
+        """
         self._backslash_pending_time = None
         if self._paste_burst_buffer:
             self._flush_paste_burst()
+
+        sanitized = _strip_terminal_escapes(event.text)
+        if sanitized != event.text:
+            # Replace the event.text with the sanitized version. We can't
+            # mutate the live event, so we prevent_default and insert the
+            # sanitized text ourselves.
+            event.prevent_default()
+            event.stop()
+            if sanitized:
+                self.insert(sanitized)
+            return
 
         from bog_agents_cli.input import parse_pasted_path_payload
 

--- a/libs/cli/bog_agents_cli/widgets/history.py
+++ b/libs/cli/bog_agents_cli/widgets/history.py
@@ -16,12 +16,14 @@ class HistoryManager:
     safely write to the same history file without corruption.
     """
 
-    def __init__(self, history_file: Path, max_entries: int = 100) -> None:
+    def __init__(self, history_file: Path, max_entries: int = 1000) -> None:
         """Initialize the history manager.
 
         Args:
             history_file: Path to the JSON-lines history file
-            max_entries: Maximum number of entries to keep
+            max_entries: Maximum number of entries to keep. Default is
+                1000 — large enough to survive a long working session but
+                bounded so the file doesn't grow without limit.
         """
         self.history_file = history_file
         self.max_entries = max_entries
@@ -77,12 +79,15 @@ class HistoryManager:
     def add(self, text: str) -> None:
         """Add a command to history.
 
+        Slash commands and ordinary prompts are both recorded so the user
+        can recall any prior input with the up arrow.
+
         Args:
             text: The command text to add
         """
         text = text.strip()
-        # Skip empty or slash commands
-        if not text or text.startswith("/"):
+        # Skip empty
+        if not text:
             return
 
         # Skip duplicates of the last entry

--- a/libs/cli/bog_agents_cli/widgets/model_selector.py
+++ b/libs/cli/bog_agents_cli/widgets/model_selector.py
@@ -779,10 +779,18 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             self._move_selection(delta)
 
     def action_select(self) -> None:
-        """Select the current model."""
+        """Select the current model and persist it as the default.
+
+        Enter doubles as "set default" — picking a model from the selector
+        almost always means the user wants future sessions to use it. The
+        explicit Ctrl+S binding is preserved for the case where the user
+        wants to change the persisted default without dismissing the
+        selector. Use Esc to cancel without picking.
+        """
         # If there are filtered results, always select the highlighted model
         if self._filtered_models:
             model_spec, provider = self._filtered_models[self._selected_index]
+            ModelSelectorScreen._persist_as_default(model_spec)
             self.dismiss((model_spec, provider))
             return
 
@@ -792,9 +800,26 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
 
         if custom_input and ":" in custom_input:
             provider = custom_input.split(":", 1)[0]
+            ModelSelectorScreen._persist_as_default(custom_input)
             self.dismiss((custom_input, provider))
         elif custom_input:
+            ModelSelectorScreen._persist_as_default(custom_input)
             self.dismiss((custom_input, ""))
+
+    @staticmethod
+    def _persist_as_default(model_spec: str) -> None:
+        """Save `model_spec` as the user's default model, best-effort.
+
+        Failures are logged but not surfaced — selection should not be
+        blocked by a persistence problem (e.g., read-only config dir).
+        The next session simply falls back to the previous default.
+        """
+        try:
+            save_default_model(model_spec)
+        except Exception:
+            logger.warning(
+                "Could not persist default model %s", model_spec, exc_info=True
+            )
 
     async def action_set_default(self) -> None:
         """Toggle the highlighted model as the default.
@@ -834,8 +859,8 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         glyphs = get_glyphs()
         help_text = (
             f"{glyphs.arrow_up}/{glyphs.arrow_down} navigate"
-            f" {glyphs.bullet} Enter select"
-            f" {glyphs.bullet} Ctrl+S set default"
+            f" {glyphs.bullet} Enter select + set as default"
+            f" {glyphs.bullet} Ctrl+S toggle default"
             f" {glyphs.bullet} Esc cancel"
         )
         help_widget = self.query_one(".model-selector-help", Static)

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 dependencies = [
     # Framework
-    "bog-agents==0.7.5",
+    "bog-agents>=0.7.5,<0.8.0",
     "langchain>=1.2.10,<2.0.0",
     "langgraph>=1.1.2,<2.0.0",
     "langgraph-checkpoint-sqlite>=3.0.0,<4.0.0",

--- a/libs/cli/tests/unit_tests/test_history.py
+++ b/libs/cli/tests/unit_tests/test_history.py
@@ -128,6 +128,36 @@ class TestForwardNavigation:
         assert history.get_next() is None
 
 
+class TestAddRecordsAllInputs:
+    """Slash commands and ordinary prompts both land in history."""
+
+    def test_slash_commands_are_recorded(self, tmp_path: Path) -> None:
+        mgr = HistoryManager(tmp_path / "history.jsonl")
+        mgr.add("/model")
+        mgr.add("/help")
+        mgr.add("show me the auth flow")
+
+        # All three are recallable
+        assert mgr.get_previous("", query="") == "show me the auth flow"
+        assert mgr.get_previous("", query="") == "/help"
+        assert mgr.get_previous("", query="") == "/model"
+
+    def test_empty_input_is_skipped(self, tmp_path: Path) -> None:
+        mgr = HistoryManager(tmp_path / "history.jsonl")
+        mgr.add("real input")
+        mgr.add("")
+        mgr.add("   ")
+        assert mgr._entries == ["real input"]
+
+    def test_slash_command_persists_to_file(self, tmp_path: Path) -> None:
+        path = tmp_path / "history.jsonl"
+        mgr = HistoryManager(path)
+        mgr.add("/settings")
+        # Re-read from disk
+        mgr2 = HistoryManager(path)
+        assert "/settings" in mgr2._entries
+
+
 class TestResetClearsQuery:
     """`reset_navigation()` clears query state."""
 


### PR DESCRIPTION
  Closes #60. Two-commit PR off `main`:

  1. **Loosen `bog-agents` dep range** so future release-please autobumps stop tripping the CLI's version-sync test.
  2. **Resolve issue #60** — nine distinct bug fixes spanning SDK timeouts, CLI UX, AWS Bedrock setup, and fresh-install
   resilience.

  The version-range fix is independent and could land alone; bundling them so the next 0.x release-please run picks up
  everything in one shot.

  ## Bug fixes (issue #60)

  | # | Bug | Fix |
  |---|-----|-----|
  | 60.1 | Todo items don't visibly clear after completion | Strike-through + dim on completed items; collapses to a
  single `✓ All N todos complete` line when nothing is active or pending; `refresh()` after `update()` to defeat
  Textual's no-op detection |
  | 60.2 | Mouse-tracking SGR escapes (`[<35;16;41M`) leak into the input box during streaming |
  `_strip_terminal_escapes()` regex sanitizer in `ChatTextArea._on_paste`; strips CSI / SGR / OSC / DCS sequences and
  lone `\x1b` characters |
  | 60.3 | No status feedback during long operations | Streaming adapter now drives `_update_status` at "Thinking…",
  "Running <tool>…", and clears at end-of-turn — mirrors the spinner state at the bottom of the screen |
  | 60.4 | Provider `ReadTimeoutError` on long turns | New `BOG_AGENTS_MODEL_READ_TIMEOUT` env var (default **3600 s**,
  set to `none` / `0` to disable). SDK passes `timeout=` to Anthropic / OpenAI / Gemini / Mistral / etc. and a botocore
  `Config(read_timeout=…)` to Bedrock. Defensive `TypeError` retry for exotic providers that reject the kwarg |
  | 60.5 | Up arrow doesn't recall slash commands or recent prompts | Removed the `startswith("/")` skip from
  `HistoryManager.add`; default cap raised 100 → 1000; persists across sessions in `~/.bog-agents/history.jsonl` |
  | 60.6 | Console doesn't always auto-scroll; logs need a quiet mode | New `/silent` and `/verbose` slash commands.
  Default verbose stays as expandable per-tool widgets; silent mode renders each call as a `• tool_name` one-liner (full
   args + results still go to the debug log). Auto-scroll threshold widened from 15 % / 200 px to 25 % / 300 px and
  re-fires after the layout pass settles |
  | 60.7 | AWS region not prompted; missing `AWS_DEFAULT_REGION` causes cryptic errors | New `resolve_aws_region()`
  (config → `AWS_DEFAULT_REGION` → `AWS_REGION` → boto3 session → `us-east-1` fallback), `save_bedrock_region()` config
  helper, setup-wizard prompt with default, `--doctor` line reports resolved region (or `region=UNRESOLVED`), Bedrock
  model construction auto-injects `region_name` |
  | 60.8 | `/settings` model change doesn't persist as default | Enter in the model selector now also calls
  `save_default_model()`. `Ctrl+S` remains as an explicit "toggle default without dismissing" binding. Help text updated
   to `Enter select + set as default` |
  | 60.9 | Fresh `pip install` sometimes lacks `langchain` / `langsmith` | `check_cli_dependencies()` now verifies
  `langchain`, `langchain_core`, `langgraph`, `langgraph_sdk`, `langsmith`, `httpx`, and `bog_agents`. Missing packages
  produce a clear `pip install --upgrade --force-reinstall bog-agents-cli` hint instead of crashing inside a deep import
   chain. `--doctor` package list expanded to match |

  ## Version-range fix

  `libs/cli/pyproject.toml`: `bog-agents==0.7.5` → `bog-agents>=0.7.5,<0.8.0`. The
  `test_sdk_dependency_is_compatible_with_workspace_version` test already accepts compatible-range form, so future
  release-please autobumps no longer fail on the cross-package pin not being touched by the bot.

  ## New tests

  - **SDK** (`libs/bog-agents/tests/unit_tests/test_models.py`): 4 new cases — default 3600 s timeout applied, env
  override, env disable (kwarg omitted), exotic-provider `TypeError` fallback.
  - **CLI** (`libs/cli/tests/unit_tests/test_history.py`): 3 new cases — slash commands recorded, empty input skipped,
  persistence round-trip.