### PR TITLE
feat(cli): refine model/provider system

### DIFF
--- a/libs/cli/bog_agents_cli/agent.py
+++ b/libs/cli/bog_agents_cli/agent.py
@@ -56,6 +56,68 @@ from bog_agents_cli.unicode_security import (
 
 logger = logging.getLogger(__name__)
 
+
+def _resolve_thinking_config() -> tuple[bool, int]:
+    """Determine the initial state of the extended-thinking middleware.
+
+    Resolution order (highest priority first):
+
+    1. ``BOG_AGENTS_THINKING`` env var (``1``/``true``/``yes`` = on,
+       anything else = off) — handy for one-off sessions without
+       editing config.toml.
+    2. ``[models.providers.<provider>].params.thinking_enabled`` in
+       ``~/.bog-agents/config.toml`` — per-provider opt-in.
+    3. Default ``False``.
+
+    The budget follows the same hierarchy via
+    ``BOG_AGENTS_THINKING_BUDGET`` / ``thinking_budget_tokens``, with
+    a default of 8 000 tokens.
+
+    Returns:
+        ``(enabled, budget_tokens)``.
+    """
+    env_enable = os.environ.get("BOG_AGENTS_THINKING", "").strip().lower()
+    env_budget_raw = os.environ.get("BOG_AGENTS_THINKING_BUDGET", "").strip()
+
+    enabled = env_enable in ("1", "true", "yes", "on")
+    budget = 8_000
+    if env_budget_raw:
+        try:
+            budget = max(1_000, int(env_budget_raw))
+        except ValueError:
+            logger.warning(
+                "Invalid BOG_AGENTS_THINKING_BUDGET=%r; ignoring", env_budget_raw
+            )
+
+    if env_enable:
+        # Env var wins — no need to consult config.toml.
+        return enabled, budget
+
+    # Fall back to config.toml. Read only the active provider's params
+    # to avoid leaking unrelated providers' settings into the session.
+    provider = (settings.model_provider or "").strip()
+    if not provider:
+        return enabled, budget
+    try:
+        from bog_agents_cli.model_config import ModelConfig
+
+        cfg = ModelConfig.load()
+    except (OSError, ValueError):
+        return enabled, budget
+    provider_cfg = cfg.providers.get(provider) or {}
+    params = provider_cfg.get("params") if isinstance(provider_cfg, dict) else {}
+    if not isinstance(params, dict):
+        return enabled, budget
+
+    cfg_enable = params.get("thinking_enabled")
+    if isinstance(cfg_enable, bool):
+        enabled = cfg_enable
+    cfg_budget = params.get("thinking_budget_tokens")
+    if isinstance(cfg_budget, int) and cfg_budget >= 1_000:
+        budget = cfg_budget
+    return enabled, budget
+
+
 DEFAULT_AGENT_NAME = "agent"
 """The default agent name used when no `-a` flag is provided."""
 
@@ -1066,6 +1128,28 @@ def create_cli_agent(
                 auto_test=auto_test,
             )
         )
+
+    # Extended-thinking middleware — defaults to disabled but always
+    # attached so `/think on` works mid-session without a restart. When
+    # the user sets ``thinking_enabled = true`` in the provider's
+    # ``params`` block (or exports ``BOG_AGENTS_THINKING=1``), it
+    # auto-enables for thinking-capable models. The middleware itself
+    # is a no-op for models that don't support native thinking — it
+    # simply forwards the request unchanged when ``enabled=False``.
+    try:
+        from bog_agents.middleware.thinking import ThinkingMiddleware
+
+        thinking_enabled_default, thinking_budget = _resolve_thinking_config()
+        agent_middleware.append(
+            ThinkingMiddleware(
+                enabled=thinking_enabled_default,
+                budget_tokens=thinking_budget,
+            )
+        )
+        if thinking_enabled_default:
+            logger.info("ThinkingMiddleware auto-enabled (budget=%d)", thinking_budget)
+    except ImportError:
+        logger.debug("ThinkingMiddleware not importable; skipping")
 
     # Worktree isolation middleware (Feature #1)
     if sandbox is None and enable_git_tools:

--- a/libs/cli/bog_agents_cli/app.py
+++ b/libs/cli/bog_agents_cli/app.py
@@ -3451,6 +3451,104 @@ class BogAgentsApp(App):
         report += "\nModel config caches cleared."
         await self._mount_message(AppMessage(report))
 
+    async def _handle_refresh_models_command(self, command: str) -> None:
+        """Re-scan installed providers and rebuild the model catalog cache.
+
+        Reads the live state of every installed langchain provider package
+        (and the local Ollama daemon, if running), persists the result to
+        ``~/.bog-agents/models.cache.json``, and reports the per-provider
+        counts. Picker views opened afterwards see the fresh list.
+        """
+        from bog_agents_cli.model_config import refresh_available_models
+
+        await self._mount_message(UserMessage(command))
+        await self._mount_message(AppMessage("Refreshing model catalog…"))
+        try:
+            catalog = await asyncio.to_thread(refresh_available_models)
+        except Exception as exc:
+            logger.exception("refresh-models failed")
+            await self._mount_message(
+                ErrorMessage(f"Failed to refresh model catalog: {exc}")
+            )
+            return
+
+        total = sum(len(models) for models in catalog.values())
+        lines = [
+            f"[bold]Catalog refreshed — {total} models across "
+            f"{len(catalog)} providers[/bold]\n"
+        ]
+        for provider in sorted(catalog):
+            lines.append(f"  • {provider}: {len(catalog[provider])}")
+        await self._mount_message(AppMessage("\n".join(lines)))
+
+    async def _handle_smoketest_command(self, command: str) -> None:
+        """Smoke-test a model+provider combo for connectivity and inference.
+
+        Usage:
+            /smoketest                       — test the active model
+            /smoketest provider:model        — test a specific spec
+            /smoketest --thinking            — test with extended thinking
+            /smoketest provider:model --thinking
+
+        Bedrock specs delegate to the existing ``probe_bedrock`` reporter.
+        Other providers create the model and send one short prompt with a
+        16-token budget and a 30s timeout. All known failure shapes
+        (auth, network, quota, model-not-found) yield an actionable hint.
+        """
+        from bog_agents_cli.smoketest import smoketest_model
+
+        await self._mount_message(UserMessage(command))
+        raw_arg = command.strip()[len("/smoketest") :].strip()
+
+        thinking = False
+        if "--thinking" in raw_arg:
+            thinking = True
+            raw_arg = raw_arg.replace("--thinking", "").strip()
+
+        spec = raw_arg
+        if not spec:
+            provider = getattr(settings, "model_provider", "") or ""
+            model_name = getattr(settings, "model_name", "") or ""
+            if provider and model_name:
+                spec = f"{provider}:{model_name}"
+            elif model_name:
+                spec = model_name
+        if not spec:
+            from bog_agents_cli.model_config import ModelConfig
+
+            config = ModelConfig.load()
+            spec = config.default_model or ""
+
+        if not spec:
+            await self._mount_message(
+                ErrorMessage(
+                    "No model specified and no active model — pass a "
+                    "provider:model spec (e.g. /smoketest anthropic:claude-haiku-4-5)"
+                )
+            )
+            return
+
+        thinking_note = " (with thinking)" if thinking else ""
+        await self._mount_message(
+            AppMessage(f"Smoke-testing [bold]{spec}[/bold]{thinking_note}…")
+        )
+
+        try:
+            result = await asyncio.to_thread(smoketest_model, spec, thinking=thinking)
+        except Exception as exc:
+            logger.exception("smoketest crashed")
+            await self._mount_message(
+                ErrorMessage(f"Smoketest crashed for {spec}: {exc}")
+            )
+            return
+
+        if result.ok:
+            await self._mount_message(
+                AppMessage(f"[green]{result.report_text()}[/green]")
+            )
+        else:
+            await self._mount_message(AppMessage(f"[red]{result.report_text()}[/red]"))
+
     async def _handle_repomap_command(self, command: str) -> None:
         """Show or refresh the semantic repository map."""
         from bog_agents_cli.repo_map_display import (
@@ -9704,12 +9802,26 @@ class BogAgentsApp(App):
         raw_arg = command.strip()[len("/think") :].strip().lower()
 
         if not raw_arg or raw_arg == "status":
+            from bog_agents_cli.provider_catalog import supports_native_thinking
+
             state = "enabled" if mw.is_enabled else "disabled"
+            active_model = getattr(settings, "model_name", "") or ""
+            native = supports_native_thinking(active_model) if active_model else False
+            support_line = f"Model {active_model!r}: " + (
+                "[green]native thinking supported[/green]"
+                if native
+                else "[yellow]native thinking not supported — "
+                "falls back to chain-of-thought prompt injection[/yellow]"
+            )
             await self._mount_message(
                 AppMessage(
                     f"Extended thinking: {state}\n"
-                    f"Budget tokens: {mw.budget_tokens:,}\n\n"
-                    "Usage: /think on | /think off | /think toggle | /think budget <N>"
+                    f"Budget tokens: {mw.budget_tokens:,}\n"
+                    f"{support_line}\n\n"
+                    "Usage: /think on | /think off | /think toggle | "
+                    "/think budget <N>\n"
+                    "Persist via [bold]thinking_enabled = true[/bold] under "
+                    "the provider's [params] in ~/.bog-agents/config.toml."
                 )
             )
             return

--- a/libs/cli/bog_agents_cli/commands/config.py
+++ b/libs/cli/bog_agents_cli/commands/config.py
@@ -181,6 +181,16 @@ COMMANDS: tuple[SlashCommand, ...] = (
     ),
     SlashCommand(
         spec=SlashCommandSpec(
+            "/refresh-models",
+            "Re-scan installed providers and rebuild the model catalog",
+            "models providers catalog refresh ollama bedrock anthropic openai",
+            "config",
+            available=True,
+        ),
+        handler_method="_handle_refresh_models_command",
+    ),
+    SlashCommand(
+        spec=SlashCommandSpec(
             "/reload",
             "Reload config from environment variables and `.env`",
             "refresh",
@@ -188,6 +198,20 @@ COMMANDS: tuple[SlashCommand, ...] = (
             available=True,
         ),
         handler_method="_handle_reload_command",
+    ),
+    SlashCommand(
+        spec=SlashCommandSpec(
+            "/smoketest",
+            "Test model+provider connectivity — credentials, network, tiny inference call",
+            "test ping verify smoke connection auth inference thinking bedrock",
+            "config",
+            available=True,
+            subcommands=(
+                ("[provider:model]", "Test a specific model spec (defaults to active)"),
+                ("--thinking", "Also exercise extended-thinking parameter support"),
+            ),
+        ),
+        handler_method="_handle_smoketest_command",
     ),
     SlashCommand(
         spec=SlashCommandSpec(

--- a/libs/cli/bog_agents_cli/config.py
+++ b/libs/cli/bog_agents_cli/config.py
@@ -1819,6 +1819,12 @@ def _get_provider_kwargs(
     """
     config = ModelConfig.load()
     result: dict[str, Any] = config.get_kwargs(provider, model_name=model_name)
+    # ``thinking_enabled`` / ``thinking_budget_tokens`` configure the
+    # ThinkingMiddleware, not the underlying chat model — strip them
+    # here so ``init_chat_model`` doesn't reject them as unknown kwargs.
+    # The middleware reads them directly from config.toml on its own.
+    for middleware_key in ("thinking_enabled", "thinking_budget_tokens"):
+        result.pop(middleware_key, None)
     base_url = config.get_base_url(provider)
     if base_url:
         result["base_url"] = base_url

--- a/libs/cli/bog_agents_cli/model_config.py
+++ b/libs/cli/bog_agents_cli/model_config.py
@@ -24,10 +24,13 @@ if TYPE_CHECKING:
 
 from bog_agents_cli._debug import configure_debug_logging
 from bog_agents_cli.provider_catalog import (
+    clear_cached_catalog,
     clear_provider_catalog_caches,
     get_local_ollama_models,
     get_profile_overrides as get_curated_profile_overrides,
     get_supplemental_model_profiles,
+    load_cached_catalog,
+    save_cached_catalog,
 )
 
 logger = logging.getLogger(__name__)
@@ -563,7 +566,48 @@ def get_available_models() -> dict[str, list[str]]:
                 existing.add(model_name)
 
     _available_models_cache = available
+    # Persist a snapshot to disk so the next cold start can paint the
+    # picker instantly while a background refresh runs. Best-effort —
+    # a failed save (read-only dir, etc.) is just a missed optimization.
+    try:
+        save_cached_catalog(available)
+    except Exception:
+        logger.debug("Failed to persist model catalog cache", exc_info=True)
     return available
+
+
+def refresh_available_models() -> dict[str, list[str]]:
+    """Force a re-scan of installed provider packages and live Ollama list.
+
+    Clears the in-memory cache plus any provider-catalog caches (so the
+    Ollama HTTP probe re-runs) and re-derives the model list. The fresh
+    list is also persisted to ``~/.bog-agents/models.cache.json`` for
+    the next cold start.
+
+    Returns:
+        The refreshed ``{provider: [model, ...]}`` catalog.
+    """
+    global _available_models_cache  # noqa: PLW0603
+    _available_models_cache = None
+    clear_provider_catalog_caches()
+    try:
+        clear_cached_catalog()
+    except Exception:
+        logger.debug("Failed to delete model catalog cache", exc_info=True)
+    return get_available_models()
+
+
+def get_cached_available_models() -> dict[str, list[str]] | None:
+    """Return the disk-cached catalog (if present) without a live scan.
+
+    Useful at cold-start: the CLI can paint the picker from the cached
+    snapshot in microseconds, then call ``refresh_available_models()``
+    in the background to update.
+    """
+    cached = load_cached_catalog()
+    if cached is None:
+        return None
+    return {provider: list(models) for provider, models in cached.items()}
 
 
 def _build_entry(

--- a/libs/cli/bog_agents_cli/provider_catalog.py
+++ b/libs/cli/bog_agents_cli/provider_catalog.py
@@ -3,16 +3,23 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
+import re
 import shutil
 import subprocess  # noqa: S404
+import time
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from functools import lru_cache
+from pathlib import Path
 from types import MappingProxyType
 from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
 from urllib.request import urlopen
+
+logger = logging.getLogger(__name__)
 
 OPENAI_DETECTION_EXACT: frozenset[str] = frozenset(
     {
@@ -108,21 +115,38 @@ DEFAULT_MODEL_CANDIDATES: Mapping[str, tuple[str, ...]] = MappingProxyType(
         ),
         # bedrock_converse is the modern wrapper; recommends the same IDs.
         "bedrock_converse": (
+            # Cross-region inference profile IDs (preferred — higher quota,
+            # on-demand throughput is being deprecated for newer Anthropic models).
             "us.anthropic.claude-opus-4-7",
-            "anthropic.claude-opus-4-7",
+            "eu.anthropic.claude-opus-4-7",
+            "apac.anthropic.claude-opus-4-7",
             "us.anthropic.claude-sonnet-4-6",
-            "anthropic.claude-sonnet-4-6",
+            "eu.anthropic.claude-sonnet-4-6",
+            "apac.anthropic.claude-sonnet-4-6",
             "us.anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
+            "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
+            "apac.anthropic.claude-haiku-4-5-20251001-v1:0",
             "us.anthropic.claude-opus-4-6-v1",
-            "anthropic.claude-opus-4-6-v1",
             "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            "us.anthropic.claude-opus-4-1-20250805-v1:0",
+            # Base IDs (work in single-region calls without an inference profile).
+            "anthropic.claude-opus-4-7",
+            "anthropic.claude-sonnet-4-6",
+            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0",
+            # Amazon Nova
             "us.amazon.nova-premier-v1:0",
             "us.amazon.nova-pro-v1:0",
             "us.amazon.nova-lite-v1:0",
+            "us.amazon.nova-micro-v1:0",
+            # Meta / Mistral / DeepSeek
             "us.meta.llama4-maverick-17b-instruct-v1:0",
+            "us.meta.llama4-scout-17b-instruct-v1:0",
+            "us.meta.llama3-3-70b-instruct-v1:0",
             "us.mistral.mistral-large-3-2411-v1:0",
+            "us.mistral.pixtral-large-2502-v1:0",
+            "us.deepseek.deepseek-r1-v1:0",
         ),
         "google_genai": (
             # Live IDs from ai.google.dev/gemini-api/docs/models
@@ -390,3 +414,395 @@ def get_supplemental_model_profiles(provider: str) -> Mapping[str, dict[str, Any
 def get_profile_overrides(provider: str) -> Mapping[str, dict[str, Any]]:
     """Return curated profile overrides for an installed provider profile set."""
     return PROFILE_OVERRIDES.get(provider, MappingProxyType({}))
+
+
+# ---------------------------------------------------------------------------
+# Display-name derivation
+# ---------------------------------------------------------------------------
+
+_PROVIDER_DISPLAY_NAMES: Mapping[str, str] = MappingProxyType(
+    {
+        "anthropic": "Anthropic",
+        "azure_openai": "Azure OpenAI",
+        "baseten": "Baseten",
+        "bedrock": "AWS Bedrock",
+        "bedrock_converse": "AWS Bedrock",
+        "cohere": "Cohere",
+        "deepseek": "DeepSeek",
+        "fireworks": "Fireworks",
+        "google_genai": "Google Gemini",
+        "google_vertexai": "Google Vertex AI",
+        "groq": "Groq",
+        "huggingface": "Hugging Face",
+        "ibm": "IBM watsonx",
+        "litellm": "LiteLLM",
+        "mistralai": "Mistral",
+        "nvidia": "NVIDIA NIM",
+        "ollama": "Ollama (local)",
+        "openai": "OpenAI",
+        "openrouter": "OpenRouter",
+        "perplexity": "Perplexity",
+        "together": "Together",
+        "xai": "xAI",
+    }
+)
+
+
+def get_provider_display_name(provider: str) -> str:
+    """Return a human-readable label for a provider id (e.g. 'AWS Bedrock').
+
+    Falls back to a title-cased version of the raw id when the provider
+    isn't in the curated mapping.
+    """
+    if provider in _PROVIDER_DISPLAY_NAMES:
+        return _PROVIDER_DISPLAY_NAMES[provider]
+    return provider.replace("_", " ").title()
+
+
+@dataclass(frozen=True)
+class ModelDisplay:
+    """Derived display metadata for a `provider:model` spec.
+
+    Attributes:
+        spec: The original `provider:model` string (preserved verbatim).
+        display_name: Human-readable label (e.g. 'Claude Sonnet 4.6').
+        provider_display: Provider label (e.g. 'AWS Bedrock').
+        family: Coarse family tag for grouping ('claude', 'gemini', 'gpt',
+            'nova', 'llama', 'mistral', 'ollama', or '' if unknown).
+        vendor: Origin vendor when distinct from the API provider — e.g.
+            Bedrock-hosted Anthropic models have vendor='anthropic',
+            provider='bedrock_converse'.
+        supports_thinking: True if the model is known to support native
+            extended-thinking / reasoning APIs.
+        is_inference_profile: True for Bedrock cross-region inference
+            profile IDs (`us.*`, `eu.*`, `apac.*`, ...).
+    """
+
+    spec: str
+    display_name: str
+    provider_display: str
+    family: str
+    vendor: str
+    supports_thinking: bool
+    is_inference_profile: bool
+
+
+_CLAUDE_NAME_RE = re.compile(
+    r"claude[-_.]?(opus|sonnet|haiku)[-_.]?(\d+)(?:[-_.](\d+))?",
+    re.IGNORECASE,
+)
+_GEMINI_NAME_RE = re.compile(r"gemini[-_.]?(\d+)(?:[-_.](\d+))?", re.IGNORECASE)
+_GPT_NAME_RE = re.compile(r"gpt[-_.]?(\d+)(?:[-_.](\d+))?", re.IGNORECASE)
+_NOVA_NAME_RE = re.compile(r"nova[-_.]?(\w+)", re.IGNORECASE)
+_LLAMA_NAME_RE = re.compile(r"llama[-_.]?(\d+)(?:[-_.](\d+))?", re.IGNORECASE)
+
+
+def _strip_bedrock_prefix(model_id: str) -> tuple[str, str, bool]:
+    """Split a Bedrock model id into (region_prefix, bare_id, is_profile).
+
+    Returns:
+        (region, bare, is_profile) — region is '' when not a cross-region
+        profile id, is_profile True when the id has a `us.` / `eu.` /
+        `apac.` / etc. prefix.
+    """
+    lower = model_id.lower()
+    for region in BEDROCK_REGION_PREFIXES:
+        if lower.startswith(region):
+            return (region.rstrip("."), model_id[len(region) :], True)
+    return ("", model_id, False)
+
+
+def _detect_family_and_vendor(model_name: str) -> tuple[str, str]:
+    """Return (family, vendor) for a bare model name.
+
+    Vendor is the upstream maker (anthropic/openai/google/meta/mistral/
+    amazon/deepseek). Family is a finer grouping suitable for the picker.
+    """
+    name = model_name.lower()
+    # Bedrock vendor prefixes encode the vendor explicitly.
+    for vendor_prefix in BEDROCK_VENDOR_PREFIXES:
+        if name.startswith(vendor_prefix):
+            vendor = vendor_prefix.rstrip(".")
+            # Sub-family hint from the remainder.
+            tail = name[len(vendor_prefix) :]
+            if "claude" in tail:
+                return ("claude", vendor)
+            if "nova" in tail:
+                return ("nova", vendor)
+            if "llama" in tail:
+                return ("llama", vendor)
+            if "mistral" in tail or "pixtral" in tail:
+                return ("mistral", vendor)
+            if "deepseek" in tail:
+                return ("deepseek", vendor)
+            return (vendor, vendor)
+    if "claude" in name:
+        return ("claude", "anthropic")
+    if name.startswith(("gemini", "models/gemini")):
+        return ("gemini", "google")
+    if name.startswith(("gpt-", "chatgpt", "codex-")):
+        return ("gpt", "openai")
+    if name.startswith(("o1", "o3", "o4")):
+        return ("o-series", "openai")
+    if "nova" in name:
+        return ("nova", "amazon")
+    if "llama" in name:
+        return ("llama", "meta")
+    if "mistral" in name or "pixtral" in name:
+        return ("mistral", "mistral")
+    if "deepseek" in name:
+        return ("deepseek", "deepseek")
+    if "qwen" in name:
+        return ("qwen", "alibaba")
+    if "nemotron" in name:
+        return ("nemotron", "nvidia")
+    return ("", "")
+
+
+def supports_native_thinking(model_name: str) -> bool:
+    """Return whether a bare model name supports native extended-thinking APIs.
+
+    Mirrors the detection in ``bog_agents.middleware.thinking`` so the CLI
+    can show a 'thinking-capable' marker without importing the SDK middleware.
+    """
+    name = model_name.lower()
+    if "claude-3-7" in name or "claude-3.7" in name:
+        return True
+    if "claude-sonnet-4" in name or "claude-opus-4" in name or "claude-haiku-4" in name:
+        return True
+    if "gemini-2.5" in name or "gemini-2-5" in name:
+        return True
+    if "gemini-3" in name:
+        return True
+    # OpenAI o-series reasoning models.
+    return name.startswith(("o1", "o3", "o4"))
+
+
+def _humanize_claude(bare: str) -> str:
+    """Render a Claude bare model id as 'Claude Sonnet 4.6'."""
+    m = _CLAUDE_NAME_RE.search(bare)
+    if not m:
+        return bare
+    variant = m.group(1).capitalize()
+    major = m.group(2)
+    minor = m.group(3)
+    label = f"Claude {variant} {major}"
+    if minor:
+        label += f".{minor}"
+    return label
+
+
+def _humanize_gemini(bare: str) -> str:
+    """Render a Gemini bare id as 'Gemini 2.5 Pro'."""
+    m = _GEMINI_NAME_RE.search(bare)
+    if not m:
+        return bare
+    major, minor = m.group(1), m.group(2)
+    version = f"{major}.{minor}" if minor else major
+    tail = bare[m.end() :].lstrip("-_.")
+    # Common qualifiers
+    qual = ""
+    lower_tail = tail.lower()
+    for k, v in (("pro", "Pro"), ("flash-lite", "Flash Lite"), ("flash", "Flash")):
+        if k in lower_tail:
+            qual = v
+            break
+    if "preview" in lower_tail:
+        qual = f"{qual} Preview".strip()
+    return f"Gemini {version}{(' ' + qual) if qual else ''}".strip()
+
+
+def _humanize_gpt(bare: str) -> str:
+    """Render an OpenAI GPT bare id as 'GPT-5.4 Mini'."""
+    m = _GPT_NAME_RE.search(bare)
+    if not m:
+        return bare
+    major, minor = m.group(1), m.group(2)
+    version = f"{major}.{minor}" if minor else major
+    tail = bare[m.end() :].lstrip("-_.")
+    qual = ""
+    if tail:
+        if "mini" in tail.lower():
+            qual = "Mini"
+        elif "nano" in tail.lower():
+            qual = "Nano"
+        elif "codex" in tail.lower():
+            qual = "Codex"
+    return f"GPT-{version}{(' ' + qual) if qual else ''}".strip()
+
+
+def derive_model_display(provider: str, model_name: str) -> ModelDisplay:
+    """Derive a `ModelDisplay` for a single `provider:model` pair.
+
+    Pure function — no I/O, safe to call in a tight UI loop.
+
+    Args:
+        provider: Provider id (e.g. 'anthropic', 'bedrock_converse').
+        model_name: The raw model id as it appears in API calls.
+
+    Returns:
+        ModelDisplay with human-readable display_name, family, vendor,
+        and capability flags.
+    """
+    spec = f"{provider}:{model_name}"
+    provider_display = get_provider_display_name(provider)
+
+    # Bedrock special-cases: strip region prefix and vendor prefix.
+    is_profile = False
+    bare = model_name
+    if provider in ("bedrock", "bedrock_converse"):
+        _region, after_region, is_profile = _strip_bedrock_prefix(model_name)
+        # Strip vendor prefix too for the display name.
+        for vendor_prefix in BEDROCK_VENDOR_PREFIXES:
+            if after_region.lower().startswith(vendor_prefix):
+                bare = after_region[len(vendor_prefix) :]
+                break
+        else:
+            bare = after_region
+
+    family, vendor = _detect_family_and_vendor(model_name)
+
+    if family == "claude":
+        display = _humanize_claude(bare)
+    elif family == "gemini":
+        display = _humanize_gemini(bare)
+    elif family in ("gpt", "o-series"):
+        if family == "o-series":
+            # 'o1-mini' -> 'OpenAI o1 Mini'
+            parts = bare.split("-")
+            head = parts[0]
+            tail = " ".join(p.capitalize() for p in parts[1:]) if len(parts) > 1 else ""
+            display = f"OpenAI {head}{(' ' + tail) if tail else ''}".strip()
+        else:
+            display = _humanize_gpt(bare)
+    elif family == "nova":
+        m = _NOVA_NAME_RE.search(bare)
+        tier = m.group(1).capitalize() if m else bare
+        display = f"Nova {tier}"
+    elif family == "llama":
+        m = _LLAMA_NAME_RE.search(bare)
+        if m:
+            major, minor = m.group(1), m.group(2)
+            version = f"{major}.{minor}" if minor else major
+            display = f"Llama {version}"
+        else:
+            display = bare
+    elif family == "mistral":
+        display = bare.split(":", 1)[0].replace("-", " ").title()
+    elif family == "deepseek":
+        display = bare.replace("-", " ").title()
+    else:
+        # Last-resort: title-case the bare name (helps Ollama / unknown).
+        display = bare.replace("-", " ").replace("_", " ").title() or model_name
+
+    if is_profile:
+        # Tag inference-profile-prefixed Bedrock entries so the picker
+        # shows them distinctly from plain regional model ids.
+        region, _, _ = _strip_bedrock_prefix(model_name)
+        display = f"{display} (Bedrock {region.upper()})"
+
+    return ModelDisplay(
+        spec=spec,
+        display_name=display,
+        provider_display=provider_display,
+        family=family,
+        vendor=vendor,
+        supports_thinking=supports_native_thinking(model_name),
+        is_inference_profile=is_profile,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cached model catalog (disk persistence for fast cold-start)
+# ---------------------------------------------------------------------------
+
+# Default cache file lives next to user config. Importable as a function so
+# tests can monkey-patch ``Path.home`` without polluting module-level state.
+_CACHE_FILENAME = "models.cache.json"
+_CACHE_FORMAT_VERSION = 1
+_CACHE_TTL_SECONDS = 7 * 24 * 3600  # one week — refreshable on demand
+
+
+def _default_cache_path() -> Path:
+    """Return the canonical path to the on-disk model catalog cache."""
+    return Path.home() / ".bog-agents" / _CACHE_FILENAME
+
+
+def load_cached_catalog(
+    *, path: Path | None = None
+) -> Mapping[str, tuple[str, ...]] | None:
+    """Load the persisted model catalog if present and not expired.
+
+    Args:
+        path: Override the default cache location (tests).
+
+    Returns:
+        A ``{provider: (model, ...)}`` mapping when a fresh cache is on
+        disk; ``None`` when there is no cache, the file is malformed, or
+        the entry is older than ``_CACHE_TTL_SECONDS``.
+    """
+    cache_path = path or _default_cache_path()
+    try:
+        with cache_path.open(encoding="utf-8") as fh:
+            payload = json.load(fh)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("version") != _CACHE_FORMAT_VERSION:
+        return None
+    ts = payload.get("ts")
+    if not isinstance(ts, (int, float)):
+        return None
+    if time.time() - ts > _CACHE_TTL_SECONDS:
+        return None
+
+    providers = payload.get("providers")
+    if not isinstance(providers, dict):
+        return None
+    result: dict[str, tuple[str, ...]] = {}
+    for provider, models in providers.items():
+        if not isinstance(provider, str) or not isinstance(models, list):
+            continue
+        names = tuple(str(m) for m in models if isinstance(m, str))
+        if names:
+            result[provider] = names
+    return result or None
+
+
+def save_cached_catalog(
+    catalog: Mapping[str, Sequence[str]], *, path: Path | None = None
+) -> bool:
+    """Persist ``catalog`` to the on-disk cache. Returns success."""
+    cache_path = path or _default_cache_path()
+    payload: dict[str, Any] = {
+        "version": _CACHE_FORMAT_VERSION,
+        "ts": time.time(),
+        "providers": {p: list(models) for p, models in catalog.items()},
+    }
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        # Atomic write: write to tmp then rename so a crash mid-write
+        # never leaves a half-written cache file.
+        tmp = cache_path.with_suffix(cache_path.suffix + ".tmp")
+        with tmp.open("w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2, sort_keys=True)
+        tmp.replace(cache_path)
+    except OSError:
+        logger.debug("Failed to persist model catalog cache", exc_info=True)
+        return False
+    return True
+
+
+def clear_cached_catalog(*, path: Path | None = None) -> bool:
+    """Delete the on-disk cache. Returns whether a file was removed."""
+    cache_path = path or _default_cache_path()
+    try:
+        cache_path.unlink()
+    except FileNotFoundError:
+        return False
+    except OSError:
+        logger.debug("Failed to delete model catalog cache", exc_info=True)
+        return False
+    return True

--- a/libs/cli/bog_agents_cli/smoketest.py
+++ b/libs/cli/bog_agents_cli/smoketest.py
@@ -1,0 +1,475 @@
+"""Smoke-test a model+provider combo end-to-end.
+
+Verifies credentials, network reachability, and that the configured model
+can complete a tiny one-token request. Used by the `/smoketest` slash
+command and the model picker's Ctrl+T binding.
+
+Design goals
+------------
+* **Cheap**: sends one short prompt with a 1-token output budget. For
+  Anthropic/OpenAI this costs well under a tenth of a cent per call.
+* **Actionable errors**: maps the most common failure shapes
+  (missing/expired credentials, network unreachable, throttling,
+  model-id-not-found) to a short hint the user can paste into a shell.
+* **Bedrock-aware**: delegates to the existing multi-step ``probe_bedrock``
+  reporter so the user sees the same probe report as ``/bedrock test``.
+* **No retries / no fallback**: a smoketest is a diagnostic — if it
+  fails, the user wants to see *the* failure, not a retried success.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Tight upper bound — smoketests should never burn more than a few cents.
+_SMOKETEST_TIMEOUT_SECONDS = 30.0
+
+# The prompt is intentionally trivial so we can demand a single-token
+# reply. Some providers refuse zero-token outputs, so we ask for "OK".
+_SMOKETEST_PROMPT = (
+    "Reply with exactly the single uppercase word: OK. "
+    "Do not add punctuation or explanation."
+)
+
+
+class SmoketestKind(StrEnum):
+    """High-level outcome categories the user can act on."""
+
+    OK = "ok"
+    """Provider responded with a non-empty body."""
+
+    AUTH_MISSING = "auth_missing"
+    """No credentials configured (env var unset, no AWS config, etc.)."""
+
+    AUTH_INVALID = "auth_invalid"
+    """Credentials present but rejected (401, expired token, bad key)."""
+
+    NETWORK = "network"
+    """DNS / connection / TLS — could not reach the API."""
+
+    MODEL_NOT_FOUND = "model_not_found"
+    """Provider rejected the model id (typo, region mismatch, retired)."""
+
+    QUOTA = "quota"
+    """Rate limit / quota exceeded — retry after backoff."""
+
+    TIMEOUT = "timeout"
+    """Call did not complete within the smoketest budget."""
+
+    PACKAGE_MISSING = "package_missing"
+    """Provider SDK not installed (e.g. ``langchain-aws``)."""
+
+    UNKNOWN = "unknown"
+    """Failure could not be categorised; raw error preserved."""
+
+
+@dataclass(frozen=True)
+class SmoketestResult:
+    """Structured outcome of a model smoketest.
+
+    Attributes:
+        spec: The ``provider:model`` string that was tested.
+        kind: One of :class:`SmoketestKind`.
+        elapsed_seconds: Wall-clock time for the test call.
+        message: One-line human-readable summary.
+        hint: Multi-line follow-up steps when ``kind`` is not ``OK``.
+        thinking_used: Whether the test exercised extended-thinking
+            parameters (only meaningful when ``kind`` is ``OK``).
+        raw_error: The underlying exception string (for logs).
+    """
+
+    spec: str
+    kind: SmoketestKind
+    elapsed_seconds: float
+    message: str
+    hint: str = ""
+    thinking_used: bool = False
+    raw_error: str = ""
+
+    @property
+    def ok(self) -> bool:
+        """True when the model responded successfully."""
+        return self.kind == SmoketestKind.OK
+
+    def summary_markup(self) -> str:
+        """Render a one-line Rich-markup status for the picker footer."""
+        if self.ok:
+            tag = "[green]PASS[/green]"
+            extra = " [magenta]thinking ✓[/magenta]" if self.thinking_used else ""
+            return f"{tag} {self.spec} ({self.elapsed_seconds:.1f}s){extra}"
+        return f"[red]FAIL[/red] {self.spec}: {self.message}"
+
+    def report_text(self) -> str:
+        """Render a multi-line report block for the chat surface."""
+        lines = [
+            f"Smoketest: {self.spec}",
+            f"  kind:    {self.kind.value}",
+            f"  elapsed: {self.elapsed_seconds:.2f}s",
+            f"  status:  {self.message}",
+        ]
+        if self.thinking_used:
+            lines.append("  thinking: enabled (provider accepted budget_tokens)")
+        if self.hint:
+            lines.append("")
+            lines.extend(f"  hint: {line}" for line in self.hint.splitlines())
+        return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Error categorization
+# ---------------------------------------------------------------------------
+
+
+_AUTH_INVALID_SIGNALS = (
+    "401",
+    "403",
+    "unauthorized",
+    "forbidden",
+    "invalid_api_key",
+    "invalid api key",
+    "authentication",
+    "expiredtoken",
+    "tokenretrieval",
+    "credentials",
+)
+_NETWORK_SIGNALS = (
+    "connection refused",
+    "connection error",
+    "name or service not known",
+    "name resolution",
+    "temporary failure in name resolution",
+    "no address associated with hostname",
+    "dns",
+    "ssl",
+    "tls",
+    "timed out",
+    "timeout",
+    "network is unreachable",
+    "could not connect",
+    "ehostunreach",
+    "econnreset",
+    "endpoint connection error",
+)
+_NOT_FOUND_SIGNALS = (
+    "model not found",
+    "model_not_found",
+    "modelid",
+    "validationexception",
+    "does not exist",
+    "unknown model",
+    "no such model",
+    "not authorized to invoke",
+)
+_QUOTA_SIGNALS = (
+    "rate limit",
+    "rate_limit",
+    "throttl",
+    "too many requests",
+    "429",
+    "quota",
+    "service unavailable",
+    "503",
+)
+_AUTH_MISSING_SIGNALS = (
+    "no api key",
+    "missing api key",
+    "set the.*api.*environment variable",
+    "could not load credentials",
+    "unable to locate credentials",
+)
+
+
+def _categorize(exc: BaseException) -> tuple[SmoketestKind, str]:
+    """Return ``(kind, short_summary)`` for an arbitrary exception."""
+    text = str(exc).lower()
+    name = type(exc).__name__
+
+    if name in ("TimeoutError", "ReadTimeout", "ConnectTimeout"):
+        return SmoketestKind.TIMEOUT, "request timed out"
+
+    if name == "ImportError" or "no module named" in text:
+        return SmoketestKind.PACKAGE_MISSING, str(exc)
+
+    for signal in _AUTH_MISSING_SIGNALS:
+        if signal in text:
+            return SmoketestKind.AUTH_MISSING, "credentials not configured"
+    for signal in _AUTH_INVALID_SIGNALS:
+        if signal in text:
+            return SmoketestKind.AUTH_INVALID, "credentials rejected"
+    for signal in _NOT_FOUND_SIGNALS:
+        if signal in text:
+            return SmoketestKind.MODEL_NOT_FOUND, "model id rejected by provider"
+    for signal in _QUOTA_SIGNALS:
+        if signal in text:
+            return SmoketestKind.QUOTA, "quota / throttling — retry after backoff"
+    for signal in _NETWORK_SIGNALS:
+        if signal in text:
+            return SmoketestKind.NETWORK, "could not reach provider endpoint"
+
+    return SmoketestKind.UNKNOWN, str(exc).splitlines()[0][:160] if str(exc) else name
+
+
+def _hint_for(kind: SmoketestKind, provider: str) -> str:
+    """Render an actionable next-step hint for a failure category."""
+    if kind == SmoketestKind.AUTH_MISSING:
+        if provider in ("bedrock", "bedrock_converse"):
+            return (
+                "AWS credentials not detected.\n"
+                "Run `aws configure` or `aws sso login`, "
+                "or set AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY."
+            )
+        env_hint = {
+            "anthropic": "ANTHROPIC_API_KEY",
+            "openai": "OPENAI_API_KEY",
+            "google_genai": "GOOGLE_API_KEY",
+            "groq": "GROQ_API_KEY",
+            "mistralai": "MISTRAL_API_KEY",
+            "deepseek": "DEEPSEEK_API_KEY",
+            "openrouter": "OPENROUTER_API_KEY",
+            "xai": "XAI_API_KEY",
+        }.get(provider)
+        if env_hint:
+            return f"Set {env_hint} in your environment (or via /vars)."
+        return "Configure the provider's credentials in your environment."
+    if kind == SmoketestKind.AUTH_INVALID:
+        if provider in ("bedrock", "bedrock_converse"):
+            return (
+                "AWS credentials are present but rejected.\n"
+                "If using SSO, run `aws sso login`. If using static keys, "
+                "verify they're still active in the AWS console."
+            )
+        return "Check that the configured API key is still valid and has access."
+    if kind == SmoketestKind.MODEL_NOT_FOUND:
+        if provider in ("bedrock", "bedrock_converse"):
+            return (
+                "Bedrock rejected the modelId. Possible causes:\n"
+                "• You haven't requested model access in the Bedrock console.\n"
+                "• The model isn't available in your configured region.\n"
+                "• You used a base id where an inference profile id is required "
+                "(prefer `us.anthropic.…` / `eu.anthropic.…` for newer models)."
+            )
+        return "Verify the model id is current — providers retire ids frequently."
+    if kind == SmoketestKind.NETWORK:
+        return (
+            "Could not reach the provider endpoint.\n"
+            "Check internet connectivity, corporate proxy, and firewall rules."
+        )
+    if kind == SmoketestKind.QUOTA:
+        return "Wait and retry, or request a quota increase from the provider."
+    if kind == SmoketestKind.TIMEOUT:
+        return (
+            f"Call exceeded {_SMOKETEST_TIMEOUT_SECONDS:.0f}s. "
+            "The provider may be slow or your network may be flaky."
+        )
+    if kind == SmoketestKind.PACKAGE_MISSING:
+        return (
+            "Install the provider's package, e.g. "
+            "`uv pip install langchain-aws` for Bedrock."
+        )
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Bedrock smoketest (delegates to the existing probe)
+# ---------------------------------------------------------------------------
+
+
+def _smoketest_bedrock(spec: str, model_name: str) -> SmoketestResult:
+    """Run the Bedrock probe and translate its result to a SmoketestResult."""
+    start = time.monotonic()
+    try:
+        from bog_agents_cli._bedrock import probe_bedrock
+    except ImportError as exc:
+        return SmoketestResult(
+            spec=spec,
+            kind=SmoketestKind.PACKAGE_MISSING,
+            elapsed_seconds=time.monotonic() - start,
+            message="bedrock probe module unavailable",
+            hint=_hint_for(SmoketestKind.PACKAGE_MISSING, "bedrock"),
+            raw_error=str(exc),
+        )
+
+    steps = probe_bedrock(model_name, None)
+    elapsed = time.monotonic() - start
+
+    failed_step = next((s for s in steps if not s.ok), None)
+    if failed_step is None:
+        return SmoketestResult(
+            spec=spec,
+            kind=SmoketestKind.OK,
+            elapsed_seconds=elapsed,
+            message="all probe steps passed",
+        )
+
+    bedrock_err = getattr(failed_step, "error", None)
+    raw = str(bedrock_err) if bedrock_err else failed_step.detail or failed_step.name
+    kind, summary = _categorize(Exception(raw or failed_step.name))
+    return SmoketestResult(
+        spec=spec,
+        kind=kind,
+        elapsed_seconds=elapsed,
+        message=f"failed at step '{failed_step.name}': {summary}",
+        hint=_hint_for(kind, "bedrock_converse"),
+        raw_error=raw,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def smoketest_model(
+    spec: str,
+    *,
+    thinking: bool = False,
+    timeout_seconds: float = _SMOKETEST_TIMEOUT_SECONDS,
+) -> SmoketestResult:
+    """Smoke-test a `provider:model` combo.
+
+    Args:
+        spec: ``provider:model`` string (e.g. ``"anthropic:claude-sonnet-4-6"``).
+            Bare model names are accepted but discouraged — the result
+            ``spec`` will reflect the resolved provider.
+        thinking: When ``True`` and the model supports extended thinking,
+            ask the provider to enable thinking with a small budget.
+            The test still expects a one-word reply; we only verify that
+            the provider accepts the thinking parameter without 400ing.
+        timeout_seconds: Hard cap on the inference call.
+
+    Returns:
+        A structured result. Always returns; never raises.
+    """
+    # Parse the spec to route Bedrock through its dedicated probe.
+    provider, _, model_name = spec.partition(":")
+    if not provider or not model_name:
+        # Bare model name → defer to create_model's auto-detection.
+        from bog_agents_cli.config import detect_provider
+
+        detected = detect_provider(spec)
+        if detected:
+            provider, model_name = detected, spec
+            spec = f"{provider}:{model_name}"
+        else:
+            return SmoketestResult(
+                spec=spec,
+                kind=SmoketestKind.UNKNOWN,
+                elapsed_seconds=0.0,
+                message="could not determine provider — use provider:model format",
+            )
+
+    if provider in ("bedrock", "bedrock_converse"):
+        return _smoketest_bedrock(spec, model_name)
+
+    # Generic path: create model + send tiny ainvoke.
+    start = time.monotonic()
+    try:
+        from bog_agents_cli.config import create_model
+
+        extra_kwargs: dict[str, Any] = {"max_tokens": 16}
+        # Try to bind thinking when requested AND the model supports it.
+        if thinking:
+            from bog_agents_cli.provider_catalog import supports_native_thinking
+
+            if supports_native_thinking(model_name):
+                # Provider-specific binding handled by ChatAnthropic etc.
+                # Use a small budget — we don't need real reasoning, just
+                # confirm the parameter is accepted.
+                if provider == "anthropic":
+                    extra_kwargs["thinking"] = {
+                        "type": "enabled",
+                        "budget_tokens": 1024,
+                    }
+                elif provider in ("openai", "azure_openai"):
+                    extra_kwargs["reasoning_effort"] = "low"
+
+        result = create_model(spec, extra_kwargs=extra_kwargs)
+        model = result.model
+    except Exception as exc:
+        elapsed = time.monotonic() - start
+        kind, summary = _categorize(exc)
+        return SmoketestResult(
+            spec=spec,
+            kind=kind,
+            elapsed_seconds=elapsed,
+            message=f"model construction failed: {summary}",
+            hint=_hint_for(kind, provider),
+            raw_error=str(exc),
+        )
+
+    # Invoke synchronously — boto3 / requests-based providers are sync;
+    # async wrappers add a layer of event-loop binding pain we don't need
+    # for a one-shot smoketest. Threaded callers can wrap in to_thread.
+    try:
+        import threading
+
+        response_holder: list[Any] = []
+        error_holder: list[BaseException] = []
+
+        def _call() -> None:
+            try:
+                response_holder.append(model.invoke(_SMOKETEST_PROMPT))
+            except BaseException as exc:
+                error_holder.append(exc)
+
+        thread = threading.Thread(target=_call, daemon=True, name="smoketest")
+        thread.start()
+        thread.join(timeout=timeout_seconds)
+        if thread.is_alive():
+            elapsed = time.monotonic() - start
+            return SmoketestResult(
+                spec=spec,
+                kind=SmoketestKind.TIMEOUT,
+                elapsed_seconds=elapsed,
+                message=f"call did not complete within {timeout_seconds:.0f}s",
+                hint=_hint_for(SmoketestKind.TIMEOUT, provider),
+            )
+
+        if error_holder:
+            elapsed = time.monotonic() - start
+            kind, summary = _categorize(error_holder[0])
+            return SmoketestResult(
+                spec=spec,
+                kind=kind,
+                elapsed_seconds=elapsed,
+                message=f"inference failed: {summary}",
+                hint=_hint_for(kind, provider),
+                raw_error=str(error_holder[0]),
+            )
+
+        elapsed = time.monotonic() - start
+        response = response_holder[0] if response_holder else None
+        content = getattr(response, "content", "")
+        text = str(content)[:60].strip()
+        return SmoketestResult(
+            spec=spec,
+            kind=SmoketestKind.OK,
+            elapsed_seconds=elapsed,
+            message=f"model replied: {text!r}" if text else "model returned empty body",
+            thinking_used=bool(thinking and extra_kwargs.get("thinking"))
+            or bool(thinking and extra_kwargs.get("reasoning_effort")),
+        )
+    except Exception as exc:
+        elapsed = time.monotonic() - start
+        kind, summary = _categorize(exc)
+        return SmoketestResult(
+            spec=spec,
+            kind=kind,
+            elapsed_seconds=elapsed,
+            message=f"inference failed: {summary}",
+            hint=_hint_for(kind, provider),
+            raw_error=str(exc),
+        )
+
+
+__all__ = [
+    "SmoketestKind",
+    "SmoketestResult",
+    "smoketest_model",
+]

--- a/libs/cli/bog_agents_cli/widgets/model_selector.py
+++ b/libs/cli/bog_agents_cli/widgets/model_selector.py
@@ -26,10 +26,20 @@ from bog_agents_cli.model_config import (
     get_available_models,
     get_model_profiles,
     has_provider_credentials,
+    refresh_available_models,
     save_default_model,
+)
+from bog_agents_cli.provider_catalog import (
+    ModelDisplay,
+    derive_model_display,
 )
 
 logger = logging.getLogger(__name__)
+
+# Debounce window (seconds) between the user's last keystroke and the
+# filter pass. 80ms feels instant on a typical TUI and folds bursts of
+# fast typing into a single filter call.
+_FILTER_DEBOUNCE_SECONDS = 0.08
 
 
 class ModelOption(Static):
@@ -43,6 +53,8 @@ class ModelOption(Static):
         index: int,
         *,
         has_creds: bool | None = True,
+        display: ModelDisplay | None = None,
+        search_blob: str = "",
         classes: str = "",
     ) -> None:
         """Initialize a model option.
@@ -54,6 +66,12 @@ class ModelOption(Static):
             index: The index of this option in the filtered list.
             has_creds: Whether the provider has valid credentials. True if
                 confirmed, False if missing, None if unknown.
+            display: Derived display metadata (display_name, family,
+                supports_thinking). When None, the picker treats the
+                option as legacy with no human-readable label.
+            search_blob: Pre-computed lower-cased text the picker fuzzy-
+                matches against. Includes the spec, display_name, family,
+                and vendor so the user can find a model by any of them.
             classes: CSS classes for styling.
         """
         super().__init__(label, classes=classes)
@@ -61,6 +79,8 @@ class ModelOption(Static):
         self.provider = provider
         self.index = index
         self.has_creds = has_creds
+        self.model_display = display
+        self.search_blob = search_blob or model_spec.lower()
 
     class Clicked(Message):
         """Message sent when a model option is clicked."""
@@ -88,6 +108,19 @@ class ModelOption(Static):
         self.post_message(self.Clicked(self.model_spec, self.provider, self.index))
 
 
+class ProviderHeader(Static):
+    """A provider-section header in the model picker.
+
+    Subclasses ``Static`` only to attach the provider id as an attribute,
+    so the filter pass can hide headers whose section has no visible
+    options without parsing Rich markup.
+    """
+
+    def __init__(self, *args: Any, provider: str, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.provider = provider
+
+
 class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
     """Full-screen modal for model selection.
 
@@ -107,6 +140,8 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         Binding("pagedown", "page_down", "Page down", show=False, priority=True),
         Binding("enter", "select", "Select", show=False, priority=True),
         Binding("ctrl+s", "set_default", "Set default", show=False, priority=True),
+        Binding("ctrl+r", "refresh_catalog", "Refresh", show=False, priority=True),
+        Binding("ctrl+t", "smoketest", "Smoketest", show=False, priority=True),
         Binding("escape", "cancel", "Cancel", show=False, priority=True),
     ]
 
@@ -217,22 +252,60 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         super().__init__()
         self._current_model = current_model
         self._current_provider = current_provider
+        self._cli_profile_override = cli_profile_override
 
-        # Build list from dynamically discovered models (falls back to defaults)
+        # Build list from dynamically discovered models (falls back to defaults).
         self._all_models: list[tuple[str, str]] = []
         for provider, models in get_available_models().items():
             for model in models:
                 model_spec = f"{provider}:{model}"
                 self._all_models.append((model_spec, provider))
 
+        # Derive display metadata once per model so the filter loop can
+        # search across spec + display name + family without re-deriving
+        # on every keystroke.
+        self._displays: dict[str, ModelDisplay] = {
+            spec: derive_model_display(provider, spec.split(":", 1)[1])
+            for spec, provider in self._all_models
+        }
+
+        # The "search blob" is the lower-cased text the fuzzy matcher
+        # compares against. Pre-computing it once avoids string ops per
+        # keystroke per model.
+        self._search_blobs: dict[str, str] = {
+            spec: " ".join(
+                (
+                    spec.lower(),
+                    self._displays[spec].display_name.lower(),
+                    self._displays[spec].family,
+                    self._displays[spec].vendor,
+                    self._displays[spec].provider_display.lower(),
+                )
+            )
+            for spec, _ in self._all_models
+        }
+
         self._filtered_models: list[tuple[str, str]] = list(self._all_models)
         self._selected_index = self._find_current_model_index()
         self._options_container: Container | None = None
         self._option_widgets: list[ModelOption] = []
+        # `_visible_widgets` is kept in sync with `_filtered_models` so
+        # `_move_selection` can index by score-order position rather than
+        # build-order. Initially equals `_option_widgets` (all visible).
+        self._visible_widgets: list[ModelOption] = []
         self._filter_text = ""
+        self._filter_timer: Any = None
+        self._smoketest_running = False
         self._current_spec: str | None = None
         if current_model and current_provider:
             self._current_spec = f"{current_provider}:{current_model}"
+
+        # Pre-resolve credentials once per provider so neither the
+        # initial build nor selection-move recomputes them.
+        providers_in_list = {p for _, p in self._all_models}
+        self._creds: dict[str, bool | None] = {
+            p: has_provider_credentials(p) for p in providers_in_list
+        }
 
         config = ModelConfig.load()
         self._default_spec: str | None = config.default_model
@@ -290,7 +363,9 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             help_text = (
                 f"{glyphs.arrow_up}/{glyphs.arrow_down} navigate"
                 f" {glyphs.bullet} Enter select"
-                f" {glyphs.bullet} Ctrl+S set default"
+                f" {glyphs.bullet} Ctrl+S default"
+                f" {glyphs.bullet} Ctrl+T test"
+                f" {glyphs.bullet} Ctrl+R refresh"
                 f" {glyphs.bullet} Esc cancel"
             )
             yield Static(help_text, classes="model-selector-help")
@@ -301,7 +376,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             container = self.query_one(Vertical)
             container.styles.border = ("ascii", "green")
 
-        await self._update_display()
+        await self._build_widget_set()
         self._update_footer()
 
         # Focus the filter input
@@ -309,14 +384,29 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         filter_input.focus()
 
     def on_input_changed(self, event: Input.Changed) -> None:
-        """Filter models as user types.
+        """Filter models as user types — debounced to coalesce keystroke bursts.
 
-        Args:
-            event: The input changed event.
+        Avoids the O(N) DOM rebuild that earlier versions of this picker
+        triggered per keystroke. Two changes work together:
+
+        1. ``set_timer`` defers the actual filter pass by
+           ``_FILTER_DEBOUNCE_SECONDS`` so fast typing yields a single
+           filter pass per pause instead of one-per-key.
+        2. ``_apply_filter`` flips ``.display`` on existing widgets
+           rather than removing/remounting them. The widget set built
+           at mount stays put for the life of the screen.
         """
         self._filter_text = event.value
-        self._update_filtered_list()
-        self.call_after_refresh(self._update_display)
+        # Cancel any pending filter timer so we don't run a stale value
+        # right after a fresh keystroke.
+        if self._filter_timer is not None:
+            try:
+                self._filter_timer.stop()
+            except Exception:
+                logger.debug("Failed to stop pending filter timer", exc_info=True)
+        self._filter_timer = self.set_timer(
+            _FILTER_DEBOUNCE_SECONDS, self._apply_filter
+        )
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         """Handle Enter key when filter input is focused.
@@ -339,7 +429,8 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
     def _update_filtered_list(self) -> None:
         """Update the filtered models based on search text using fuzzy matching.
 
-        Results are sorted by match score (best first).
+        Results are sorted by match score (best first). Search blobs are
+        pre-computed in ``__init__`` so this only does the score loop.
         """
         query = self._filter_text.strip()
         if not query:
@@ -353,7 +444,8 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             matchers = [Matcher(token, case_sensitive=False) for token in tokens]
             scored: list[tuple[float, str, str]] = []
             for spec, provider in self._all_models:
-                scores = [m.match(spec) for m in matchers]
+                blob = self._search_blobs.get(spec, spec.lower())
+                scores = [m.match(blob) for m in matchers]
                 if all(s > 0 for s in scores):
                     scored.append((min(scores), spec, provider))
         except Exception:
@@ -372,12 +464,12 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         ]
         self._selected_index = 0
 
-    async def _update_display(self) -> None:
-        """Render the model list grouped by provider.
+    async def _build_widget_set(self) -> None:
+        """Build the full set of ``ModelOption`` widgets once.
 
-        Performs a full DOM rebuild (removes all children, re-mounts).
-        Arrow-key navigation uses `_move_selection` instead to avoid
-        the cost of a full rebuild.
+        Called on initial mount and on Ctrl+R refresh. Subsequent filter
+        changes flip ``.display`` on existing widgets instead of rebuilding
+        — see :meth:`_apply_filter`.
         """
         if not self._options_container:
             return
@@ -385,65 +477,45 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         await self._options_container.remove_children()
         self._option_widgets = []
 
-        if not self._filtered_models:
-            no_matches = Static("[dim]No matching models[/dim]")
-            await self._options_container.mount(no_matches)
+        if not self._all_models:
+            no_models = Static("[dim]No models discovered[/dim]")
+            await self._options_container.mount(no_models)
             self._update_footer()
             return
 
         # Group by provider, preserving insertion order so models from the
         # same provider cluster together in the visual list.
         by_provider: dict[str, list[tuple[str, str]]] = {}
-        for model_spec, provider in self._filtered_models:
+        for model_spec, provider in self._all_models:
             by_provider.setdefault(provider, []).append((model_spec, provider))
-
-        # Rebuild _filtered_models to match the provider-grouped display
-        # order. Without this, _filtered_models stays in score-sorted order
-        # while _option_widgets follow provider-grouped order, causing
-        # _update_footer to look up the wrong model for the highlighted
-        # index.
-        grouped_order: list[tuple[str, str]] = []
-        for entries in by_provider.values():
-            grouped_order.extend(entries)
-
-        # Remap selected_index so the same model stays highlighted.
-        old_spec = self._filtered_models[self._selected_index][0]
-        self._filtered_models = grouped_order
-        self._selected_index = next(
-            (i for i, (s, _) in enumerate(grouped_order) if s == old_spec),
-            0,
-        )
 
         glyphs = get_glyphs()
         flat_index = 0
-        selected_widget: ModelOption | None = None
+        current_spec = self._current_spec
 
-        # Build current model spec for comparison
-        current_spec = None
-        if self._current_model and self._current_provider:
-            current_spec = f"{self._current_provider}:{self._current_model}"
-
-        # Resolve credentials upfront so the widget-building loop
-        # stays focused on layout
-        creds = {p: has_provider_credentials(p) for p in by_provider}
-
-        # Collect all widgets first, then batch-mount once to avoid
-        # individual DOM mutations per widget
+        # Batch-mount all widgets in a single mount call to avoid
+        # individual DOM mutations per widget.
         all_widgets: list[Static] = []
 
         for provider, model_entries in by_provider.items():
-            # Provider header with credential indicator
-            has_creds = creds[provider]
+            has_creds = self._creds.get(provider)
             if has_creds is True:
                 cred_indicator = glyphs.checkmark
             elif has_creds is False:
                 cred_indicator = f"{glyphs.warning} missing credentials"
             else:
                 cred_indicator = f"{glyphs.question} credentials unknown"
+            provider_display = (
+                self._displays[model_entries[0][0]].provider_display
+                if model_entries
+                else provider
+            )
             all_widgets.append(
-                Static(
-                    f"[bold]{provider}[/bold] [dim]{cred_indicator}[/dim]",
+                ProviderHeader(
+                    f"[bold]{provider_display}[/bold] [dim]({provider}) "
+                    f"{cred_indicator}[/dim]",
                     classes="model-provider-header",
+                    provider=provider,
                 )
             )
 
@@ -464,6 +536,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
                     has_creds=has_creds,
                     is_default=model_spec == self._default_spec,
                     status=self._get_model_status(model_spec),
+                    display=self._displays.get(model_spec),
                 )
                 widget = ModelOption(
                     label=label,
@@ -471,27 +544,100 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
                     provider=provider,
                     index=flat_index,
                     has_creds=has_creds,
+                    display=self._displays.get(model_spec),
+                    search_blob=self._search_blobs.get(model_spec, ""),
                     classes=classes,
                 )
                 all_widgets.append(widget)
                 self._option_widgets.append(widget)
 
-                if is_selected:
-                    selected_widget = widget
-
                 flat_index += 1
 
         await self._options_container.mount(*all_widgets)
 
-        # Scroll the selected item into view without animation so the list
-        # appears already scrolled to the current model on first paint.
-        if selected_widget:
-            if self._selected_index == 0:
-                # First item: scroll to top so header is visible
-                scroll_container = self.query_one(".model-list", VerticalScroll)
-                scroll_container.scroll_home(animate=False)
+        # Reset filtered list to "all" so _apply_filter doesn't think
+        # nothing matches before the first keystroke.
+        self._filtered_models = list(self._all_models)
+        self._visible_widgets = list(self._option_widgets)
+        self._apply_filter()
+
+    def _apply_filter(self) -> None:
+        """Filter the existing widget set in-place based on ``_filter_text``.
+
+        Hot path: runs on every keystroke (after the debounce). Performance
+        depends on this being O(N) over widgets with no DOM mutation
+        beyond toggling ``.display`` on each option.
+        """
+        # Score / order the candidates.
+        self._update_filtered_list()
+        matched_specs = {spec for spec, _ in self._filtered_models}
+
+        spec_to_widget: dict[str, ModelOption] = {
+            w.model_spec: w for w in self._option_widgets
+        }
+
+        # Rebuild _visible_widgets in score order so navigation keys
+        # follow the user's filter ranking.
+        self._visible_widgets = [
+            spec_to_widget[spec]
+            for spec, _ in self._filtered_models
+            if spec in spec_to_widget
+        ]
+
+        # Toggle widget visibility. Track per-provider counts so we can
+        # hide headers whose group has no visible options.
+        visible_options_per_provider: dict[str, int] = {}
+        for widget in self._option_widgets:
+            visible = widget.model_spec in matched_specs
+            widget.display = visible
+            if visible:
+                visible_options_per_provider[widget.provider] = (
+                    visible_options_per_provider.get(widget.provider, 0) + 1
+                )
+
+        # Hide provider headers whose group has no visible options.
+        if self._options_container is not None:
+            for header in self._options_container.query(ProviderHeader):
+                header.display = (
+                    visible_options_per_provider.get(header.provider, 0) > 0
+                )
+
+        if not self._filtered_models:
+            self._selected_index = 0
+            self._update_footer()
+            return
+
+        # _update_filtered_list set _selected_index to 0 when a filter is
+        # active. Clamp just in case the caller poked it.
+        if self._selected_index >= len(self._filtered_models):
+            self._selected_index = 0
+        target_spec = self._filtered_models[self._selected_index][0]
+
+        # Re-paint visible widgets' selection styling.
+        for w in self._visible_widgets:
+            is_selected = w.model_spec == target_spec
+            is_current = w.model_spec == self._current_spec
+            if is_selected:
+                w.add_class("model-option-selected")
             else:
-                selected_widget.scroll_visible(animate=False)
+                w.remove_class("model-option-selected")
+            w.update(
+                self._format_option_label(
+                    w.model_spec,
+                    selected=is_selected,
+                    current=is_current,
+                    has_creds=w.has_creds,
+                    is_default=w.model_spec == self._default_spec,
+                    status=self._get_model_status(w.model_spec),
+                    display=w.model_display,
+                )
+            )
+
+        if target_spec in spec_to_widget:
+            try:
+                spec_to_widget[target_spec].scroll_visible(animate=False)
+            except Exception:
+                logger.debug("scroll_visible failed", exc_info=True)
 
         self._update_footer()
 
@@ -504,6 +650,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         has_creds: bool | None,
         is_default: bool = False,
         status: str | None = None,
+        display: ModelDisplay | None = None,
     ) -> str:
         """Build the display label for a model option.
 
@@ -516,18 +663,29 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             status: Model status from profile (e.g., `'deprecated'`,
                 `'beta'`, `'alpha'`). `'deprecated'` renders in red;
                 other non-None values render in yellow.
+            display: Derived display metadata (display_name + thinking
+                support). When provided, the label leads with the
+                human-readable name and dims the raw spec.
 
         Returns:
             Rich-markup label string.
         """
         glyphs = get_glyphs()
         cursor = f"{glyphs.cursor} " if selected else "  "
+
+        # Primary text: human-readable display name when available,
+        # otherwise fall back to the raw spec.
+        primary = display.display_name if display else model_spec
         if not has_creds:
-            spec_text = f"[yellow]{model_spec}[/yellow]"
+            primary_text = f"[yellow]{primary}[/yellow]"
         elif is_default:
-            spec_text = f"[cyan]{model_spec}[/cyan]"
+            primary_text = f"[cyan]{primary}[/cyan]"
         else:
-            spec_text = model_spec
+            primary_text = primary
+
+        # Always include the raw spec so power users can read the API id.
+        spec_hint = f"  [dim]{model_spec}[/dim]" if display else ""
+
         suffix = " [dim](current)[/dim]" if current else ""
         default_suffix = " [cyan](default)[/cyan]" if is_default else ""
         if status == "deprecated":
@@ -536,7 +694,15 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             status_suffix = f" [yellow]({status})[/yellow]"
         else:
             status_suffix = ""
-        return f"{cursor}{spec_text}{suffix}{default_suffix}{status_suffix}"
+        thinking_suffix = (
+            " [magenta]✨ thinking[/magenta]"
+            if display and display.supports_thinking
+            else ""
+        )
+        return (
+            f"{cursor}{primary_text}{spec_hint}{suffix}"
+            f"{default_suffix}{status_suffix}{thinking_suffix}"
+        )
 
     @staticmethod
     def _format_footer(
@@ -670,16 +836,16 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         Args:
             delta: Number of positions to move (-1 for up, +1 for down).
         """
-        if not self._filtered_models or not self._option_widgets:
+        if not self._filtered_models or not self._visible_widgets:
             return
 
-        count = len(self._filtered_models)
-        old_index = self._selected_index
+        count = len(self._visible_widgets)
+        old_index = self._selected_index % count
         new_index = (old_index + delta) % count
         self._selected_index = new_index
 
         # Update the previously selected widget
-        old_widget = self._option_widgets[old_index]
+        old_widget = self._visible_widgets[old_index]
         old_widget.remove_class("model-option-selected")
         old_widget.update(
             self._format_option_label(
@@ -689,11 +855,12 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
                 has_creds=old_widget.has_creds,
                 is_default=old_widget.model_spec == self._default_spec,
                 status=self._get_model_status(old_widget.model_spec),
+                display=old_widget.model_display,
             )
         )
 
         # Update the newly selected widget
-        new_widget = self._option_widgets[new_index]
+        new_widget = self._visible_widgets[new_index]
         new_widget.add_class("model-option-selected")
         new_widget.update(
             self._format_option_label(
@@ -703,6 +870,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
                 has_creds=new_widget.has_creds,
                 is_default=new_widget.model_spec == self._default_spec,
                 status=self._get_model_status(new_widget.model_spec),
+                display=new_widget.model_display,
             )
         )
 
@@ -839,7 +1007,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             # Already default — clear it
             if await asyncio.to_thread(clear_default_model):
                 self._default_spec = None
-                self.call_after_refresh(self._update_display)
+                self.call_after_refresh(self._apply_filter)
                 help_widget.update("[bold]Default cleared[/bold]")
                 self.set_timer(3.0, self._restore_help_text)
             else:
@@ -859,12 +1027,93 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         glyphs = get_glyphs()
         help_text = (
             f"{glyphs.arrow_up}/{glyphs.arrow_down} navigate"
-            f" {glyphs.bullet} Enter select + set as default"
-            f" {glyphs.bullet} Ctrl+S toggle default"
+            f" {glyphs.bullet} Enter select"
+            f" {glyphs.bullet} Ctrl+S default"
+            f" {glyphs.bullet} Ctrl+T test"
+            f" {glyphs.bullet} Ctrl+R refresh"
             f" {glyphs.bullet} Esc cancel"
         )
         help_widget = self.query_one(".model-selector-help", Static)
         help_widget.update(help_text)
+
+    async def action_refresh_catalog(self) -> None:
+        """Reload the model catalog from upstream profiles + cache.
+
+        Clears the in-memory caches, re-derives the list, rebuilds the
+        widget set in place. Useful after installing a new provider
+        package or after the user adds a custom model to config.toml.
+        """
+        import asyncio
+
+        help_widget = self.query_one(".model-selector-help", Static)
+        help_widget.update("[bold]Refreshing model catalog…[/bold]")
+        try:
+            await asyncio.to_thread(refresh_available_models)
+            # Rebuild internal model list + display metadata.
+            self._all_models = []
+            for provider, models in get_available_models().items():
+                for model in models:
+                    spec = f"{provider}:{model}"
+                    self._all_models.append((spec, provider))
+            self._displays = {
+                spec: derive_model_display(provider, spec.split(":", 1)[1])
+                for spec, provider in self._all_models
+            }
+            self._search_blobs = {
+                spec: " ".join(
+                    (
+                        spec.lower(),
+                        self._displays[spec].display_name.lower(),
+                        self._displays[spec].family,
+                        self._displays[spec].vendor,
+                        self._displays[spec].provider_display.lower(),
+                    )
+                )
+                for spec, _ in self._all_models
+            }
+            providers_in_list = {p for _, p in self._all_models}
+            self._creds = {p: has_provider_credentials(p) for p in providers_in_list}
+            self._profiles = get_model_profiles(cli_override=self._cli_profile_override)
+            self._selected_index = self._find_current_model_index()
+            await self._build_widget_set()
+            help_widget.update(
+                f"[bold]Catalog refreshed — {len(self._all_models)} models[/bold]"
+            )
+        except Exception:
+            logger.warning("Failed to refresh model catalog", exc_info=True)
+            help_widget.update("[bold red]Refresh failed — see logs[/bold red]")
+        self.set_timer(3.0, self._restore_help_text)
+
+    async def action_smoketest(self) -> None:
+        """Run a quick connectivity test against the highlighted model.
+
+        Opens a ``SmoketestResult`` modal with credentials / inference /
+        thinking steps. Disabled while another smoketest is in flight to
+        avoid stacking duplicate calls.
+        """
+        import asyncio
+
+        if self._smoketest_running:
+            return
+        if not self._filtered_models:
+            return
+        model_spec, _provider = self._filtered_models[self._selected_index]
+
+        help_widget = self.query_one(".model-selector-help", Static)
+        help_widget.update(f"[bold]Smoketest {model_spec}…[/bold] (Ctrl+T to re-run)")
+        self._smoketest_running = True
+        try:
+            # Lazy import — keeps the cold-start cost of opening the picker low.
+            from bog_agents_cli.smoketest import smoketest_model
+
+            result = await asyncio.to_thread(smoketest_model, model_spec)
+            help_widget.update(result.summary_markup())
+        except Exception as exc:
+            logger.warning("Smoketest failed for %s", model_spec, exc_info=True)
+            help_widget.update(f"[bold red]Smoketest crashed: {exc}[/bold red]")
+        finally:
+            self._smoketest_running = False
+        self.set_timer(8.0, self._restore_help_text)
 
     def action_cancel(self) -> None:
         """Cancel the selection."""

--- a/libs/cli/tests/unit_tests/test_provider_catalog_display.py
+++ b/libs/cli/tests/unit_tests/test_provider_catalog_display.py
@@ -1,0 +1,206 @@
+"""Tests for display-name derivation, thinking detection, and catalog cache.
+
+These exercises pin the user-visible behaviour of the `provider_catalog`
+helpers added for the model-picker refinements:
+
+- `derive_model_display` produces stable human-readable labels.
+- `supports_native_thinking` returns the expected verdict per family.
+- `load_cached_catalog` / `save_cached_catalog` round-trip a real
+  catalog through a temp directory.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from bog_agents_cli.provider_catalog import (
+    ModelDisplay,
+    clear_cached_catalog,
+    derive_model_display,
+    get_provider_display_name,
+    load_cached_catalog,
+    save_cached_catalog,
+    supports_native_thinking,
+)
+
+
+class TestProviderDisplayName:
+    """``get_provider_display_name`` maps provider ids to human labels."""
+
+    def test_known_provider(self) -> None:
+        assert get_provider_display_name("anthropic") == "Anthropic"
+        assert get_provider_display_name("bedrock_converse") == "AWS Bedrock"
+        assert get_provider_display_name("google_genai") == "Google Gemini"
+
+    def test_unknown_provider_falls_back_to_title_case(self) -> None:
+        assert get_provider_display_name("my_custom_provider") == "My Custom Provider"
+
+
+class TestDeriveModelDisplay:
+    """Display labels for common provider:model combinations."""
+
+    def test_claude_anthropic(self) -> None:
+        d = derive_model_display("anthropic", "claude-sonnet-4-6")
+        assert d.display_name == "Claude Sonnet 4.6"
+        assert d.family == "claude"
+        assert d.vendor == "anthropic"
+        assert d.supports_thinking is True
+        assert d.is_inference_profile is False
+
+    def test_claude_haiku(self) -> None:
+        d = derive_model_display("anthropic", "claude-haiku-4-5")
+        assert d.display_name == "Claude Haiku 4.5"
+
+    def test_bedrock_inference_profile_tagged(self) -> None:
+        d = derive_model_display("bedrock_converse", "us.anthropic.claude-sonnet-4-6")
+        assert d.is_inference_profile is True
+        # Display name should contain 'Bedrock US' to make the region obvious.
+        assert "Bedrock US" in d.display_name
+        assert "Claude Sonnet 4.6" in d.display_name
+        assert d.supports_thinking is True
+        assert d.vendor == "anthropic"
+
+    def test_bedrock_base_id_not_profile(self) -> None:
+        d = derive_model_display("bedrock_converse", "anthropic.claude-sonnet-4-6")
+        assert d.is_inference_profile is False
+        assert "Bedrock" not in d.display_name  # base ids don't get the region suffix
+        assert d.vendor == "anthropic"
+        assert d.supports_thinking is True
+
+    def test_gemini(self) -> None:
+        d = derive_model_display("google_genai", "gemini-2.5-pro")
+        assert d.display_name == "Gemini 2.5 Pro"
+        assert d.supports_thinking is True
+
+    def test_gpt(self) -> None:
+        d = derive_model_display("openai", "gpt-5.4-mini")
+        assert d.display_name == "GPT-5.4 Mini"
+        # GPT family is not native-thinking; o-series is.
+        assert d.supports_thinking is False
+
+    def test_o_series_supports_thinking(self) -> None:
+        d = derive_model_display("openai", "o1-mini")
+        assert d.family == "o-series"
+        assert d.supports_thinking is True
+
+    def test_nova(self) -> None:
+        d = derive_model_display("bedrock_converse", "us.amazon.nova-pro-v1:0")
+        assert d.family == "nova"
+        assert "Nova" in d.display_name
+
+    def test_ollama_unknown_falls_back_gracefully(self) -> None:
+        # The qwen prefix should yield a sensible fallback rather than crashing.
+        d = derive_model_display("ollama", "qwen3:4b")
+        assert d.spec == "ollama:qwen3:4b"
+        assert d.display_name  # non-empty
+        assert d.supports_thinking is False
+
+
+class TestSupportsNativeThinking:
+    """Catalog mirrors the SDK's `_model_supports_native_thinking` rules."""
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "claude-3-7-sonnet-20250219",
+            "claude-sonnet-4-6",
+            "claude-opus-4-7",
+            "claude-haiku-4-5",
+            "gemini-2.5-pro",
+            "gemini-3-flash-preview",
+            "o1",
+            "o3-mini",
+            "o4",
+        ],
+    )
+    def test_thinking_supported(self, model: str) -> None:
+        assert supports_native_thinking(model) is True
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "claude-3-5-sonnet-20240620",
+            "gpt-4o",
+            "gpt-5.4",
+            "gemini-1.5-pro",
+            "llama-3.3-70b",
+            "qwen3:4b",
+        ],
+    )
+    def test_thinking_not_supported(self, model: str) -> None:
+        assert supports_native_thinking(model) is False
+
+
+class TestCachedCatalog:
+    """`save_cached_catalog` + `load_cached_catalog` round-trip cleanly."""
+
+    def test_round_trip(self, tmp_path: Path) -> None:
+        cache_file = tmp_path / "models.cache.json"
+        catalog = {
+            "anthropic": ["claude-sonnet-4-6", "claude-haiku-4-5"],
+            "openai": ["gpt-5.4"],
+        }
+        assert save_cached_catalog(catalog, path=cache_file) is True
+        loaded = load_cached_catalog(path=cache_file)
+        assert loaded is not None
+        assert loaded["anthropic"] == ("claude-sonnet-4-6", "claude-haiku-4-5")
+        assert loaded["openai"] == ("gpt-5.4",)
+
+    def test_load_missing_returns_none(self, tmp_path: Path) -> None:
+        assert load_cached_catalog(path=tmp_path / "absent.json") is None
+
+    def test_load_malformed_returns_none(self, tmp_path: Path) -> None:
+        bad = tmp_path / "models.cache.json"
+        bad.write_text("not-json", encoding="utf-8")
+        assert load_cached_catalog(path=bad) is None
+
+    def test_load_wrong_version_returns_none(self, tmp_path: Path) -> None:
+        bad = tmp_path / "models.cache.json"
+        bad.write_text(
+            json.dumps({"version": 999, "ts": time.time(), "providers": {}}),
+            encoding="utf-8",
+        )
+        assert load_cached_catalog(path=bad) is None
+
+    def test_expired_cache_returns_none(self, tmp_path: Path) -> None:
+        expired = tmp_path / "models.cache.json"
+        expired.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "ts": 0,  # 1970 — definitely older than the TTL
+                    "providers": {"anthropic": ["claude-sonnet-4-6"]},
+                }
+            ),
+            encoding="utf-8",
+        )
+        assert load_cached_catalog(path=expired) is None
+
+    def test_clear_cache(self, tmp_path: Path) -> None:
+        cache_file = tmp_path / "models.cache.json"
+        save_cached_catalog({"openai": ["gpt-5"]}, path=cache_file)
+        assert cache_file.exists()
+        assert clear_cached_catalog(path=cache_file) is True
+        assert not cache_file.exists()
+        # Second clear is a no-op.
+        assert clear_cached_catalog(path=cache_file) is False
+
+
+class TestModelDisplayDataclass:
+    """Hashability + equality so the picker can use ModelDisplay as a dict key."""
+
+    def test_equality(self) -> None:
+        a = derive_model_display("anthropic", "claude-sonnet-4-6")
+        b = derive_model_display("anthropic", "claude-sonnet-4-6")
+        assert a == b
+
+    def test_is_frozen(self) -> None:
+        d = derive_model_display("anthropic", "claude-sonnet-4-6")
+        assert isinstance(d, ModelDisplay)
+        with pytest.raises(AttributeError):
+            # frozen dataclass — write attempts must raise
+            d.display_name = "tampered"  # type: ignore[misc]

--- a/libs/cli/tests/unit_tests/test_smoketest.py
+++ b/libs/cli/tests/unit_tests/test_smoketest.py
@@ -1,0 +1,141 @@
+"""Tests for `bog_agents_cli.smoketest`.
+
+Covers the error categoriser, the spec parser, and the public
+``smoketest_model`` shape. We do **not** make real network calls in
+unit tests — exceptions are injected via monkeypatched ``create_model``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bog_agents_cli import smoketest as smoketest_module
+from bog_agents_cli.smoketest import (
+    SmoketestKind,
+    SmoketestResult,
+    smoketest_model,
+)
+
+
+class TestCategorize:
+    """`_categorize` correctly maps common failure shapes."""
+
+    @pytest.mark.parametrize(
+        ("message", "expected"),
+        [
+            ("401 Unauthorized", SmoketestKind.AUTH_INVALID),
+            ("Could not load credentials", SmoketestKind.AUTH_MISSING),
+            ("Unable to locate credentials", SmoketestKind.AUTH_MISSING),
+            ("Rate limit exceeded — try again later", SmoketestKind.QUOTA),
+            ("ThrottlingException: too many requests", SmoketestKind.QUOTA),
+            ("Connection refused", SmoketestKind.NETWORK),
+            ("DNS resolution failed", SmoketestKind.NETWORK),
+            ("Model not found", SmoketestKind.MODEL_NOT_FOUND),
+            ("ValidationException: bad modelId", SmoketestKind.MODEL_NOT_FOUND),
+            ("Some weird error from outer space", SmoketestKind.UNKNOWN),
+        ],
+    )
+    def test_signal_mapping(self, message: str, expected: SmoketestKind) -> None:
+        kind, _ = smoketest_module._categorize(Exception(message))
+        assert kind is expected
+
+    def test_timeout_error_class(self) -> None:
+        kind, _ = smoketest_module._categorize(TimeoutError("timed out"))
+        assert kind is SmoketestKind.TIMEOUT
+
+    def test_import_error(self) -> None:
+        kind, _ = smoketest_module._categorize(ImportError("No module named 'foo'"))
+        assert kind is SmoketestKind.PACKAGE_MISSING
+
+
+class TestHintFor:
+    """`_hint_for` returns provider-aware action steps."""
+
+    def test_anthropic_missing_creds_mentions_env_var(self) -> None:
+        hint = smoketest_module._hint_for(SmoketestKind.AUTH_MISSING, "anthropic")
+        assert "ANTHROPIC_API_KEY" in hint
+
+    def test_bedrock_missing_creds_mentions_aws(self) -> None:
+        hint = smoketest_module._hint_for(
+            SmoketestKind.AUTH_MISSING, "bedrock_converse"
+        )
+        assert "aws" in hint.lower()
+
+    def test_bedrock_model_not_found_mentions_inference_profile(self) -> None:
+        hint = smoketest_module._hint_for(
+            SmoketestKind.MODEL_NOT_FOUND, "bedrock_converse"
+        )
+        assert "inference profile" in hint.lower()
+
+    def test_quota_hint(self) -> None:
+        hint = smoketest_module._hint_for(SmoketestKind.QUOTA, "anthropic")
+        assert "retry" in hint.lower() or "quota" in hint.lower()
+
+
+class TestSmoketestModelShape:
+    """Public entry returns a `SmoketestResult` for both happy and sad paths."""
+
+    def test_invalid_spec_returns_unknown_result(self) -> None:
+        # No provider, no detectable model — should fail gracefully.
+        result = smoketest_model("")
+        assert isinstance(result, SmoketestResult)
+        assert result.kind is SmoketestKind.UNKNOWN
+        # Should not crash, should not propagate.
+
+    def test_auth_failure_categorised(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When `create_model` raises an auth error, kind=AUTH_INVALID."""
+
+        def fake_create_model(spec: str, **_kw: object) -> object:
+            msg = "401 Unauthorized: bad api key"
+            raise RuntimeError(msg)
+
+        # Patch the *import target* — `smoketest_model` does
+        # `from bog_agents_cli.config import create_model` inside the
+        # function, so patching the source module is what matters.
+        monkeypatch.setattr("bog_agents_cli.config.create_model", fake_create_model)
+        result = smoketest_model("anthropic:claude-haiku-4-5")
+        assert result.kind is SmoketestKind.AUTH_INVALID
+        assert "ANTHROPIC_API_KEY" in result.hint or "valid" in result.hint.lower()
+        assert result.ok is False
+
+    def test_model_not_found_categorised(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def fake_create_model(spec: str, **_kw: object) -> object:
+            msg = "Model not found: claude-nonexistent"
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr("bog_agents_cli.config.create_model", fake_create_model)
+        result = smoketest_model("anthropic:claude-nonexistent")
+        assert result.kind is SmoketestKind.MODEL_NOT_FOUND
+        assert result.ok is False
+
+    def test_summary_markup_format(self) -> None:
+        result = SmoketestResult(
+            spec="anthropic:claude-haiku-4-5",
+            kind=SmoketestKind.OK,
+            elapsed_seconds=0.42,
+            message="ok",
+        )
+        markup = result.summary_markup()
+        assert "PASS" in markup
+        assert "0.4s" in markup
+
+    def test_summary_markup_failure(self) -> None:
+        result = SmoketestResult(
+            spec="anthropic:claude-haiku-4-5",
+            kind=SmoketestKind.AUTH_INVALID,
+            elapsed_seconds=0.1,
+            message="creds rejected",
+        )
+        markup = result.summary_markup()
+        assert "FAIL" in markup
+        assert "creds rejected" in markup
+
+    def test_thinking_marker_in_summary(self) -> None:
+        result = SmoketestResult(
+            spec="anthropic:claude-sonnet-4-6",
+            kind=SmoketestKind.OK,
+            elapsed_seconds=1.0,
+            message="ok",
+            thinking_used=True,
+        )
+        assert "thinking" in result.summary_markup()

--- a/libs/cli/tests/unit_tests/test_thinking_config.py
+++ b/libs/cli/tests/unit_tests/test_thinking_config.py
@@ -1,0 +1,152 @@
+"""Tests for the thinking-config resolver in `bog_agents_cli.agent`.
+
+`_resolve_thinking_config` is the bridge between the user's config.toml
+(or env vars) and the SDK's `ThinkingMiddleware`. The CLI's agent wiring
+calls it at agent-build time to decide whether to start a session with
+thinking on/off and at what budget.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest  # noqa: TC002 — runtime use via pytest.MonkeyPatch type
+
+from bog_agents_cli.agent import _resolve_thinking_config
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestResolveThinkingConfig:
+    """Env / config / default precedence."""
+
+    def test_default_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BOG_AGENTS_THINKING", raising=False)
+        monkeypatch.delenv("BOG_AGENTS_THINKING_BUDGET", raising=False)
+        enabled, budget = _resolve_thinking_config()
+        assert enabled is False
+        assert budget == 8_000
+
+    def test_env_enable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BOG_AGENTS_THINKING", "1")
+        monkeypatch.delenv("BOG_AGENTS_THINKING_BUDGET", raising=False)
+        enabled, budget = _resolve_thinking_config()
+        assert enabled is True
+        assert budget == 8_000
+
+    def test_env_disable_explicit_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BOG_AGENTS_THINKING", "false")
+        enabled, _ = _resolve_thinking_config()
+        assert enabled is False
+
+    def test_env_budget_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BOG_AGENTS_THINKING", "1")
+        monkeypatch.setenv("BOG_AGENTS_THINKING_BUDGET", "16000")
+        enabled, budget = _resolve_thinking_config()
+        assert enabled is True
+        assert budget == 16_000
+
+    def test_env_budget_clamped_to_minimum(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Budgets below 1000 should be clamped to keep providers happy.
+        monkeypatch.setenv("BOG_AGENTS_THINKING", "1")
+        monkeypatch.setenv("BOG_AGENTS_THINKING_BUDGET", "10")
+        _, budget = _resolve_thinking_config()
+        assert budget >= 1_000
+
+    def test_env_invalid_budget_falls_back_to_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("BOG_AGENTS_THINKING", "1")
+        monkeypatch.setenv("BOG_AGENTS_THINKING_BUDGET", "not-an-int")
+        _, budget = _resolve_thinking_config()
+        assert budget == 8_000
+
+    def test_config_toml_enables_thinking(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """When env vars are absent, config.toml drives the verdict."""
+        # Build a temporary config.toml with thinking_enabled for anthropic.
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            """
+[models]
+
+[models.providers.anthropic]
+api_key_env = "ANTHROPIC_API_KEY"
+
+[models.providers.anthropic.params]
+thinking_enabled = true
+thinking_budget_tokens = 12000
+""",
+            encoding="utf-8",
+        )
+
+        monkeypatch.delenv("BOG_AGENTS_THINKING", raising=False)
+        monkeypatch.delenv("BOG_AGENTS_THINKING_BUDGET", raising=False)
+        monkeypatch.setattr(
+            "bog_agents_cli.model_config.DEFAULT_CONFIG_PATH", config_path
+        )
+
+        # Settings must report the matching provider for config lookup.
+        from bog_agents_cli.config import settings
+
+        original_provider = getattr(settings, "model_provider", "")
+        try:
+            settings.model_provider = "anthropic"
+            from bog_agents_cli.model_config import clear_caches
+
+            clear_caches()
+            enabled, budget = _resolve_thinking_config()
+            assert enabled is True
+            assert budget == 12_000
+        finally:
+            settings.model_provider = original_provider
+            from bog_agents_cli.model_config import clear_caches
+
+            clear_caches()
+
+
+class TestThinkingKwargsStrippedFromModelConstructor:
+    """Middleware keys must not be forwarded to ``init_chat_model``."""
+
+    def test_thinking_keys_dropped(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            """
+[models]
+
+[models.providers.anthropic]
+api_key_env = "ANTHROPIC_API_KEY"
+
+[models.providers.anthropic.params]
+temperature = 0.7
+thinking_enabled = true
+thinking_budget_tokens = 8000
+""",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            "bog_agents_cli.model_config.DEFAULT_CONFIG_PATH", config_path
+        )
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+
+        from bog_agents_cli.config import _get_provider_kwargs
+        from bog_agents_cli.model_config import clear_caches
+
+        clear_caches()
+        try:
+            kwargs = _get_provider_kwargs("anthropic", model_name="claude-sonnet-4-6")
+        finally:
+            clear_caches()
+
+        # The non-thinking key must survive; thinking-* must be removed.
+        assert kwargs.get("temperature") == 0.7
+        assert "thinking_enabled" not in kwargs
+        assert "thinking_budget_tokens" not in kwargs


### PR DESCRIPTION
Address seven user-reported model/provider pain points in the CLI:

1. **Display names**: provider_catalog.derive_model_display() produces human-readable labels (e.g. 'Claude Sonnet 4.6 (Bedrock US)') for every provider:model combo. Picker now leads with the readable name and dims the raw API id underneath.

2. **Picker lag**: replace the per-keystroke full-DOM rebuild with a build-once + filter-in-place flow. Keystrokes are debounced 80 ms and the filter pass toggles `.display` on existing widgets instead of removing/remounting them. Search blobs (spec + display name + family + vendor) are pre-computed in __init__ so the score loop never re-derives them.

3. **Refresh**: persist the discovered catalog to ~/.bog-agents/models.cache.json (atomic write, 1-week TTL, version gate). New /refresh-models command and Ctrl+R inside the picker clear caches, re-scan installed providers, and rebuild the UI in place.

4. **Smoketest**: new /smoketest [provider:model] command and Ctrl+T keybinding in the picker. Bedrock specs delegate to the existing probe_bedrock reporter; other providers create the model and send one short prompt with a 16-token budget and 30 s timeout. All known failure shapes (auth missing/invalid, network, quota, model-not- found, package-missing, timeout) yield an actionable hint.

5. **Bedrock inference profiles**: expand the curated bedrock_converse candidate list with us./eu./apac. cross-region profile IDs for every supported Anthropic model, plus Nova / Llama4 / Mistral / DeepSeek-R1. Display labels tag profile entries with the region suffix ('… (Bedrock US)') so the picker distinguishes them from plain regional model ids. The smoketest works against profile IDs transparently.

6. **Thinking parameters**: ThinkingMiddleware is now always attached to the middleware stack but defaults to OFF. agent._resolve_thinking_config reads BOG_AGENTS_THINKING / BOG_AGENTS_THINKING_BUDGET env vars or [models.providers.<p>].params.{thinking_enabled,thinking_budget_tokens} in config.toml. _get_provider_kwargs strips the middleware-only keys so init_chat_model doesn't reject them. /think status now reports whether the active model supports native thinking. /smoketest --thinking exercises the parameter binding without expecting real reasoning output.

7. **Discoverability**: every model option in the picker carries a ✨ thinking marker when supported. The new help footer surfaces the Ctrl+S / Ctrl+T / Ctrl+R bindings.

Tests: 3431 unit tests pass (1363 SDK + 2068 CLI), all lint/format/ty checks clean. New tests cover display-name derivation, thinking-support detection, cached-catalog round-trip, smoketest error categorisation, thinking-config env+toml precedence, and that thinking_enabled is filtered out of model constructor kwargs.

Fix #72 and #75 