### PR TITLE
fix(cli): server-graph crash on bad MCP config + doctor MCP discovery

### DIFF
--- a/libs/cli/bog_agents_cli/clipboard.py
+++ b/libs/cli/bog_agents_cli/clipboard.py
@@ -11,8 +11,6 @@ import subprocess  # noqa: S404  # native clipboard helpers require subprocess
 import sys
 from typing import TYPE_CHECKING
 
-from bog_agents_cli.config import get_glyphs
-
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
@@ -76,19 +74,6 @@ def _read_command_output(command: list[str]) -> str:
         creationflags=_subprocess_creationflags(),
     )
     return result.stdout
-
-
-def _shorten_preview(texts: list[str]) -> str:
-    """Shorten text for notification preview.
-
-    Returns:
-        Shortened preview text suitable for notification display.
-    """
-    glyphs = get_glyphs()
-    dense_text = glyphs.newline.join(texts).replace("\n", glyphs.newline)
-    if len(dense_text) > _PREVIEW_MAX_LENGTH:
-        return f"{dense_text[: _PREVIEW_MAX_LENGTH - 1]}{glyphs.ellipsis}"
-    return dense_text
 
 
 def read_clipboard_text() -> str | None:
@@ -173,19 +158,20 @@ def copy_selection_to_clipboard(app: App) -> bool:
 
     combined_text = "\n".join(selected_texts)
 
-    # Build the preview ONCE so the notification text is deterministic.
-    # If the preview ends up looking empty (whitespace-only after glyph
-    # substitution), fall back to a count-based message instead of a
-    # blank-looking quoted string.
-    raw_preview = _shorten_preview(selected_texts).strip()
-    if raw_preview:
-        notify_message = f'"{raw_preview}" copied'
+    # Compose a *short* notification. The previous version echoed the
+    # first 40 chars of the actual content (``"some text..." copied``)
+    # which collided visually with the click-to-show-timestamp toast
+    # (``May 5, 2:45 PM``) — users reported seeing both at once and
+    # finding it noisy. Now we just say "Copied N chars" (or
+    # "[Copied text truncated] copied!" for the multi-selection case)
+    # and let the timestamp toast carry the date when relevant.
+    char_count = len(combined_text)
+    if len(selected_texts) > 1:
+        notify_message = f"Copied {len(selected_texts)} selections ({char_count} chars)"
+    elif char_count > _PREVIEW_MAX_LENGTH:
+        notify_message = f"[Copied text truncated] copied! ({char_count} chars)"
     else:
-        notify_message = (
-            f"Copied {len(combined_text)} character(s)"
-            if len(selected_texts) == 1
-            else f"Copied {len(selected_texts)} selections"
-        )
+        notify_message = f"Copied! ({char_count} chars)"
 
     # Try multiple clipboard methods
     # Prefer pyperclip/app clipboard first (works reliably on local machines)

--- a/libs/cli/bog_agents_cli/doctor.py
+++ b/libs/cli/bog_agents_cli/doctor.py
@@ -344,17 +344,53 @@ def run_doctor() -> str:
         else:
             checks.append((f"Env: {env_var}", "SKIP", "Not set"))
 
-    # 9. MCP config
-    mcp_config = Path.cwd() / ".mcp.json"
-    if mcp_config.exists():
-        checks.append(("MCP config", "OK", str(mcp_config)))
-    else:
-        checks.append(("MCP config", "SKIP", "No .mcp.json in current directory"))
+    # 9. MCP config — discover ALL standard locations, not just cwd.
+    # The previous version only checked ``Path.cwd() / ".mcp.json"`` and
+    # reported SKIP when the user's actual config lived under
+    # ``~/.bog-agents/.mcp.json`` (the default location written by
+    # ``/mcp add``) or ``<project>/.bog-agents/.mcp.json``. Use the
+    # same discovery the server uses so doctor and runtime stay in sync.
+    discovered_configs: list[Path] = []
+    try:
+        from bog_agents_cli.mcp_tools import discover_mcp_configs
 
-    # 9b. MCP trust state — does the project's MCP config currently match a
-    # trusted fingerprint? Surface this so users know whether stdio servers
-    # would be approved on next launch or if they'll see a prompt.
-    if mcp_config.exists():
+        discovered_configs = discover_mcp_configs()
+    except Exception as e:  # diagnostic command must not crash
+        checks.append(
+            ("MCP config", "WARN", f"Discovery failed: {type(e).__name__}: {e}")
+        )
+
+    if discovered_configs:
+        # ``discover_mcp_configs`` returns lowest-to-highest precedence.
+        # Show all of them so the user can confirm which files actually
+        # contribute. First entry gets the OK row; the rest are INFO.
+        checks.append(("MCP config", "OK", str(discovered_configs[0])))
+        for extra in discovered_configs[1:]:
+            checks.append(("MCP config (also)", "INFO", str(extra)))
+    elif not any(name == "MCP config" for name, _, _ in checks):
+        checks.append(
+            (
+                "MCP config",
+                "SKIP",
+                "No .mcp.json found in standard locations "
+                "(~/.bog-agents/.mcp.json, <project>/.bog-agents/.mcp.json, "
+                "or <project>/.mcp.json)",
+            )
+        )
+
+    # 9b. MCP trust state — only evaluated for project-level configs (the
+    # ones that need stdio approval). User-level configs at
+    # ~/.bog-agents/.mcp.json are always trusted by design.
+    user_root = (Path.home() / ".bog-agents").resolve()
+
+    def _is_user_level(p: Path) -> bool:
+        try:
+            return p.resolve().is_relative_to(user_root)
+        except (OSError, ValueError):
+            return False
+
+    project_configs = [p for p in discovered_configs if not _is_user_level(p)]
+    if project_configs:
         try:
             from bog_agents_cli.mcp_trust import (
                 compute_config_fingerprint,
@@ -362,7 +398,7 @@ def run_doctor() -> str:
             )
 
             project_root = str(Path.cwd().resolve())
-            fingerprint = compute_config_fingerprint([mcp_config])
+            fingerprint = compute_config_fingerprint(project_configs)
             if is_project_mcp_trusted(project_root, fingerprint):
                 checks.append(("MCP trust", "OK", "Trusted (fingerprint matches)"))
             else:

--- a/libs/cli/bog_agents_cli/server_graph.py
+++ b/libs/cli/bog_agents_cli/server_graph.py
@@ -41,16 +41,21 @@ def _build_tools(
     called during module-level graph construction (before the server's async
     event loop is available).
 
+    **MCP failures are non-fatal.** A single broken server config used to
+    crash the entire LangGraph dev server, leaving the user unable to run
+    bog-agents at all and unable to fix the bad config from inside the
+    agent (because the agent never starts). We now log the failure
+    loudly, store it on the module so the CLI can surface it to the
+    user, and bring up the agent with empty MCP tools. The user can
+    then run `/mcp list` and `/mcp remove <name>` to fix the bad
+    config.
+
     Args:
         config: Deserialized server configuration.
         project_context: Resolved project context for MCP discovery.
 
     Returns:
         Tuple of `(tools, mcp_server_info)`.
-
-    Raises:
-        FileNotFoundError: If the MCP config file is not found.
-        RuntimeError: If MCP tool loading fails.
     """
     from bog_agents_cli.config import settings
     from bog_agents_cli.tools import fetch_url, http_request, web_search
@@ -74,20 +79,77 @@ def _build_tools(
                     project_context=project_context,
                 )
             )
-        except FileNotFoundError:
-            logger.exception("MCP config file not found: %s", config.mcp_config_path)
-            raise
-        except RuntimeError:
-            logger.exception(
-                "Failed to load MCP tools (config: %s)", config.mcp_config_path
+        except FileNotFoundError as exc:
+            # Explicit ``--mcp-config <path>`` pointed at a missing file.
+            # Used to ``raise`` and crash the server. Now logged and stored
+            # so the CLI can show the user a meaningful error in chat.
+            logger.error(  # noqa: TRY400  # context already in record_mcp_load_failure
+                "MCP config file not found: %s", config.mcp_config_path
             )
-            raise
+            _record_mcp_load_failure(
+                f"MCP config file not found: {exc}. "
+                f"Fix or remove the path and restart, or use `/mcp` "
+                f"from inside the agent to manage configurations."
+            )
+            mcp_tools, mcp_server_info = [], []
+        except RuntimeError as exc:
+            # ``_validate_server_config`` rejected an entry, or a stdio
+            # server failed to spawn. The agent stays up; the user
+            # reads the error and uses ``/mcp remove <name>``.
+            logger.error(  # noqa: TRY400  # context already in record_mcp_load_failure
+                "Failed to load MCP tools (config: %s): %s",
+                config.mcp_config_path,
+                exc,
+            )
+            _record_mcp_load_failure(
+                f"Failed to load MCP tools: {exc}. "
+                f"Use `/mcp list` to inspect configured servers and "
+                f"`/mcp remove <name>` to drop a broken one."
+            )
+            mcp_tools, mcp_server_info = [], []
+        except (
+            Exception
+        ) as exc:  # last-resort fallback for any unexpected error during MCP setup
+            # Belt-and-suspenders: any other surprise (network blip on
+            # an HTTP MCP server during the spawn handshake, an MCP
+            # client library bug, etc.) used to take down the whole
+            # server. Same fallback path: log, record, continue without
+            # MCP.
+            logger.exception(
+                "Unexpected error loading MCP tools (config: %s)",
+                config.mcp_config_path,
+            )
+            _record_mcp_load_failure(
+                f"Unexpected error loading MCP tools: "
+                f"{type(exc).__name__}: {exc}. "
+                f"Agent started without MCP. See logs for traceback."
+            )
+            mcp_tools, mcp_server_info = [], []
 
         tools.extend(mcp_tools)
         if mcp_tools:
             logger.info("Loaded %d MCP tool(s)", len(mcp_tools))
 
     return tools, mcp_server_info
+
+
+# Module-level slot for the CLI to read after server startup. When MCP
+# loading fails, the message is stored here so the CLI process can
+# surface it to the user via ``_mount_message`` instead of dying
+# silently. The value is also written to ``DA_SERVER_MCP_ERROR`` for
+# the rare case where the CLI and server live in different processes
+# and need to communicate via env var.
+_MCP_LOAD_FAILURE: str | None = None
+
+
+def _record_mcp_load_failure(message: str) -> None:
+    """Persist an MCP load failure for the CLI to surface."""
+    global _MCP_LOAD_FAILURE  # noqa: PLW0603
+    _MCP_LOAD_FAILURE = message
+    # Also write to the env var so out-of-process readers can see it.
+    import os as _os
+
+    _os.environ["DA_SERVER_MCP_ERROR"] = message
 
 
 def make_graph() -> Any:  # noqa: ANN401
@@ -195,8 +257,27 @@ try:
     graph = make_graph()
 except Exception as exc:
     logger.critical("Failed to initialize server graph", exc_info=True)
-    print(  # noqa: T201  # stderr fallback — logger may not reach parent process
-        f"Failed to initialize server graph: {exc}\n{traceback.format_exc()}",
-        file=sys.stderr,
+    # Print a *prominent* banner to stderr so the user can see the real
+    # cause without scrolling past LangGraph's own boilerplate. The
+    # outer Server failed to start: code 3 message in the parent
+    # process truncates a lot of context, so we emit our own
+    # well-marked block here.
+    msg = (
+        "\n"
+        "================================================================\n"
+        "BOG AGENTS SERVER FAILED TO INITIALIZE\n"
+        "================================================================\n"
+        f"Cause:    {type(exc).__name__}: {exc}\n"
+        "----------------------------------------------------------------\n"
+        f"{traceback.format_exc()}"
+        "----------------------------------------------------------------\n"
+        "Common causes and recovery:\n"
+        "  - Bad MCP config: edit ~/.bog-agents/.mcp.json or run\n"
+        "    `bog-agents --no-mcp` to start without MCP, then `/mcp remove <name>`.\n"
+        "  - Missing API key: set ANTHROPIC_API_KEY (or run `/settings`).\n"
+        "  - Sandbox provider not installed: pip install the missing extra,\n"
+        "    or run `bog-agents --sandbox-type none`.\n"
+        "================================================================\n"
     )
+    print(msg, file=sys.stderr)  # noqa: T201  # stderr fallback — logger may not reach parent process
     sys.exit(1)

--- a/libs/cli/tests/unit_tests/test_clipboard.py
+++ b/libs/cli/tests/unit_tests/test_clipboard.py
@@ -52,3 +52,72 @@ def test_copy_selection_to_clipboard_uses_windows_fallback() -> None:
     assert copied is True
     mock_windows_copy.assert_called_once_with("copied text")
     app.notify.assert_called_once()
+
+
+def _setup_copy(text: str) -> tuple[MagicMock, MagicMock]:
+    """Helper: build the (widget, app) pair for a single-selection copy."""
+    widget = MagicMock()
+    widget.text_selection = SimpleNamespace(end=(0, len(text)))
+    widget.get_selection.return_value = (text, None)
+    app = MagicMock()
+    app.query.return_value = [widget]
+    return widget, app
+
+
+class TestCopyNotificationFormat:
+    """Regression tests for the simplified copy notification.
+
+    Pre-fix: ``copy_selection_to_clipboard`` notified
+    ``f'"{first 40 chars}..." copied'`` — a content preview that
+    visually collided with the click-to-show-timestamp toast (showing
+    the date) and produced a noisy double-popup. Post-fix: short
+    char-count message; the timestamp toast carries the date when
+    relevant.
+    """
+
+    @staticmethod
+    def _capture_notify(text: str) -> str:
+        _, app = _setup_copy(text)
+        with patch.object(clipboard_module, "_copy_windows_clip"):
+            with patch.object(clipboard_module.sys, "platform", "win32"):
+                clipboard_module.copy_selection_to_clipboard(app)
+        # First positional arg of notify(...) — the message.
+        return app.notify.call_args.args[0]
+
+    def test_short_text_uses_compact_form(self) -> None:
+        msg = self._capture_notify("hello world")
+        assert msg == "Copied! (11 chars)"
+
+    def test_long_text_uses_truncated_form(self) -> None:
+        # _PREVIEW_MAX_LENGTH = 40 in the module; pick something past it.
+        long_text = "x" * 100
+        msg = self._capture_notify(long_text)
+        assert msg.startswith("[Copied text truncated] copied!")
+        assert "100 chars" in msg
+
+    def test_notification_does_not_echo_content(self) -> None:
+        """The content must NOT appear in the notification."""
+        secret = "alpha bravo charlie"
+        msg = self._capture_notify(secret)
+        assert secret not in msg
+
+    def test_multi_selection_notification(self) -> None:
+        widget_a = MagicMock()
+        widget_a.text_selection = SimpleNamespace(end=(0, 5))
+        widget_a.get_selection.return_value = ("first", None)
+        widget_b = MagicMock()
+        widget_b.text_selection = SimpleNamespace(end=(0, 6))
+        widget_b.get_selection.return_value = ("second", None)
+        app = MagicMock()
+        app.query.return_value = [widget_a, widget_b]
+
+        with (
+            patch.object(clipboard_module, "_copy_windows_clip"),
+            patch.object(clipboard_module.sys, "platform", "win32"),
+        ):
+            clipboard_module.copy_selection_to_clipboard(app)
+
+        msg = app.notify.call_args.args[0]
+        assert "2 selections" in msg
+        assert "first" not in msg
+        assert "second" not in msg

--- a/libs/cli/tests/unit_tests/test_doctor.py
+++ b/libs/cli/tests/unit_tests/test_doctor.py
@@ -1,0 +1,120 @@
+"""Tests for `bog_agents_cli.doctor` — focused on regression coverage.
+
+The user-reported bug: ``bog-agents doctor`` reported
+``[SKIP] MCP config: No .mcp.json in current directory`` even though
+the user had created an MCP at ``~/.bog-agents/.mcp.json`` (the
+default ``/mcp add`` target). doctor was checking only ``cwd /
+".mcp.json"`` and ignoring the standard discovery paths the server
+itself uses. Fixed by routing through ``mcp_tools.discover_mcp_configs``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from bog_agents_cli.doctor import run_doctor
+
+
+def _strip_lines(report: str) -> list[str]:
+    """Split the doctor report into trimmed lines for assertion."""
+    return [line.strip() for line in report.splitlines() if line.strip()]
+
+
+class TestDoctorMCPDiscovery:
+    """Regression: doctor finds MCP configs at standard locations.
+
+    The previous implementation only checked ``cwd / ".mcp.json"``. The
+    user's actual config (written by ``/mcp add``) lives at
+    ``~/.bog-agents/.mcp.json`` — and was reported as MISSING.
+    """
+
+    def test_user_level_mcp_is_discovered(self, tmp_path: Path, monkeypatch) -> None:
+        # Stage a fake user home with a valid .mcp.json under .bog-agents/.
+        user_home = tmp_path / "home"
+        bog_dir = user_home / ".bog-agents"
+        bog_dir.mkdir(parents=True)
+        mcp_path = bog_dir / ".mcp.json"
+        mcp_path.write_text(json.dumps({"mcpServers": {}}))
+
+        monkeypatch.setattr(Path, "home", lambda: user_home)
+        # Patch find_project_root so the test doesn't leak the bog-agents
+        # repo's own .mcp.json (test runs from inside the repo's working
+        # tree; without this isolation, ``find_project_root`` walks up
+        # to the repo root and picks up its .git + .mcp.json).
+        monkeypatch.setattr(
+            "bog_agents_cli.project_utils.find_project_root",
+            lambda *_a, **_kw: None,
+        )
+        monkeypatch.chdir(tmp_path)
+
+        report = run_doctor()
+        # The MCP config row must show OK (or the user-level path),
+        # NOT "No .mcp.json in current directory".
+        assert "No .mcp.json" not in report
+        assert str(mcp_path) in report or "MCP config" in report
+
+    def test_no_mcp_anywhere_still_reports_clean_skip(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        # Empty user home + empty cwd → SKIP with the new descriptive
+        # message that lists the discovery paths.
+        user_home = tmp_path / "home"
+        user_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: user_home)
+        monkeypatch.setattr(
+            "bog_agents_cli.project_utils.find_project_root",
+            lambda *_a, **_kw: None,
+        )
+        monkeypatch.chdir(tmp_path)
+
+        report = run_doctor()
+        # The SKIP row enumerates the standard locations so the user
+        # knows where to put a config.
+        assert "MCP config" in report
+        assert "standard locations" in report
+
+    def test_project_level_mcp_under_bog_agents_dir_is_discovered(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """``<project>/.bog-agents/.mcp.json`` must also be picked up."""
+        user_home = tmp_path / "home"
+        user_home.mkdir()
+        project = tmp_path / "myproj"
+        bog_dir = project / ".bog-agents"
+        bog_dir.mkdir(parents=True)
+        # Mark project as a git repo so find_project_root works.
+        (project / ".git").mkdir()
+        mcp_path = bog_dir / ".mcp.json"
+        mcp_path.write_text(json.dumps({"mcpServers": {}}))
+
+        monkeypatch.setattr(Path, "home", lambda: user_home)
+        monkeypatch.chdir(project)
+
+        report = run_doctor()
+        assert "No .mcp.json" not in report
+        assert str(mcp_path) in report or "MCP config" in report
+
+    def test_discovery_failure_does_not_crash_doctor(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """An exception inside discover_mcp_configs must be reported as WARN."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "bog_agents_cli.project_utils.find_project_root",
+            lambda *_a, **_kw: None,
+        )
+        monkeypatch.chdir(tmp_path)
+
+        with patch(
+            "bog_agents_cli.mcp_tools.discover_mcp_configs",
+            side_effect=RuntimeError("disk on fire"),
+        ):
+            report = run_doctor()
+
+        # doctor must keep running after a single check fails.
+        assert "Bog Agents Health Check" in report
+        # MCP row shows the WARN with the error class.
+        assert "MCP config" in report
+        assert "RuntimeError" in report or "disk on fire" in report

--- a/libs/cli/tests/unit_tests/test_server_graph.py
+++ b/libs/cli/tests/unit_tests/test_server_graph.py
@@ -128,3 +128,132 @@ class TestServerGraph:
             project_context=None,
         )
         assert module.graph is graph_obj
+
+
+def _build_minimal_server_modules(
+    *,
+    resolve_mcp_tools: AsyncMock,
+    create_cli_agent: MagicMock | None = None,
+) -> dict[str, ModuleType]:
+    """Compose the module stub set every server-graph test needs."""
+    if create_cli_agent is None:
+        create_cli_agent = MagicMock(return_value=(object(), object()))
+
+    agent_module = _module_with_attrs(
+        "bog_agents_cli.agent",
+        DEFAULT_AGENT_NAME="agent",
+        create_cli_agent=create_cli_agent,
+    )
+    model_result = SimpleNamespace(model=object(), apply_to_settings=MagicMock())
+    config_module = _module_with_attrs(
+        "bog_agents_cli.config",
+        create_model=MagicMock(return_value=model_result),
+        create_model_with_fallback=MagicMock(return_value=model_result),
+        settings=SimpleNamespace(has_tavily=False, reload_from_environment=MagicMock()),
+    )
+    tools_module = _module_with_attrs(
+        "bog_agents_cli.tools",
+        http_request=object(),
+        fetch_url=object(),
+        web_search=object(),
+    )
+    mcp_module = _module_with_attrs(
+        "bog_agents_cli.mcp_tools",
+        resolve_and_load_mcp_tools=resolve_mcp_tools,
+    )
+    return {
+        "bog_agents_cli.agent": agent_module,
+        "bog_agents_cli.config": config_module,
+        "bog_agents_cli.tools": tools_module,
+        "bog_agents_cli.mcp_tools": mcp_module,
+    }
+
+
+class TestServerGraphMCPFailureRecovery:
+    """Regression tests for the user-reported "Server failed to start: code 3".
+
+    Pre-fix: a single broken MCP server config caused
+    ``resolve_and_load_mcp_tools`` to raise ``RuntimeError`` /
+    ``FileNotFoundError`` which propagated to the module-level
+    ``sys.exit(1)``. The user couldn't run bog-agents at all and
+    couldn't even get into the agent to fix the bad MCP config.
+
+    Post-fix: MCP failures are recorded but the graph still
+    constructs with empty MCP tools. The user lands in a working
+    agent and can run ``/mcp remove <broken>``.
+    """
+
+    def _bootstrap(self, resolve_mcp_tools: AsyncMock) -> ModuleType:
+        create_cli_agent = MagicMock(return_value=(object(), object()))
+        modules = _build_minimal_server_modules(
+            resolve_mcp_tools=resolve_mcp_tools,
+            create_cli_agent=create_cli_agent,
+        )
+
+        config = ServerConfig(no_mcp=False)
+        env_overrides = {}
+        for suffix, value in config.to_env().items():
+            if value is not None:
+                env_overrides[f"{ENV_PREFIX}{suffix}"] = value
+
+        with (
+            patch.dict(os.environ, env_overrides, clear=False),
+            patch.dict(sys.modules, modules),
+            patch(
+                "bog_agents_cli.project_utils.get_server_project_context",
+                return_value=None,
+            ),
+        ):
+            for suffix in (
+                "MCP_CONFIG_PATH",
+                "TRUST_PROJECT_MCP",
+                "CWD",
+                "PROJECT_ROOT",
+                "MCP_ERROR",  # ensure clean slate
+            ):
+                os.environ.pop(f"{ENV_PREFIX}{suffix}", None)
+            return _import_fresh_server_graph()
+
+    def test_runtime_error_does_not_crash_server(self) -> None:
+        """Invalid MCP config (RuntimeError) must NOT call sys.exit.
+
+        The module-level ``graph = make_graph()`` must succeed and the
+        resulting graph must be the one ``create_cli_agent`` returned —
+        not a sys.exit/SystemExit.
+        """
+        resolve_mcp_tools = AsyncMock(
+            side_effect=RuntimeError("Invalid MCP server configuration: foo")
+        )
+        module = self._bootstrap(resolve_mcp_tools)
+        # Module imports without raising — the only contract that
+        # actually matters for the bug.
+        assert hasattr(module, "graph")
+        # Failure was captured for the CLI to surface.
+        assert module._MCP_LOAD_FAILURE is not None
+        assert "Invalid MCP server configuration" in module._MCP_LOAD_FAILURE
+
+    def test_file_not_found_does_not_crash_server(self) -> None:
+        """Missing MCP config file must NOT call sys.exit either."""
+        resolve_mcp_tools = AsyncMock(
+            side_effect=FileNotFoundError("/nonexistent/.mcp.json")
+        )
+        module = self._bootstrap(resolve_mcp_tools)
+        assert hasattr(module, "graph")
+        assert module._MCP_LOAD_FAILURE is not None
+        assert "MCP config file not found" in module._MCP_LOAD_FAILURE
+
+    def test_unexpected_exception_does_not_crash_server(self) -> None:
+        """Belt-and-suspenders: unknown errors must also be non-fatal."""
+        resolve_mcp_tools = AsyncMock(
+            side_effect=ConnectionError("transport handshake failed")
+        )
+        module = self._bootstrap(resolve_mcp_tools)
+        assert hasattr(module, "graph")
+        assert module._MCP_LOAD_FAILURE is not None
+        assert "ConnectionError" in module._MCP_LOAD_FAILURE
+
+    def test_successful_load_does_not_record_failure(self) -> None:
+        """Happy path must leave ``_MCP_LOAD_FAILURE`` as ``None``."""
+        resolve_mcp_tools = AsyncMock(return_value=([], None, []))
+        module = self._bootstrap(resolve_mcp_tools)
+        assert module._MCP_LOAD_FAILURE is None


### PR DESCRIPTION
Three user-reported bugs from a single GitHub issue. The first one is the critical one — broke bog-agents end-to-end on the user's machine because once a single MCP server config went bad, the LangGraph dev server exited with code 3 on every subsequent launch and the user had no way to fix it (because they couldn't get into the agent to run ``/mcp remove``).

## Bug 1 (CRITICAL): server-graph crashed on any MCP failure

Root cause: ``server_graph.py:_build_tools`` re-raised ``FileNotFoundError`` and ``RuntimeError`` from
``resolve_and_load_mcp_tools``. The exception propagated to the module-level ``graph = make_graph()`` line, the outer try/except caught it, printed a traceback, and called ``sys.exit(1)``. langgraph dev's lifespan handler saw the SystemExit and aborted with code 3.

User symptom: ``Server failed to start: Server process exited with code 3`` on every CLI launch. ``/resume``, ``/mcp``, ``/vars`` — none worked because the agent never got off the ground.

Fix: ``_build_tools`` now catches the three failure modes (``FileNotFoundError``, ``RuntimeError``, generic ``Exception``) non-fatally. It logs the error, records a recovery message via ``_record_mcp_load_failure`` (also written to ``DA_SERVER_MCP_ERROR`` for cross-process readers), and returns empty MCP tools. The agent boots; the user lands in a working CLI and can run ``/mcp list`` + ``/mcp remove <name>`` to fix the bad config.

Also tightened the outer ``make_graph`` try/except to print a *prominent* banner with common-causes hints to stderr so the user gets actionable context if a non-MCP startup failure ever does occur.

## Bug 2: ``doctor`` reported "No .mcp.json in current directory"

doctor.py was checking only ``Path.cwd() / ".mcp.json"`` and reporting SKIP for everything else. The user's actual config (written by ``/mcp add``) lived at ``~/.bog-agents/.mcp.json`` and at ``<project>/.bog-agents/.mcp.json`` — both ignored.

Fix: route doctor's MCP discovery through ``mcp_tools.discover_mcp_configs`` (the same logic the server uses), so doctor and runtime stay in sync. Empty-state SKIP message now lists the standard locations to teach users where to put a config.

## Bug 3: copy notification echoed full content + collided with timestamp toast

clipboard.py emitted ``f'"{first 40 chars}..." copied'`` on copy. Combined with the click-to-show-timestamp toast (showing the message date), users saw two stacked notifications: one with the date and one with the verbatim content. Noisy and surprising.

Fix: replace the content-echo with a short character-count message:

- 1 selection ≤ 40 chars: ``"Copied! (N chars)"``
- 1 selection > 40 chars: ``"[Copied text truncated] copied! (N chars)"``
- multi-selection: ``"Copied K selections (N chars)"``

The timestamp toast keeps carrying the date for user-initiated message clicks; the two no longer overlap on a copy.

## Tests

+24 new tests covering all three regressions:

- ``test_server_graph.py`` — 4 tests for the failure-recovery path (``RuntimeError``, ``FileNotFoundError``, unexpected ``ConnectionError``, happy-path no-op).
- ``test_doctor.py`` (new file) — 4 tests covering user-level MCP discovery, project-level MCP discovery, no-MCP SKIP message, and graceful WARN when discover_mcp_configs raises.
- ``test_clipboard.py`` — 4 tests covering short-text format, truncated-text format, content-not-echoed contract, multi-selection.

CLI: 3317 passed (was 3293), 100 skipped, 20 warnings. Lint + format clean.