### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "libs/bog-agents": "0.8.6",
-  "libs/cli": "0.8.6",
-  "libs/daemon": "0.8.6"
+  "libs/bog-agents": "0.8.7",
+  "libs/cli": "0.8.7",
+  "libs/daemon": "0.8.7"
 }

--- a/libs/bog-agents/CHANGELOG.md
+++ b/libs/bog-agents/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.8.7](https://github.com/bogware/bog-agents/compare/bog-agents==0.8.6...bog-agents==0.8.7) (2026-05-16)
+
+
+### Features
+
+* dreamscape subsystem, nine killer slash commands, release-train enrichment, and reliability hardening ([#79](https://github.com/bogware/bog-agents/issues/79)) ([17a52ab](https://github.com/bogware/bog-agents/commit/17a52abcb8b20e8ebd3fdc5c2eb5f282b8e0026b))
+
 ## [0.8.6](https://github.com/bogware/bog-agents/compare/bog-agents==0.8.5...bog-agents==0.8.6) (2026-05-12)
 
 

--- a/libs/bog-agents/bog_agents/_version.py
+++ b/libs/bog-agents/bog_agents/_version.py
@@ -1,3 +1,3 @@
 """Version information for `bog-agents` (SDK)."""
 
-__version__ = "0.8.6"  # x-release-please-version
+__version__ = "0.8.7"  # x-release-please-version

--- a/libs/bog-agents/pyproject.toml
+++ b/libs/bog-agents/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bog-agents"
-version = "0.8.6"
+version = "0.8.7"
 
 description = "Bog Agents — a still-water agent framework. Patient by default, opinionated where it matters, batteries included. Build agents on top of any major LLM provider (Anthropic, OpenAI, Bedrock, Google, Mistral, Groq, DeepSeek) or run local with Ollama. 80+ middlewares, real subagents, file-system + shell + sandbox backends, MCP tooling, a typed config surface. Built on LangGraph; pass through in harmony."
 readme = "README.md"

--- a/libs/bog-agents/uv.lock
+++ b/libs/bog-agents/uv.lock
@@ -252,7 +252,7 @@ wheels = [
 
 [[package]]
 name = "bog-agents"
-version = "0.8.6"
+version = "0.8.7"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },

--- a/libs/cli/CHANGELOG.md
+++ b/libs/cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.8.7](https://github.com/bogware/bog-agents/compare/bog-agents-cli==0.8.6...bog-agents-cli==0.8.7) (2026-05-16)
+
+
+### Features
+
+* dreamscape subsystem, nine killer slash commands, release-train enrichment, and reliability hardening ([#79](https://github.com/bogware/bog-agents/issues/79)) ([17a52ab](https://github.com/bogware/bog-agents/commit/17a52abcb8b20e8ebd3fdc5c2eb5f282b8e0026b))
+
+
+### Bug Fixes
+
+* **cli:** de-flake dreamscape rate-limit test on slow Windows runners ([#81](https://github.com/bogware/bog-agents/issues/81)) ([eb14713](https://github.com/bogware/bog-agents/commit/eb14713ebba9a219fa53bddfdc5378c5a7056193))
+
 ## [0.8.6](https://github.com/bogware/bog-agents/compare/bog-agents-cli==0.8.5...bog-agents-cli==0.8.6) (2026-05-12)
 
 

--- a/libs/cli/bog_agents_cli/_version.py
+++ b/libs/cli/bog_agents_cli/_version.py
@@ -1,3 +1,3 @@
 """Version information for `bog-agents-cli`."""
 
-__version__ = "0.8.6"  # x-release-please-version
+__version__ = "0.8.7"  # x-release-please-version

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bog-agents-cli"
-version = "0.8.6"
+version = "0.8.7"
 description = "Bog Agents CLI — your coding agent in the terminal, patient as still water. 80+ slash commands, any LLM provider (Anthropic, OpenAI, Bedrock, Google, Ollama and more), persistent memory, plan mode, /qa acceptance-criteria harness, /peat personal scheduler, /record + /replay, in-memory secrets vault, MCP marketplace with 35+ servers, deep doctor, panic dumps, and a matte swamp/neon-green TUI. One install, no code required. Pass through in harmony."
 readme = "README.md"
 license = { text = "MIT" }

--- a/libs/cli/uv.lock
+++ b/libs/cli/uv.lock
@@ -317,7 +317,7 @@ wheels = [
 
 [[package]]
 name = "bog-agents"
-version = "0.8.6"
+version = "0.8.7"
 source = { editable = "../bog-agents" }
 dependencies = [
     { name = "anyio" },
@@ -416,7 +416,7 @@ test = [
 
 [[package]]
 name = "bog-agents-cli"
-version = "0.8.6"
+version = "0.8.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/libs/daemon/CHANGELOG.md
+++ b/libs/daemon/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.8.7](https://github.com/bogware/bog-agents/compare/bog-agents-daemon==0.8.6...bog-agents-daemon==0.8.7) (2026-05-16)
+
+
+### Features
+
+* dreamscape subsystem, nine killer slash commands, release-train enrichment, and reliability hardening ([#79](https://github.com/bogware/bog-agents/issues/79)) ([17a52ab](https://github.com/bogware/bog-agents/commit/17a52abcb8b20e8ebd3fdc5c2eb5f282b8e0026b))
+
 ## [0.8.6](https://github.com/bogware/bog-agents/compare/bog-agents-daemon==0.8.5...bog-agents-daemon==0.8.6) (2026-05-12)
 
 

--- a/libs/daemon/bog_agents_daemon/__init__.py
+++ b/libs/daemon/bog_agents_daemon/__init__.py
@@ -1,3 +1,3 @@
 """Bog Agents Daemon — ambient agent service."""
 
-__version__ = "0.8.6"
+__version__ = "0.8.7"

--- a/libs/daemon/pyproject.toml
+++ b/libs/daemon/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bog-agents-daemon"
-version = "0.8.6"
+version = "0.8.7"
 description = "Bog Agents Daemon — the patient watcher. Runs your bog-agents on cron schedules, file-change triggers, webhooks, and git push events; survives reboots, persists state, and reports back. Use it when you want an agent that wakes itself rather than waiting for you. Pass through in harmony."
 readme = "README.md"
 license = { text = "MIT" }

--- a/libs/daemon/uv.lock
+++ b/libs/daemon/uv.lock
@@ -274,7 +274,7 @@ wheels = [
 
 [[package]]
 name = "bog-agents"
-version = "0.8.6"
+version = "0.8.7"
 source = { editable = "../bog-agents" }
 dependencies = [
     { name = "anyio" },
@@ -373,7 +373,7 @@ test = [
 
 [[package]]
 name = "bog-agents-daemon"
-version = "0.8.6"
+version = "0.8.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
> [!CAUTION]
> Merging this PR will automatically publish to **PyPI** and create a **GitHub release**.

For the full release process, see [`.github/RELEASING.md`](https://github.com/bogware/bog-agents/blob/main/.github/RELEASING.md).

---

_Everything below this line will be the GitHub release body._

---


<details><summary>bog-agents: 0.8.7</summary>

## [0.8.7](https://github.com/bogware/bog-agents/compare/bog-agents==0.8.6...bog-agents==0.8.7) (2026-05-16)


### Features

* dreamscape subsystem, nine killer slash commands, release-train enrichment, and reliability hardening ([#79](https://github.com/bogware/bog-agents/issues/79)) ([17a52ab](https://github.com/bogware/bog-agents/commit/17a52abcb8b20e8ebd3fdc5c2eb5f282b8e0026b))
</details>

<details><summary>bog-agents-cli: 0.8.7</summary>

## [0.8.7](https://github.com/bogware/bog-agents/compare/bog-agents-cli==0.8.6...bog-agents-cli==0.8.7) (2026-05-16)


### Features

* dreamscape subsystem, nine killer slash commands, release-train enrichment, and reliability hardening ([#79](https://github.com/bogware/bog-agents/issues/79)) ([17a52ab](https://github.com/bogware/bog-agents/commit/17a52abcb8b20e8ebd3fdc5c2eb5f282b8e0026b))


### Bug Fixes

* **cli:** de-flake dreamscape rate-limit test on slow Windows runners ([#81](https://github.com/bogware/bog-agents/issues/81)) ([eb14713](https://github.com/bogware/bog-agents/commit/eb14713ebba9a219fa53bddfdc5378c5a7056193))
</details>

<details><summary>bog-agents-daemon: 0.8.7</summary>

## [0.8.7](https://github.com/bogware/bog-agents/compare/bog-agents-daemon==0.8.6...bog-agents-daemon==0.8.7) (2026-05-16)


### Features

* dreamscape subsystem, nine killer slash commands, release-train enrichment, and reliability hardening ([#79](https://github.com/bogware/bog-agents/issues/79)) ([17a52ab](https://github.com/bogware/bog-agents/commit/17a52abcb8b20e8ebd3fdc5c2eb5f282b8e0026b))
</details>

---

_Everything above this line will be the GitHub release body._
