### PR TITLE
fix(cli,sdk): kill ReadTimeouts on long turns + paste UX + ripgrep noise

### DIFF
--- a/libs/bog-agents/bog_agents/_models.py
+++ b/libs/bog-agents/bog_agents/_models.py
@@ -12,11 +12,13 @@ from langchain_core.language_models import BaseChatModel
 logger = logging.getLogger(__name__)
 
 
-# Long-output, long-thinking model turns can run for many minutes, especially
-# for /review-style tasks that hit deep reasoning and large outputs. The default
-# is intentionally generous so legitimate long turns never get cut off; users
-# who want a shorter ceiling can lower it via the env var.
-_DEFAULT_MODEL_READ_TIMEOUT_SECS: float = 3600.0
+# Long-output, long-thinking model turns can legitimately run for an hour
+# or more, especially for /review-style tasks chained with long tool calls
+# (builds, test suites, fan-out research) inside a single turn. The default
+# is deliberately generous so legitimate long work never gets cut off; users
+# who want a tighter ceiling can lower it via the env var, and setting it
+# to ``none``/``0`` disables the read deadline entirely.
+_DEFAULT_MODEL_READ_TIMEOUT_SECS: float = 7200.0
 
 
 def _resolve_model_read_timeout() -> float | None:

--- a/libs/bog-agents/bog_agents/backends/local_shell.py
+++ b/libs/bog-agents/bog_agents/backends/local_shell.py
@@ -23,8 +23,15 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_EXECUTE_TIMEOUT = 120
-"""Default timeout in seconds for shell command execution."""
+DEFAULT_EXECUTE_TIMEOUT = 7200
+"""Default timeout in seconds for shell command execution.
+
+Defaults to 2 hours so legitimate long-running commands (builds, test
+suites, large data fetches, fan-out scripts) don't get cut short. Lower
+it per-instance via ``LocalShellBackend(timeout=...)`` or per-call via
+the ``timeout`` kwarg on ``execute()`` / ``aexecute()`` if you want a
+tighter ceiling.
+"""
 
 # Patterns for commands that can cause catastrophic, irreversible damage.
 # Each entry is a (pattern, description) tuple. Blocked by default; pass
@@ -170,11 +177,13 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
 
             timeout: Default maximum time in seconds to wait for shell command execution.
 
-                Defaults to 120 seconds (2 minutes).
+                Defaults to 7200 seconds (2 hours) so legitimate long-running
+                commands (builds, test suites, large data fetches) don't get
+                cut short. Pass a smaller value here if you want a tighter
+                ceiling, or override per-command via the `timeout` parameter
+                on `execute()`.
 
                 Commands exceeding this timeout will be terminated.
-
-                Can be overridden per-command via the `timeout` parameter on `execute()`.
 
             max_output_bytes: Maximum number of bytes to capture from command output.
                 Output exceeding this limit will be truncated. Defaults to 100,000 bytes.

--- a/libs/bog-agents/bog_agents/graph.py
+++ b/libs/bog-agents/bog_agents/graph.py
@@ -86,12 +86,15 @@ For longer tasks, provide brief progress updates at reasonable intervals — a c
 def get_default_model() -> ChatAnthropic:
     """Get the default model for bog-agents agents.
 
+    Routes through `resolve_model` so the long-running read timeout from
+    `BOG_AGENTS_MODEL_READ_TIMEOUT` (default 3600s) is applied. A bare
+    `ChatAnthropic(...)` would inherit the SDK's stock 600s default and
+    cut off long thinking/streaming turns mid-stream.
+
     Returns:
         `ChatAnthropic` instance configured with Claude Sonnet 4.6.
     """
-    return ChatAnthropic(
-        model_name="claude-sonnet-4-6",
-    )
+    return cast(ChatAnthropic, resolve_model("anthropic:claude-sonnet-4-6"))
 
 
 def _validate_middleware_ordering(middleware_list: list[AgentMiddleware]) -> None:

--- a/libs/bog-agents/bog_agents/middleware/filesystem.py
+++ b/libs/bog-agents/bog_agents/middleware/filesystem.py
@@ -460,7 +460,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         system_prompt: str | None = None,
         custom_tool_descriptions: dict[str, str] | None = None,
         tool_token_limit_before_evict: int | None = 20000,
-        max_execute_timeout: int = 3600,
+        max_execute_timeout: int = 7200,
         artifacts_root: str | None = None,
     ) -> None:
         """Initialize the filesystem middleware.
@@ -477,7 +477,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 offloaded. When omitted, composite backends may provide their
                 own `artifacts_root`, otherwise `/large_tool_results` is used.
 
-                Defaults to 3600 seconds (1 hour). Any per-command timeout
+                Defaults to 7200 seconds (2 hours). Any per-command timeout
                 exceeding this value will be rejected with an error message.
 
         Raises:

--- a/libs/bog-agents/tests/unit_tests/test_models.py
+++ b/libs/bog-agents/tests/unit_tests/test_models.py
@@ -31,8 +31,8 @@ class TestResolveModel:
             mock.return_value = MagicMock(spec=BaseChatModel)
             result = resolve_model("openai:gpt-5")
 
-        # OpenAI also gets the long read timeout (3600s default).
-        mock.assert_called_once_with("openai:gpt-5", use_responses_api=True, timeout=3600.0)
+        # OpenAI also gets the long read timeout (7200s default).
+        mock.assert_called_once_with("openai:gpt-5", use_responses_api=True, timeout=7200.0)
         assert result is mock.return_value
 
     def test_non_openai_string(self) -> None:
@@ -41,7 +41,7 @@ class TestResolveModel:
             result = resolve_model("anthropic:claude-sonnet-4-6")
 
         # Anthropic is forwarded with `timeout=` so long turns don't get cut off.
-        mock.assert_called_once_with("anthropic:claude-sonnet-4-6", timeout=3600.0)
+        mock.assert_called_once_with("anthropic:claude-sonnet-4-6", timeout=7200.0)
         assert result is mock.return_value
 
     def test_timeout_env_override_applied(self, monkeypatch: object) -> None:

--- a/libs/cli/bog_agents_cli/app.py
+++ b/libs/cli/bog_agents_cli/app.py
@@ -1053,27 +1053,10 @@ class BogAgentsApp(App):
             logger.warning("peat scheduler failed to start", exc_info=True)
             self._peat_scheduler = None
 
-        # Warn about missing optional tools (advisory only — never block startup)
-        try:
-            from bog_agents_cli.main import (
-                check_optional_tools,
-                format_tool_warning_tui,
-            )
-        except ImportError:
-            logger.warning(
-                "Could not import optional tools checker; skipping tool warnings",
-                exc_info=True,
-            )
-        else:
-            try:
-                for tool in check_optional_tools():
-                    self.notify(
-                        format_tool_warning_tui(tool),
-                        severity="warning",
-                        timeout=15,
-                    )
-            except Exception:
-                logger.debug("Failed to check for optional tools", exc_info=True)
+        # Optional-tool warnings (e.g. missing ripgrep) used to fire here but
+        # were too noisy on every TUI start. The grep tool falls back to a
+        # pure-Python search transparently. Users who actually want the prompt
+        # can still call ``check_optional_tools()`` directly.
 
         # Auto-submit initial prompt if provided via -m flag.
         # This check must come first because _lc_thread_id and _agent are

--- a/libs/cli/bog_agents_cli/input.py
+++ b/libs/cli/bog_agents_cli/input.py
@@ -70,6 +70,21 @@ Used to extract numeric IDs from placeholder tokens so the tracker can prune
 stale entries and compute the next available ID.
 """
 
+PASTED_TEXT_PLACEHOLDER_PATTERN = re.compile(
+    r"\[Pasted #(?P<id>\d+)(?:: (?P<lines>\d+) lines?)?\]"
+)
+"""Pattern for large-paste placeholders, e.g. ``[Pasted #1: 450 lines]``.
+
+The lines suffix is optional so older surviving tokens (or copy-pastes of the
+placeholder by the user) still match. The id is required.
+"""
+
+PASTED_TEXT_LINE_THRESHOLD = 5
+"""Pastes with more than this many lines get replaced by a placeholder."""
+
+PASTED_TEXT_CHAR_THRESHOLD = 800
+"""Pastes longer than this character count get replaced by a placeholder."""
+
 _UNICODE_SPACE_EQUIVALENTS = str.maketrans(
     {
         "\u00a0": " ",  # NO-BREAK SPACE
@@ -267,6 +282,90 @@ class MediaTracker:
             if match is not None:
                 max_id = max(max_id, int(match.group("id")))
         return max_id + 1 if max_id else fallback_count + 1
+
+
+class PastedTextTracker:
+    """Track large pasted text blocks so they can be folded into placeholders.
+
+    When a paste exceeds ``PASTED_TEXT_LINE_THRESHOLD`` lines or
+    ``PASTED_TEXT_CHAR_THRESHOLD`` characters, the visual input gets a token
+    like ``[Pasted #1: 450 lines]`` while this tracker holds the full content.
+    At submit time the placeholder is expanded back into the full text so the
+    model still sees everything.
+
+    Mirrors the ``MediaTracker`` pattern used for image/video pastes.
+    """
+
+    def __init__(self) -> None:
+        """Initialize an empty paste tracker."""
+        self._blocks: dict[int, str] = {}
+        self._next_id: int = 1
+
+    @staticmethod
+    def should_fold(text: str) -> bool:
+        """Return True when ``text`` is large enough to warrant a placeholder."""
+        if len(text) >= PASTED_TEXT_CHAR_THRESHOLD:
+            return True
+        return text.count("\n") >= PASTED_TEXT_LINE_THRESHOLD
+
+    def add(self, text: str) -> str:
+        """Store ``text`` and return its placeholder token.
+
+        Args:
+            text: Full pasted content.
+
+        Returns:
+            Placeholder string like ``[Pasted #1: 450 lines]``.
+        """
+        block_id = self._next_id
+        self._next_id += 1
+        self._blocks[block_id] = text
+        line_count = text.count("\n") + 1
+        suffix = "line" if line_count == 1 else "lines"
+        return f"[Pasted #{block_id}: {line_count} {suffix}]"
+
+    def expand(self, text: str) -> str:
+        """Replace any placeholder tokens in ``text`` with their stored content.
+
+        Tokens whose id is unknown are left as-is (e.g. user typed a similar
+        bracketed string by hand). Empty tracker returns ``text`` unchanged.
+        """
+        if not self._blocks:
+            return text
+
+        def _sub(match: re.Match[str]) -> str:
+            block_id = int(match.group("id"))
+            return self._blocks.get(block_id, match.group(0))
+
+        return PASTED_TEXT_PLACEHOLDER_PATTERN.sub(_sub, text)
+
+    def sync_to_text(self, text: str) -> None:
+        """Drop stored blocks whose placeholder no longer appears in ``text``.
+
+        Mirrors ``MediaTracker.sync_to_text``: when the user deletes the
+        placeholder from the input box, the underlying content is no longer
+        needed and shouldn't silently leak into a later submission.
+        """
+        live_ids = {
+            int(m.group("id")) for m in PASTED_TEXT_PLACEHOLDER_PATTERN.finditer(text)
+        }
+        if not live_ids:
+            self.clear()
+            return
+        self._blocks = {
+            bid: data for bid, data in self._blocks.items() if bid in live_ids
+        }
+        if not self._blocks:
+            self._next_id = 1
+
+    def clear(self) -> None:
+        """Reset the tracker to an empty state."""
+        self._blocks.clear()
+        self._next_id = 1
+
+    def __len__(self) -> int:
+        """Number of currently-tracked paste blocks."""
+        return len(self._blocks)
 
 
 def parse_file_mentions(text: str) -> tuple[str, list[Path]]:

--- a/libs/cli/bog_agents_cli/main.py
+++ b/libs/cli/bog_agents_cli/main.py
@@ -1755,24 +1755,10 @@ def cli_main() -> None:
                 # No subcommand provided, show threads help screen
                 show_threads_help()
         elif args.non_interactive_message:
-            # Check for optional tools before running agent (stderr so
-            # --quiet piped output stays clean)
-            try:
-                from rich.console import Console as _Console
-            except ImportError:
-                logger.warning(
-                    "Could not import rich.console; skipping tool warnings",
-                    exc_info=True,
-                )
-            else:
-                try:
-                    warn_console = _Console(stderr=True)
-                    for tool in check_optional_tools():
-                        warn_console.print(
-                            f"[yellow]Warning:[/yellow] {format_tool_warning_cli(tool)}"
-                        )
-                except Exception:
-                    logger.debug("Failed to check for optional tools", exc_info=True)
+            # Optional-tool warnings (e.g. missing ripgrep) used to fire here
+            # but were too noisy. The grep tool falls back to a pure-Python
+            # search transparently; users who want the prompt can still call
+            # ``check_optional_tools()`` directly.
             # Non-interactive mode - execute single task and exit
             from bog_agents_cli.non_interactive import run_non_interactive
 

--- a/libs/cli/bog_agents_cli/main.py
+++ b/libs/cli/bog_agents_cli/main.py
@@ -1337,6 +1337,20 @@ def cli_main() -> None:
     if "--acp" not in sys.argv[1:] and "--serve" not in sys.argv[1:]:
         check_cli_dependencies()
 
+    # Translate the user's ``[timeouts]`` settings into env vars before any
+    # SDK code reads them. Existing env values win, so a shell override
+    # (``BOG_AGENTS_MODEL_READ_TIMEOUT=300 bog ...``) still takes precedence
+    # over what's in settings.json.
+    try:
+        from bog_agents_cli.timeouts import apply_to_env as _apply_timeout_env
+
+        project_root = Path.cwd() if (Path.cwd() / ".bog-agents").is_dir() else None
+        _apply_timeout_env(project_root=project_root)
+    except Exception:
+        # Misconfigured timeouts must never block startup. Log and continue
+        # with whatever defaults the SDK and remote_client provide.
+        logger.warning("timeouts: failed to apply settings cascade", exc_info=True)
+
     from bog_agents_cli.config import console, settings
 
     try:

--- a/libs/cli/bog_agents_cli/remote_client.py
+++ b/libs/cli/bog_agents_cli/remote_client.py
@@ -21,19 +21,34 @@ from bog_agents_cli._debug import configure_debug_logging
 logger = logging.getLogger(__name__)
 configure_debug_logging(logger)
 
-# Default read timeout for the langgraph SDK's underlying httpx client.
-# The SDK default is 300s, which is too tight for /review-style turns that
-# can fan out to many tool calls and span 5-20 minutes of model work.
-# Aligned with ``BOG_AGENTS_MODEL_READ_TIMEOUT`` default (3600s) so the SSE
-# deadline never fires before the underlying model call has had its full
-# budget. Override with ``BOG_AGENTS_REMOTE_READ_TIMEOUT`` (seconds, or
-# ``none``/``0`` to disable).
-_DEFAULT_READ_TIMEOUT_SECS: float = 3600.0
+# Default per-chunk read timeout for the langgraph SDK's underlying httpx
+# client. NB: httpx ``read`` is per-chunk, not total — a healthy SSE stream
+# that emits keepalives or token-streaming events stays alive indefinitely
+# under this deadline; only a *stall* longer than ``read`` fails. We pick
+# 2h so even a long-running tool call (build, test suite, slow MCP fetch)
+# that happens server-side between events doesn't trip the deadline.
+# Aligned with ``BOG_AGENTS_MODEL_READ_TIMEOUT`` so the SSE side never fires
+# before the underlying model call has had its full budget. Override with
+# ``BOG_AGENTS_REMOTE_READ_TIMEOUT`` (seconds, or ``none``/``0`` to disable).
+_DEFAULT_READ_TIMEOUT_SECS: float = 7200.0
 
 # Number of times to re-issue an astream() call when the SSE stream raises a
-# transient error *before any events have flowed*. Once events have been
-# emitted, retrying is unsafe (the server has already mutated state).
-_PRE_FIRST_EVENT_RETRIES: int = 2
+# transient error *before any events have flowed*. The server has not yet
+# committed any state, so retrying is fully safe.
+_PRE_FIRST_EVENT_RETRIES: int = 3
+
+# Number of times to re-issue an astream() call AFTER events have started
+# flowing but the stream then died from a transient network/provider error.
+# This is the resilience layer: the langgraph server persists thread state
+# checkpoint-by-checkpoint, so re-calling astream resumes from the last
+# committed checkpoint. The UI may briefly see duplicated events for the
+# in-flight checkpoint; the adapter dedupes by message ID.
+_MID_STREAM_RETRIES: int = 2
+
+# Initial backoff seconds for retry; doubles each attempt, capped at
+# ``_MAX_RETRY_BACKOFF_SECS``.
+_INITIAL_RETRY_BACKOFF_SECS: float = 1.0
+_MAX_RETRY_BACKOFF_SECS: float = 16.0
 
 # Substrings that indicate a transient (network/provider) failure worth
 # retrying when raised before the first event. Matched case-insensitively
@@ -138,11 +153,14 @@ class RemoteAgent:
                 the environment.
             headers: Extra HTTP headers to include in every request
                 (e.g. bearer tokens, proxy headers).
-            read_timeout: SSE read timeout in seconds. When `None`, the
-                value from `BOG_AGENTS_REMOTE_READ_TIMEOUT` is used,
-                falling back to `_DEFAULT_READ_TIMEOUT_SECS` (1800s) when
-                that env var is unset. Set the env var to `none`/`0` to
-                disable the read deadline entirely.
+            read_timeout: Per-chunk SSE read timeout in seconds. When `None`,
+                the value from `BOG_AGENTS_REMOTE_READ_TIMEOUT` is used,
+                falling back to `_DEFAULT_READ_TIMEOUT_SECS` (7200s, i.e.
+                2 hours) when that env var is unset. Set the env var to
+                `none`/`0` to disable the deadline entirely.
+
+                NB: this is a per-chunk read deadline, not a total
+                stream deadline — healthy streams stay alive indefinitely.
         """
         self._url = url
         self._graph_name = graph_name
@@ -239,12 +257,11 @@ class RemoteAgent:
         dropped_count = 0
 
         modes = stream_mode or ["messages", "updates"]
-        first_event_seen = False
-        attempt = 0
-        max_attempts = 1 + _PRE_FIRST_EVENT_RETRIES
+        events_emitted = 0
+        pre_first_event_attempt = 0
+        mid_stream_attempt = 0
 
         while True:
-            attempt += 1
             try:
                 async for ns, mode, data in graph.astream(
                     input,
@@ -253,33 +270,55 @@ class RemoteAgent:
                     config=config,
                     context=context,
                 ):
-                    first_event_seen = True
                     async for converted in RemoteAgent._process_chunk(
                         ns, mode, data, BaseMessage
                     ):
                         if converted is _DROPPED:
                             dropped_count += 1
                         else:
+                            events_emitted += 1
                             yield converted
                 break
             except Exception as exc:
-                if (
-                    not first_event_seen
-                    and attempt < max_attempts
-                    and _is_transient_stream_error(exc)
-                ):
-                    backoff = min(2 ** (attempt - 1), 8)
-                    logger.warning(
-                        "Transient %s before first stream event "
-                        "(attempt %d/%d); retrying in %.1fs",
-                        type(exc).__name__,
-                        attempt,
-                        max_attempts,
-                        backoff,
-                    )
-                    await asyncio.sleep(backoff)
-                    continue
-                raise
+                if not _is_transient_stream_error(exc):
+                    raise
+
+                # Two retry budgets: pre-first-event (fully safe — server
+                # has not committed any state yet) and mid-stream
+                # (resilience — server checkpoint replay may emit a few
+                # duplicate events but the UI dedupes by message ID).
+                if events_emitted == 0:
+                    pre_first_event_attempt += 1
+                    if pre_first_event_attempt > _PRE_FIRST_EVENT_RETRIES:
+                        raise
+                    attempt_no = pre_first_event_attempt
+                    max_attempts = _PRE_FIRST_EVENT_RETRIES
+                    phase = "pre-first-event"
+                else:
+                    mid_stream_attempt += 1
+                    if mid_stream_attempt > _MID_STREAM_RETRIES:
+                        raise
+                    attempt_no = mid_stream_attempt
+                    max_attempts = _MID_STREAM_RETRIES
+                    phase = "mid-stream"
+
+                backoff = min(
+                    _INITIAL_RETRY_BACKOFF_SECS * (2 ** (attempt_no - 1)),
+                    _MAX_RETRY_BACKOFF_SECS,
+                )
+                logger.warning(
+                    "Transient %s during %s phase (attempt %d/%d, %d events "
+                    "emitted); retrying in %.1fs — server will resume from "
+                    "checkpoint",
+                    type(exc).__name__,
+                    phase,
+                    attempt_no,
+                    max_attempts,
+                    events_emitted,
+                    backoff,
+                )
+                await asyncio.sleep(backoff)
+                continue
 
         if dropped_count:
             logger.warning(

--- a/libs/cli/bog_agents_cli/remote_client.py
+++ b/libs/cli/bog_agents_cli/remote_client.py
@@ -24,8 +24,11 @@ configure_debug_logging(logger)
 # Default read timeout for the langgraph SDK's underlying httpx client.
 # The SDK default is 300s, which is too tight for /review-style turns that
 # can fan out to many tool calls and span 5-20 minutes of model work.
-# Override with BOG_AGENTS_REMOTE_READ_TIMEOUT (seconds, or "none" to disable).
-_DEFAULT_READ_TIMEOUT_SECS: float = 1800.0
+# Aligned with ``BOG_AGENTS_MODEL_READ_TIMEOUT`` default (3600s) so the SSE
+# deadline never fires before the underlying model call has had its full
+# budget. Override with ``BOG_AGENTS_REMOTE_READ_TIMEOUT`` (seconds, or
+# ``none``/``0`` to disable).
+_DEFAULT_READ_TIMEOUT_SECS: float = 3600.0
 
 # Number of times to re-issue an astream() call when the SSE stream raises a
 # transient error *before any events have flowed*. Once events have been

--- a/libs/cli/bog_agents_cli/timeouts.py
+++ b/libs/cli/bog_agents_cli/timeouts.py
@@ -1,0 +1,218 @@
+"""User-facing timeout settings for long-running model calls and tool execution.
+
+Three pieces of work fight against premature ReadTimeoutError on long turns:
+
+- The **model** layer (``BOG_AGENTS_MODEL_READ_TIMEOUT``) controls how long
+  the LLM HTTP client will wait for the provider to respond.
+- The **remote** layer (``BOG_AGENTS_REMOTE_READ_TIMEOUT``) controls how
+  long the CLI's ``RemoteGraph`` SSE stream will wait between chunks before
+  it gives up. NB: this is a per-chunk read deadline — a healthy stream
+  with regular keepalives stays alive forever under it.
+- The **tool** layer (``LocalShellBackend(timeout=...)``) controls how
+  long a single shell command can run before being killed.
+
+This module centralises the configuration surface so users have one
+place — ``~/.bog-agents/settings.json`` ``[timeouts]`` — to tune all of
+them. We translate settings into the env vars the SDK already consumes
+so the SDK does not need to know about the CLI's settings cascade.
+
+Cascade precedence (highest first):
+
+1. The env var itself, if it was already set in the user's shell.
+2. ``<project>/.bog-agents/settings.json`` ``timeouts`` section.
+3. ``~/.bog-agents/settings.json`` ``timeouts`` section.
+4. Built-in defaults (2 hours for model + remote, 2 hours for tools).
+
+A value of ``"none"``, ``"off"``, or ``0`` disables that timeout entirely.
+
+Example ``settings.json``::
+
+    {"timeouts": {"model_read_seconds": 7200, "remote_read_seconds": 7200, "tool_seconds": "none"}}
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any
+
+from bog_agents_cli._settings_cascade import load_layered_section
+
+logger = logging.getLogger(__name__)
+
+
+# Defaults match the SDK's ``_DEFAULT_MODEL_READ_TIMEOUT_SECS`` and the CLI's
+# ``_DEFAULT_READ_TIMEOUT_SECS`` so this module is purely additive — applying
+# it to a fresh install changes no behaviour.
+_DEFAULT_MODEL_READ_SECS = 7200
+_DEFAULT_REMOTE_READ_SECS = 7200
+_DEFAULT_TOOL_SECS = 7200
+
+_MODEL_ENV = "BOG_AGENTS_MODEL_READ_TIMEOUT"
+_REMOTE_ENV = "BOG_AGENTS_REMOTE_READ_TIMEOUT"
+_TOOL_ENV = "BOG_AGENTS_TOOL_TIMEOUT"
+
+_DISABLED_TOKENS = {"none", "off", "0", ""}
+
+
+@dataclass(frozen=True)
+class TimeoutSettings:
+    """Resolved timeout configuration in seconds.
+
+    A value of ``None`` means "no timeout" (caller should pass through to
+    httpx / subprocess as ``None`` / unlimited). A positive integer is the
+    deadline in seconds.
+    """
+
+    model_read_seconds: int | None = _DEFAULT_MODEL_READ_SECS
+    remote_read_seconds: int | None = _DEFAULT_REMOTE_READ_SECS
+    tool_seconds: int | None = _DEFAULT_TOOL_SECS
+
+    def merge_dict(self, override: dict[str, Any]) -> TimeoutSettings:
+        """Merge a settings.json ``timeouts`` block into this config.
+
+        Unknown keys are ignored with a debug log so future schema additions
+        don't crash older CLIs. Bad values fall back to the existing setting
+        with a warning so a typo in settings.json never turns into a
+        runtime error mid-turn.
+        """
+        kwargs: dict[str, Any] = {}
+        for key in ("model_read_seconds", "remote_read_seconds", "tool_seconds"):
+            if key not in override:
+                continue
+            value = _coerce_value(key, override[key])
+            # Skip the sentinel: malformed entries leave the existing
+            # value untouched rather than overwriting it with garbage.
+            if value is _SENTINEL_KEEP:
+                continue
+            kwargs[key] = value
+        unknown = set(override) - {
+            "model_read_seconds",
+            "remote_read_seconds",
+            "tool_seconds",
+        }
+        if unknown:
+            logger.debug("timeouts: ignoring unknown setting keys %s", sorted(unknown))
+        return replace(self, **kwargs) if kwargs else self
+
+
+def _coerce_value(key: str, raw: Any) -> int | None:  # noqa: ANN401  # JSON values are typed as Any
+    """Coerce a JSON value to a non-negative int, or ``None`` for disabled."""
+    if isinstance(raw, str) and raw.strip().lower() in _DISABLED_TOKENS:
+        return None
+    if isinstance(raw, bool):
+        # ``bool`` is an ``int`` subclass — reject it explicitly so
+        # ``"tool_seconds": false`` is treated as a typo, not as 0.
+        logger.warning(
+            "timeouts: %s=%r is a bool — expected int seconds or 'none'; ignoring",
+            key,
+            raw,
+        )
+        return _SENTINEL_KEEP
+    if isinstance(raw, (int, float)):
+        value = int(raw)
+        if value <= 0:
+            return None
+        return value
+    if isinstance(raw, str):
+        try:
+            value = int(raw.strip())
+        except ValueError:
+            logger.warning("timeouts: %s=%r is not a valid int; ignoring", key, raw)
+            return _SENTINEL_KEEP
+        return None if value <= 0 else value
+    logger.warning(
+        "timeouts: %s=%r has unsupported type %s; ignoring",
+        key,
+        raw,
+        type(raw).__name__,
+    )
+    return _SENTINEL_KEEP
+
+
+# Sentinel returned from ``_coerce_value`` when the override is malformed.
+# Callers detect it and skip the assignment so the existing value survives.
+_SENTINEL_KEEP: Any = object()
+
+
+def load_timeout_settings(*, project_root: Path | None = None) -> TimeoutSettings:
+    """Resolve the cascade-merged timeout configuration."""
+
+    def _merge(current: TimeoutSettings, override: dict[str, Any]) -> TimeoutSettings:
+        # Drop sentinels before passing through so malformed entries don't
+        # clobber the prior layer's good value.
+        cleaned = {
+            k: v
+            for k, v in current.merge_dict(override).__dict__.items()
+            if v is not _SENTINEL_KEEP
+        }
+        return TimeoutSettings(**cleaned)
+
+    return load_layered_section(
+        section="timeouts",
+        initial=TimeoutSettings(),
+        merge=_merge,
+        project_root=project_root,
+    )
+
+
+def apply_to_env(
+    settings: TimeoutSettings | None = None,
+    *,
+    project_root: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> None:
+    """Translate resolved timeout settings into env vars the SDK consumes.
+
+    Existing env values win — this respects the user's explicit shell
+    overrides. Only env vars that are *currently unset* get populated from
+    the cascade. ``"none"`` becomes the literal env string ``"none"`` so
+    the SDK's parser disables the deadline.
+
+    Args:
+        settings: Pre-resolved settings. When ``None`` the cascade is read.
+        project_root: Optional project dir for the cascade walk.
+        env: Override target environment (defaults to ``os.environ``).
+            Tests pass an empty dict to verify behaviour without touching
+            the real process env.
+    """
+    target = env if env is not None else os.environ
+    if settings is None:
+        settings = load_timeout_settings(project_root=project_root)
+
+    for key, env_name in (
+        ("model_read_seconds", _MODEL_ENV),
+        ("remote_read_seconds", _REMOTE_ENV),
+        ("tool_seconds", _TOOL_ENV),
+    ):
+        if env_name in target:
+            continue
+        value = getattr(settings, key)
+        target[env_name] = "none" if value is None else str(value)
+
+
+def resolve_tool_timeout() -> int | None:
+    """Return the effective tool-execution timeout in seconds, or ``None``.
+
+    Callers (e.g. ``LocalShellBackend`` setup at CLI launch) use this to
+    pick the runtime ``timeout`` for new shell-backed sandboxes. Mirrors
+    the env-var logic in ``_models.py`` so the contract is identical.
+    """
+    raw = os.environ.get(_TOOL_ENV)
+    if raw is None:
+        return _DEFAULT_TOOL_SECS
+    if raw.strip().lower() in _DISABLED_TOKENS:
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid %s=%r, falling back to default %ds",
+            _TOOL_ENV,
+            raw,
+            _DEFAULT_TOOL_SECS,
+        )
+        return _DEFAULT_TOOL_SECS
+    return None if value <= 0 else value

--- a/libs/cli/bog_agents_cli/widgets/chat_input.py
+++ b/libs/cli/bog_agents_cli/widgets/chat_input.py
@@ -104,7 +104,11 @@ if TYPE_CHECKING:
     from textual.events import Click
     from textual.timer import Timer
 
-    from bog_agents_cli.input import MediaTracker, ParsedPastedPathPayload
+    from bog_agents_cli.input import (
+        MediaTracker,
+        ParsedPastedPathPayload,
+        PastedTextTracker,
+    )
 
 
 class CompletionOption(Static):
@@ -378,6 +382,10 @@ class ChatTextArea(TextArea):
         self._paste_burst_timer: Timer | None = None
         # See _BACKSLASH_ENTER_GAP_SECONDS for context.
         self._backslash_pending_time: float | None = None
+        # Large pastes get folded into a ``[Pasted #N: 450 lines]`` placeholder
+        # so they don't drown the input box. Full content is expanded back in
+        # at submit time. Lazy-imported to avoid pulling input.py at startup.
+        self._pasted_text_tracker: PastedTextTracker | None = None
 
     def set_app_focus(self, *, has_focus: bool) -> None:
         """Set whether the app should show the cursor as active.
@@ -730,6 +738,78 @@ class ChatTextArea(TextArea):
                     return start, end
         return None
 
+    def _ensure_paste_tracker(self) -> PastedTextTracker:
+        """Lazily build the pasted-text tracker."""
+        if self._pasted_text_tracker is None:
+            from bog_agents_cli.input import PastedTextTracker
+
+            self._pasted_text_tracker = PastedTextTracker()
+        return self._pasted_text_tracker
+
+    def _maybe_fold_large_paste(self, text: str) -> bool:
+        """Insert a placeholder instead of ``text`` when it's large.
+
+        Returns:
+            ``True`` if the paste was folded (and inserted as a placeholder),
+            ``False`` if it was small enough to insert verbatim.
+        """
+        from bog_agents_cli.input import PastedTextTracker
+
+        if not PastedTextTracker.should_fold(text):
+            return False
+        tracker = self._ensure_paste_tracker()
+        placeholder = tracker.add(text)
+        self.insert(placeholder)
+        return True
+
+    def expand_pasted_blocks(self, text: str) -> str:
+        """Expand ``[Pasted #N]`` tokens in ``text`` to their full content."""
+        if self._pasted_text_tracker is None:
+            return text
+        return self._pasted_text_tracker.expand(text)
+
+    def sync_pasted_blocks_to_text(self) -> None:
+        """Prune stored pastes whose placeholder no longer appears in input."""
+        if self._pasted_text_tracker is None:
+            return
+        self._pasted_text_tracker.sync_to_text(self.text)
+
+    def on_mouse_down(self, event: events.MouseDown) -> None:
+        """Treat right-click on the input as a paste-from-clipboard.
+
+        Textual captures terminal mouse events when the app is running, which
+        defeats the terminal emulator's native right-click-pastes-clipboard
+        behaviour. We restore that affordance manually: when the user
+        right-clicks inside the chat input, read the system clipboard and
+        run the paste through the same path bracketed-paste would take
+        (sanitization + large-paste folding).
+
+        Button numbers: 1 = left, 2 = middle, 3 = right. We also check for
+        attribute presence so we don't crash on terminals that emit only
+        partial mouse events.
+        """
+        button = getattr(event, "button", None)
+        if button != 3:
+            return
+        try:
+            from bog_agents_cli.clipboard import read_clipboard_text
+        except ImportError:
+            return
+        try:
+            text = read_clipboard_text()
+        except Exception:
+            logger.debug("right-click paste: clipboard read failed", exc_info=True)
+            return
+        if not text:
+            return
+        event.prevent_default()
+        event.stop()
+        sanitized = _strip_terminal_escapes(text)
+        if not sanitized:
+            return
+        if not self._maybe_fold_large_paste(sanitized):
+            self.insert(sanitized)
+
     async def _on_paste(self, event: events.Paste) -> None:
         r"""Handle paste events and detect dragged file paths.
 
@@ -739,6 +819,11 @@ class ChatTextArea(TextArea):
         capture during streaming. Without this filter the user sees raw
         SGR strings appear in the input box if they move the mouse over
         the terminal while the agent is working.
+
+        Large pastes (>=5 lines or >=800 chars that are NOT file-drop
+        payloads) are folded into a ``[Pasted #N: K lines]`` placeholder so
+        the input box stays readable. Full content is restored at submit time
+        via ``expand_pasted_blocks``.
         """
         self._backslash_pending_time = None
         if self._paste_burst_buffer:
@@ -751,7 +836,7 @@ class ChatTextArea(TextArea):
             # sanitized text ourselves.
             event.prevent_default()
             event.stop()
-            if sanitized:
+            if sanitized and not self._maybe_fold_large_paste(sanitized):
                 self.insert(sanitized)
             return
 
@@ -762,6 +847,9 @@ class ChatTextArea(TextArea):
             # Don't call super() here — Textual's MRO dispatch already calls
             # TextArea._on_paste after this handler returns. Calling super()
             # would insert the text a second time, duplicating the paste.
+            if self._maybe_fold_large_paste(event.text):
+                event.prevent_default()
+                event.stop()
             return
 
         event.prevent_default()
@@ -774,6 +862,8 @@ class ChatTextArea(TextArea):
         self._paste_burst_last_char_time = None
         self._cancel_paste_burst_timer()
         self._backslash_pending_time = None
+        if self._pasted_text_tracker is not None:
+            self._pasted_text_tracker.clear()
         self._navigating_history = True
         self.text = text
         # Move cursor to end
@@ -790,6 +880,8 @@ class ChatTextArea(TextArea):
         self._paste_burst_last_char_time = None
         self._cancel_paste_burst_timer()
         self._backslash_pending_time = None
+        if self._pasted_text_tracker is not None:
+            self._pasted_text_tracker.clear()
         self.text = ""
         self.move_cursor((0, 0))
 
@@ -995,6 +1087,8 @@ class ChatInput(Vertical):
         """Detect input mode and update completions."""
         text = event.text_area.text
         self._sync_media_tracker_to_text(text)
+        if self._text_area is not None:
+            self._text_area.sync_pasted_blocks_to_text()
 
         # History handlers explicitly decide mode and stripped display text.
         # Skip mode detection here so recalled entries don't inherit stale mode.
@@ -1231,6 +1325,11 @@ class ChatInput(Vertical):
 
         if self._completion_manager:
             self._completion_manager.reset()
+
+        # Expand any [Pasted #N] placeholders back to their full content
+        # before the value flows out to the agent / history.
+        if self._text_area is not None:
+            value = self._text_area.expand_pasted_blocks(value)
 
         value = self._replace_submitted_paths_with_images(value)
 

--- a/libs/cli/tests/unit_tests/test_pasted_text_tracker.py
+++ b/libs/cli/tests/unit_tests/test_pasted_text_tracker.py
@@ -1,0 +1,95 @@
+"""Unit tests for `PastedTextTracker` and large-paste folding."""
+
+from __future__ import annotations
+
+from bog_agents_cli.input import (
+    PASTED_TEXT_CHAR_THRESHOLD,
+    PASTED_TEXT_LINE_THRESHOLD,
+    PastedTextTracker,
+)
+
+
+class TestShouldFold:
+    """Threshold rules for folding large pastes into a placeholder."""
+
+    def test_short_single_line_not_folded(self) -> None:
+        assert not PastedTextTracker.should_fold("hello world")
+
+    def test_few_lines_not_folded(self) -> None:
+        text = "\n".join("line" for _ in range(PASTED_TEXT_LINE_THRESHOLD - 1))
+        assert not PastedTextTracker.should_fold(text)
+
+    def test_many_lines_folded(self) -> None:
+        text = "\n".join("line" for _ in range(PASTED_TEXT_LINE_THRESHOLD + 1))
+        assert PastedTextTracker.should_fold(text)
+
+    def test_long_single_line_folded(self) -> None:
+        text = "x" * (PASTED_TEXT_CHAR_THRESHOLD + 1)
+        assert PastedTextTracker.should_fold(text)
+
+
+class TestAddAndExpand:
+    """Round-trip storage + placeholder expansion."""
+
+    def test_placeholder_format_includes_id_and_lines(self) -> None:
+        tracker = PastedTextTracker()
+        text = "a\nb\nc\nd\ne\nf"  # 6 lines
+        placeholder = tracker.add(text)
+        assert placeholder == "[Pasted #1: 6 lines]"
+
+    def test_singular_for_one_line(self) -> None:
+        tracker = PastedTextTracker()
+        placeholder = tracker.add("just one line")
+        assert placeholder == "[Pasted #1: 1 line]"
+
+    def test_ids_increment(self) -> None:
+        tracker = PastedTextTracker()
+        first = tracker.add("a")
+        second = tracker.add("b")
+        assert first == "[Pasted #1: 1 line]"
+        assert second == "[Pasted #2: 1 line]"
+
+    def test_expand_restores_full_text(self) -> None:
+        tracker = PastedTextTracker()
+        original = "line1\nline2\nline3"
+        placeholder = tracker.add(original)
+        rendered = f"prefix {placeholder} suffix"
+        assert tracker.expand(rendered) == f"prefix {original} suffix"
+
+    def test_expand_unknown_id_kept_intact(self) -> None:
+        tracker = PastedTextTracker()
+        # Tracker is empty; placeholder doesn't match anything
+        rendered = "[Pasted #99: 12 lines]"
+        assert tracker.expand(rendered) == rendered
+
+    def test_expand_empty_tracker_is_noop(self) -> None:
+        tracker = PastedTextTracker()
+        assert tracker.expand("hello") == "hello"
+
+
+class TestSyncToText:
+    """Pruning storage when the user deletes the placeholder."""
+
+    def test_sync_drops_blocks_no_longer_referenced(self) -> None:
+        tracker = PastedTextTracker()
+        tracker.add("first")
+        tracker.add("second")
+        # User deleted both placeholders; text mentions neither
+        tracker.sync_to_text("just plain typing")
+        assert len(tracker) == 0
+
+    def test_sync_keeps_referenced_block(self) -> None:
+        tracker = PastedTextTracker()
+        kept = tracker.add("first")
+        tracker.add("second")
+        tracker.sync_to_text(f"hello {kept} world")
+        assert len(tracker) == 1
+        # Surviving placeholder still expands
+        assert tracker.expand(kept) == "first"
+
+    def test_clear_resets_id_counter(self) -> None:
+        tracker = PastedTextTracker()
+        tracker.add("data")
+        tracker.clear()
+        next_placeholder = tracker.add("new")
+        assert next_placeholder == "[Pasted #1: 1 line]"

--- a/libs/cli/tests/unit_tests/test_remote_client.py
+++ b/libs/cli/tests/unit_tests/test_remote_client.py
@@ -603,7 +603,7 @@ class TestRemoteAgentInit:
             mock_cls.assert_called_once()
 
     def test_extended_read_timeout_applied_to_clients(self) -> None:
-        """Default 1800s read timeout is configured on the underlying httpx clients.
+        """Default 3600s read timeout is configured on the underlying httpx clients.
 
         The langgraph_sdk default is 300s; we extend it so /review-style turns
         don't get killed mid-stream by the default deadline.
@@ -619,7 +619,7 @@ class TestRemoteAgentInit:
                 _, kwargs = mock.call_args
                 timeout = kwargs.get("timeout")
                 assert timeout is not None
-                assert timeout.read == 1800.0
+                assert timeout.read == 3600.0
 
     def test_read_timeout_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """BOG_AGENTS_REMOTE_READ_TIMEOUT overrides the default."""

--- a/libs/cli/tests/unit_tests/test_remote_client.py
+++ b/libs/cli/tests/unit_tests/test_remote_client.py
@@ -603,7 +603,7 @@ class TestRemoteAgentInit:
             mock_cls.assert_called_once()
 
     def test_extended_read_timeout_applied_to_clients(self) -> None:
-        """Default 3600s read timeout is configured on the underlying httpx clients.
+        """Default 7200s read timeout is configured on the underlying httpx clients.
 
         The langgraph_sdk default is 300s; we extend it so /review-style turns
         don't get killed mid-stream by the default deadline.
@@ -619,7 +619,7 @@ class TestRemoteAgentInit:
                 _, kwargs = mock.call_args
                 timeout = kwargs.get("timeout")
                 assert timeout is not None
-                assert timeout.read == 3600.0
+                assert timeout.read == 7200.0
 
     def test_read_timeout_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """BOG_AGENTS_REMOTE_READ_TIMEOUT overrides the default."""
@@ -655,11 +655,11 @@ class TestRemoteAgentWithConfig:
 
 
 class TestRemoteAgentTransientRetry:
-    """Pre-first-event retry on ReadTimeoutError / transient SSE errors.
+    """Retry semantics for transient SSE errors.
 
-    Once events have flowed, retrying is unsafe; the stream must propagate.
-    Before first event, we re-issue the call up to `_PRE_FIRST_EVENT_RETRIES`
-    times since the server hasn't begun mutating thread state.
+    Two retry budgets: pre-first-event (fully safe — server hasn't
+    committed any state yet) and mid-stream (resilience — server checkpoint
+    replay may emit a few duplicate events but the UI dedupes by message ID).
     """
 
     @pytest.mark.asyncio
@@ -688,12 +688,54 @@ class TestRemoteAgentTransientRetry:
         assert events == [((), "updates", {"ok": True})]
 
     @pytest.mark.asyncio
-    async def test_does_not_retry_after_first_event_emitted(self) -> None:
+    async def test_mid_stream_transient_error_triggers_retry(self) -> None:
+        """Stream that dies *after* events flowed should still retry.
+
+        The langgraph server persists state checkpoint-by-checkpoint, so
+        re-calling astream resumes from the last committed checkpoint. The
+        UI dedupes by message ID so duplicate events from the resumed
+        stream are harmless.
+        """
         from bog_agents_cli import remote_client as rc
 
+        attempts: list[int] = []
+
         async def _gen(*_a: Any, **_kw: Any):  # async generator
-            yield ((), "updates", {"started": True})
-            msg = "ReadTimeoutError partway through"
+            attempts.append(1)
+            if len(attempts) == 1:
+                yield ((), "updates", {"first": True})
+                msg = "ReadTimeoutError partway through"
+                raise TimeoutError(msg)
+            yield ((), "updates", {"resumed": True})
+
+        config = {"configurable": {"thread_id": _TEST_THREAD_ID}}
+        agent = RemoteAgent(url="http://localhost:8123", graph_name="agent")
+        mock_graph = MagicMock()
+        mock_graph.astream = _gen
+        agent._graph = mock_graph
+
+        with patch.object(rc.asyncio, "sleep", AsyncMock()):
+            events = [chunk async for chunk in agent.astream({}, config=config)]
+
+        # First (failed) stream + retry stream were both consumed.
+        assert len(attempts) == 2
+        # Both events surface to the caller; UI handles dedup.
+        assert events == [
+            ((), "updates", {"first": True}),
+            ((), "updates", {"resumed": True}),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_mid_stream_retry_budget_exhausted_propagates(self) -> None:
+        """When mid-stream retries run out, the last error propagates."""
+        from bog_agents_cli import remote_client as rc
+
+        attempts: list[int] = []
+
+        async def _gen(*_a: Any, **_kw: Any):  # async generator
+            attempts.append(1)
+            yield ((), "updates", {"n": len(attempts)})
+            msg = "ReadTimeoutError keeps blowing up"
             raise TimeoutError(msg)
 
         config = {"configurable": {"thread_id": _TEST_THREAD_ID}}
@@ -708,6 +750,9 @@ class TestRemoteAgentTransientRetry:
         ):
             async for _ in agent.astream({}, config=config):
                 pass
+
+        # Initial attempt + _MID_STREAM_RETRIES retries.
+        assert len(attempts) == 1 + rc._MID_STREAM_RETRIES
 
     @pytest.mark.asyncio
     async def test_non_transient_error_propagates_immediately(self) -> None:

--- a/libs/cli/tests/unit_tests/test_timeouts.py
+++ b/libs/cli/tests/unit_tests/test_timeouts.py
@@ -1,0 +1,162 @@
+"""Tests for the unified timeouts settings cascade and env application."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from bog_agents_cli.timeouts import (
+    TimeoutSettings,
+    apply_to_env,
+    load_timeout_settings,
+    resolve_tool_timeout,
+)
+
+if TYPE_CHECKING:
+    import pytest
+
+
+class TestTimeoutSettingsMerge:
+    """Direct merge_dict semantics on a single layer."""
+
+    def test_defaults_match_two_hour_baseline(self) -> None:
+        settings = TimeoutSettings()
+        assert settings.model_read_seconds == 7200
+        assert settings.remote_read_seconds == 7200
+        assert settings.tool_seconds == 7200
+
+    def test_int_override_replaces_default(self) -> None:
+        settings = TimeoutSettings().merge_dict({"model_read_seconds": 600})
+        assert settings.model_read_seconds == 600
+        # other fields unchanged
+        assert settings.remote_read_seconds == 7200
+
+    def test_zero_disables_timeout(self) -> None:
+        settings = TimeoutSettings().merge_dict({"tool_seconds": 0})
+        assert settings.tool_seconds is None
+
+    def test_none_string_disables(self) -> None:
+        settings = TimeoutSettings().merge_dict({"remote_read_seconds": "none"})
+        assert settings.remote_read_seconds is None
+
+    def test_off_string_disables(self) -> None:
+        settings = TimeoutSettings().merge_dict({"tool_seconds": "off"})
+        assert settings.tool_seconds is None
+
+    def test_string_int_coerced(self) -> None:
+        settings = TimeoutSettings().merge_dict({"model_read_seconds": "3600"})
+        assert settings.model_read_seconds == 3600
+
+    def test_unknown_key_ignored(self) -> None:
+        settings = TimeoutSettings().merge_dict(
+            {"model_read_seconds": 600, "future_key": 999}
+        )
+        assert settings.model_read_seconds == 600
+
+    def test_bool_value_keeps_default(self) -> None:
+        # ``"tool_seconds": false`` should not be silently treated as 0.
+        settings = TimeoutSettings().merge_dict({"tool_seconds": False})
+        assert settings.tool_seconds == 7200
+
+    def test_garbage_string_keeps_default(self) -> None:
+        settings = TimeoutSettings().merge_dict({"model_read_seconds": "abc"})
+        assert settings.model_read_seconds == 7200
+
+
+class TestLoadCascade:
+    """Cascade walking with user + project layers."""
+
+    def test_no_files_returns_defaults(self, tmp_path: Path) -> None:
+        # tmp_path acts as the user home; no settings.json present.
+        settings = load_timeout_settings(project_root=tmp_path)
+        assert settings == TimeoutSettings()
+
+    def test_user_file_applied(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home = tmp_path / "home"
+        (home / ".bog-agents").mkdir(parents=True)
+        (home / ".bog-agents" / "settings.json").write_text(
+            json.dumps({"timeouts": {"model_read_seconds": 1234}})
+        )
+        monkeypatch.setattr(Path, "home", lambda: home)
+        settings = load_timeout_settings()
+        assert settings.model_read_seconds == 1234
+        # Defaults preserved for unset fields.
+        assert settings.remote_read_seconds == 7200
+
+    def test_project_overrides_user(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home = tmp_path / "home"
+        project = tmp_path / "proj"
+        (home / ".bog-agents").mkdir(parents=True)
+        (project / ".bog-agents").mkdir(parents=True)
+        (home / ".bog-agents" / "settings.json").write_text(
+            json.dumps({"timeouts": {"model_read_seconds": 1000, "tool_seconds": 500}})
+        )
+        (project / ".bog-agents" / "settings.json").write_text(
+            json.dumps({"timeouts": {"model_read_seconds": 2000}})
+        )
+        monkeypatch.setattr(Path, "home", lambda: home)
+        settings = load_timeout_settings(project_root=project)
+        # Project overrides the user value.
+        assert settings.model_read_seconds == 2000
+        # User-only setting survives.
+        assert settings.tool_seconds == 500
+
+
+class TestApplyToEnv:
+    """Translation from settings to env vars the SDK consumes."""
+
+    def test_existing_env_wins(self) -> None:
+        env: dict[str, str] = {"BOG_AGENTS_MODEL_READ_TIMEOUT": "60"}
+        settings = TimeoutSettings(model_read_seconds=7200)
+        apply_to_env(settings, env=env)
+        # User's shell override is preserved.
+        assert env["BOG_AGENTS_MODEL_READ_TIMEOUT"] == "60"
+
+    def test_unset_env_populated_from_settings(self) -> None:
+        env: dict[str, str] = {}
+        settings = TimeoutSettings(
+            model_read_seconds=600,
+            remote_read_seconds=1200,
+            tool_seconds=1800,
+        )
+        apply_to_env(settings, env=env)
+        assert env["BOG_AGENTS_MODEL_READ_TIMEOUT"] == "600"
+        assert env["BOG_AGENTS_REMOTE_READ_TIMEOUT"] == "1200"
+        assert env["BOG_AGENTS_TOOL_TIMEOUT"] == "1800"
+
+    def test_disabled_value_renders_as_none(self) -> None:
+        env: dict[str, str] = {}
+        settings = TimeoutSettings(tool_seconds=None)
+        apply_to_env(settings, env=env)
+        assert env["BOG_AGENTS_TOOL_TIMEOUT"] == "none"
+
+
+class TestResolveToolTimeout:
+    """The runtime helper that the CLI calls when constructing sandboxes."""
+
+    def test_default_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BOG_AGENTS_TOOL_TIMEOUT", raising=False)
+        assert resolve_tool_timeout() == 7200
+
+    def test_env_value_used(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BOG_AGENTS_TOOL_TIMEOUT", "300")
+        assert resolve_tool_timeout() == 300
+
+    def test_env_none_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BOG_AGENTS_TOOL_TIMEOUT", "none")
+        assert resolve_tool_timeout() is None
+
+    def test_env_zero_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BOG_AGENTS_TOOL_TIMEOUT", "0")
+        assert resolve_tool_timeout() is None
+
+    def test_garbage_falls_back_to_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("BOG_AGENTS_TOOL_TIMEOUT", "abc")
+        assert resolve_tool_timeout() == 7200

--- a/libs/cli/tests/unit_tests/test_ui.py
+++ b/libs/cli/tests/unit_tests/test_ui.py
@@ -107,18 +107,23 @@ class TestFormatToolDisplayExecute:
         assert result == f'{prefix} execute("echo hello")'
 
     def test_execute_with_default_timeout_hidden(self) -> None:
-        """Test execute display excludes timeout when it equals the default (120s)."""
+        """Test execute display excludes timeout when it equals the default (7200s)."""
+        from bog_agents.backends import DEFAULT_EXECUTE_TIMEOUT
+
         prefix = get_glyphs().tool_prefix
         result = format_tool_display(
-            "execute", {"command": "echo hello", "timeout": 120}
+            "execute", {"command": "echo hello", "timeout": DEFAULT_EXECUTE_TIMEOUT}
         )
         assert result == f'{prefix} execute("echo hello")'
 
     def test_execute_with_default_timeout_string_hidden(self) -> None:
         """Test execute display excludes timeout when default arrives as a string."""
+        from bog_agents.backends import DEFAULT_EXECUTE_TIMEOUT
+
         prefix = get_glyphs().tool_prefix
         result = format_tool_display(
-            "execute", {"command": "echo hello", "timeout": "120"}
+            "execute",
+            {"command": "echo hello", "timeout": str(DEFAULT_EXECUTE_TIMEOUT)},
         )
         assert result == f'{prefix} execute("echo hello")'
 


### PR DESCRIPTION
Three independent post-0.8.1 bug-bash fixes from user reports, all on a single
short-lived branch.

### 1. ReadTimeoutError on long turns — root-caused and fully resilient

The user reported that long thinking phases, long tool calls (builds, test
suites, MCP fan-outs), and even mid-stream provider blips were killing turns
without the existing retry logic ever firing. Three independent gaps:

- **Default ceilings were too tight.** Model read timeout was 1h; tool
  execution defaulted to **2 minutes** (!). Bumped everything to **2h**:
  - `bog_agents._models._DEFAULT_MODEL_READ_TIMEOUT_SECS`: 3600 → 7200
  - `LocalShellBackend.DEFAULT_EXECUTE_TIMEOUT`: 120 → 7200
  - `FilesystemMiddleware.max_execute_timeout`: 3600 → 7200
  - `remote_client._DEFAULT_READ_TIMEOUT_SECS`: 3600 → 7200

  The remote `read` deadline is per-chunk, not total — a healthy SSE stream
  stays alive indefinitely. Only a >2h *stall* now trips it. `bog_agents`
  also already routed default-model construction through `resolve_model()`
  so the env-var override actually applies (the previous fix in this branch).

- **Retry only ran *before* the first event.** Once any event had flowed,
  a transient `ReadTimeoutError` bubbled straight to the user. Extended
  `remote_client.astream` with a mid-stream retry budget (2 attempts,
  1-16s exponential backoff). The LangGraph server persists state
  checkpoint-by-checkpoint, so re-issuing `astream` resumes from the last
  committed checkpoint; the UI dedupes any replayed events by message ID.
  Pre-first-event retries also bumped 2 → 3 since that path is fully safe.

- **No unified knob.** Users could set three separate env vars but had no
  config-file surface. New `libs/cli/bog_agents_cli/timeouts.py` reads a
  `[timeouts]` section from the standard cascade
  (`~/.bog-agents/settings.json` → project `settings.json`) and translates
  it into the env vars the SDK already consumes. Precedence: shell env >
  project config > user config > 2h defaults. `"none"`, `"off"`, or `0`
  disables that layer entirely (useful for multi-hour batch jobs).

  ```json
  {
    "timeouts": {
      "model_read_seconds": 7200,
      "remote_read_seconds": "none",
      "tool_seconds": 1800
    }
  }

2. Paste UX

- Right-click paste now works inside the chat input. Textual captures
terminal mouse events, defeating the emulator's native right-click-pastes
behavior; added ChatTextArea.on_mouse_down to detect button=3 and
paste through the same sanitize + fold path bracketed-paste uses.
- Large-paste placeholder. Pasting a 500-line log used to fill the
input box visually. Added PastedTextTracker (mirrors the existing
MediaTracker pattern), folds pastes ≥5 lines or ≥800 chars into a
[Pasted #N: K lines] token, and expands them back to full content at
submit time. Tokens are pruned automatically if the user deletes them.

3. Suppress missing-ripgrep warning

Too noisy on every TUI start (the grep tool already falls back to a
pure-Python search transparently). Removed the call sites in app.py and
main.py; helpers + tests stay for direct invocation.
