### PR TITLE
feat(sdk,cli): Bedrock seamless — auto inference-profile resolver, /bedrock fix + config, auto SSO refresh, docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,12 @@ examples wherever possible.
 | [Tool bundles](sdk/tool-bundles.md) | The W4 alternative to "middleware that only ships tools" |
 | [Backends](sdk/backends.md) | Filesystem, shell, sandbox; safe defaults explained |
 
+## Providers
+
+| | |
+|---|---|
+| [AWS Bedrock](providers/bedrock.md) | Inference profiles, model access, six-step probe, `/bedrock fix` |
+
 ## Daemon (`bog-agents-daemon`)
 
 | | |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,6 +31,10 @@ export GOOGLE_API_KEY=AI...           # Gemini
 # or: GROQ_API_KEY, MISTRAL_API_KEY, DEEPSEEK_API_KEY, ...
 ```
 
+For Bedrock — the AWS-hosted path — see the dedicated walkthrough at
+**[providers/bedrock.md](providers/bedrock.md)**. Inference profiles,
+model access, the six-step probe.
+
 Running with no key launches an interactive setup wizard. Running in
 a non-TTY context (CI, daemon, piped stdin) with no key gives you an
 actionable error pointing at the env vars above — no hangs.

--- a/docs/providers/bedrock.md
+++ b/docs/providers/bedrock.md
@@ -1,0 +1,221 @@
+# AWS Bedrock — end-to-end setup
+
+> Bedrock is the AWS-hosted way to run Claude, Nova, Llama, Mistral,
+> and DeepSeek behind your AWS account's IAM. It's the right choice
+> when compliance, data residency, or an existing AWS footprint
+> matter more than the absolute latest features.
+>
+> It is also the provider most likely to bite a new user. This page
+> takes you from zero to a working `/model bedrock_converse:...` call.
+
+## What you need before you start
+
+- An AWS account with IAM permissions for Bedrock.
+- An AWS region where the models you want are actually available.
+  US-East-1 (N. Virginia) and US-West-2 (Oregon) have the broadest
+  coverage. EU-West-3 (Paris) and AP-Northeast-1 (Tokyo) carry the
+  Claude profile family but not every variant.
+- A credential method. Pick one — they're listed below in
+  decreasing order of "easy and works on a laptop":
+  1. **`aws configure`** — writes long-lived keys to `~/.aws/credentials`. Fine for solo work.
+  2. **`aws sso login`** — refresh-token via your org's SSO. The right default for teams.
+  3. **EC2 / ECS instance role** — auto-detected. Nothing to do if you're already on AWS infra.
+  4. **Static env vars** — `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN` (the last when via STS).
+
+## Install the AWS extra
+
+```bash
+pip install --upgrade 'bog-agents-cli[bedrock]'
+```
+
+This pulls `langchain-aws` and `boto3` alongside the base CLI. If
+you're using the SDK directly:
+
+```bash
+pip install --upgrade 'bog-agents[bedrock]'
+```
+
+## Inference profiles — the thing that bites everyone
+
+Claude 4.x on Bedrock **requires** a cross-region inference profile
+prefix:
+
+| Region you call from | Prefix | Example model id |
+|---|---|---|
+| us-east-1 / us-west-2 / ca-central-1 | `us.` | `us.anthropic.claude-opus-4-7` |
+| eu-west-1 / eu-central-1 / eu-west-3 | `eu.` | `eu.anthropic.claude-sonnet-4-6` |
+| ap-southeast-1 / ap-southeast-2 | `apac.` | `apac.anthropic.claude-haiku-4-5-20251001-v1:0` |
+| ap-northeast-1 (Tokyo) | `jp.` | `jp.anthropic.claude-opus-4-7` |
+| sa-east-1 | `sa.` | `sa.anthropic.claude-sonnet-4-6` |
+
+The bare id `anthropic.claude-opus-4-7` returns `AccessDeniedException`
+even when you have model access granted. AWS retired on-demand
+throughput for the Claude 4.x line; cross-region profiles are now
+the only path.
+
+bog-agents auto-rewrites bare → prefixed based on `AWS_REGION` at
+agent-creation time, with a `WARNING` log so the rewrite is visible
+in `--debug`. The model picker only lists the prefixed ids, so
+clicking through never hits the trap. Set the prefix explicitly to
+silence the rewrite log.
+
+## The 30-second setup
+
+```bash
+# 1. credentials
+aws configure
+# or: aws sso login
+
+# 2. region
+export AWS_REGION=us-east-1
+
+# 3. install the extra (if you haven't)
+pip install --upgrade 'bog-agents-cli[bedrock]'
+
+# 4. confirm AWS can see your account
+aws sts get-caller-identity
+
+# 5. probe Bedrock specifically (six-step check)
+bog-agents test-bedrock
+
+# 6. start the TUI and pick a model
+bog-agents
+# then: /model bedrock_converse:us.anthropic.claude-opus-4-7
+```
+
+If step 5 prints `[OK]` on every line you're done. If anything is
+red, jump to **Fixing what breaks** below.
+
+## Granting model access in the Bedrock console
+
+This trips up everyone the first time. AWS requires explicit
+per-region opt-in for every foundation model.
+
+1. Open <https://console.aws.amazon.com/bedrock/>.
+2. Top-right region selector → switch to the region you'll call from.
+3. Left sidebar → **Model access**.
+4. Click **Modify model access**.
+5. Tick the models you want. For Claude pick **all variants** so the
+   inference-profile family resolves cleanly.
+6. **Submit**. Wait ~1 minute for the grant to propagate.
+
+Re-run `bog-agents test-bedrock` after the grant lands.
+
+## Inside the TUI
+
+Once your environment is set up:
+
+- **`/model`** opens the picker. Bedrock entries show **`Bedrock US/EU/APAC`** suffixes for the inference-profile family. Press **Ctrl+T** with a Bedrock model highlighted to run the deep 6-step probe right inside the picker.
+- **`/bedrock test`** runs the probe from the chat surface and prints a per-step pass/fail report.
+- **`/bedrock fix`** runs the probe and turns each failure into a numbered copy-paste command (set region, `aws sso login`, open the model-access console, etc.). Use this when something's broken and you want the shortest path back.
+- **`/bedrock config`** shows the active settings (auth mode, AWS profile, region, the path to `config.toml`) and an example `[models.providers.bedrock_converse]` block you can paste in.
+- **`/bedrock status`** is an alias for `/bedrock test`.
+
+## Config file
+
+bog-agents reads `~/.bog-agents/config.toml`. The Bedrock-relevant
+keys:
+
+```toml
+[models.providers.bedrock_converse]
+auth_mode   = "auto"        # auto | iam | profile | sso | env
+aws_profile = "my-profile"  # only honored when auth_mode = "profile"
+```
+
+`auto` walks the boto3 credential chain in the natural order
+(env → AWS_PROFILE → SSO → instance role). Pin to a specific mode
+only when you have multiple credential sources and want
+deterministic resolution.
+
+Environment-variable equivalents (override the file):
+
+```bash
+export BOG_AGENTS_BEDROCK_AUTH_MODE=sso
+export BOG_AGENTS_BEDROCK_PROFILE=my-team-sso
+export AWS_REGION=us-east-1
+```
+
+## Auth modes — when to use which
+
+| Mode | When |
+|---|---|
+| `auto` | Default. Walks the boto3 credential chain. Right for ~95% of users. |
+| `iam` | Force the env-var chain (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`). Use when you want to ignore profiles. |
+| `profile` | Pin to a named profile from `~/.aws/credentials`. Pair with `aws_profile = "..."`. |
+| `sso` | Force SSO refresh. If your SSO token is expired, this fails fast instead of falling back. |
+| `env` | Static env vars only. Useful in CI. |
+
+## Fixing what breaks
+
+Run `bog-agents test-bedrock` (or `/bedrock fix` in the TUI) — the
+output points you at the right fix for every common failure. Below
+is the same recipe in narrative form.
+
+### `AccessDeniedException` on a Claude 4.x model
+
+You either don't have model access, or you used the bare id instead
+of the inference profile.
+
+```bash
+# Check the model-access console:
+#   https://console.aws.amazon.com/bedrock/  →  Model access
+# Then switch the id in /model:
+/model bedrock_converse:us.anthropic.claude-opus-4-7
+```
+
+### `ValidationException` — invalid model identifier
+
+Almost always wrong region or wrong prefix. The probe step
+**ListModels** prints the model ids your account can actually
+invoke in the current region.
+
+```bash
+bog-agents test-bedrock --model us.anthropic.claude-opus-4-7
+```
+
+### `ExpiredTokenException` — SSO refresh
+
+```bash
+aws sso login
+```
+
+### `Could not connect to the endpoint`
+
+Corp firewall, VPN, or proxy. Try:
+
+```bash
+curl -v https://bedrock-runtime.us-east-1.amazonaws.com
+# If that fails:
+export HTTPS_PROXY=http://your-corp-proxy:8080
+```
+
+### `ThrottlingException`
+
+You hit the on-demand quota. Options:
+
+- Wait — the `provider_retry` middleware backs off automatically.
+- Request a quota bump under **Service Quotas → Amazon Bedrock**.
+- Switch models — the throttle is per-model per-region.
+
+## Verifying it all works
+
+A minimal end-to-end smoke test from the SDK:
+
+```python
+from bog_agents import create_agent
+
+agent = create_agent("bedrock_converse:us.anthropic.claude-sonnet-4-6")
+result = agent.invoke({"messages": [{"role": "user", "content": "Say only OK."}]})
+print(result["messages"][-1].content)
+# OK
+```
+
+If that prints `OK` (or anything close), the wiring is correct and
+the rest of bog-agents will work as expected — middleware, tool
+calls, sub-agents, all of it.
+
+## Related
+
+- [Getting started](../getting-started.md) — full first-run setup, all providers.
+- [Troubleshooting](../troubleshooting.md) — non-Bedrock issues.
+- [Security](../security.md) — secrets handling, IAM minimums.

--- a/docs/providers/bedrock.md
+++ b/docs/providers/bedrock.md
@@ -175,9 +175,32 @@ bog-agents test-bedrock --model us.anthropic.claude-opus-4-7
 
 ### `ExpiredTokenException` — SSO refresh
 
+In interactive mode (TTY), bog-agents detects this and runs `aws sso
+login` for you automatically. A browser tab opens; approve; the model
+call retries once. The session is capped at three auto-refreshes; past
+that, the categorized error banner takes over so you can investigate.
+
+In headless mode (`bog-agents -p`, CI, the daemon), no subprocess
+spawns — the actionable banner goes to stderr and the call fails fast
+so the caller can decide what to do:
+
 ```bash
 aws sso login
 ```
+
+Disable auto-refresh entirely via the SDK by omitting
+`BedrockRefreshMiddleware` from your middleware list.
+
+### `bedrock` vs `bedrock_converse` — which to use
+
+| | `bedrock:` | `bedrock_converse:` |
+|---|---|---|
+| AWS API | InvokeModel (legacy) | Converse (recommended) |
+| Tool calling | Per-vendor formats | Unified schema |
+| Multimodal | Inconsistent | First-class |
+| What to pick | Only for a few legacy Cohere variants without Converse adapters | Everything else |
+
+Use `bedrock_converse:` unless you have a specific reason not to.
 
 ### `Could not connect to the endpoint`
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -88,6 +88,10 @@ aws sts get-caller-identity   # confirms credentials work
 The CLI uses boto3's credential chain (env vars, profile, SSO,
 instance role). Anything boto3 finds, bog-agents finds.
 
+For anything beyond credentials — model access, inference profiles,
+region selection, the SSO/static fallback chain — see the dedicated
+walkthrough at **[providers/bedrock.md](providers/bedrock.md)**.
+
 ### "MCP server `foo` did not start in 15s — disabled"
 
 A stdio MCP server (typically `npx -y something`) didn't initialize

--- a/libs/bog-agents/bog_agents/_models.py
+++ b/libs/bog-agents/bog_agents/_models.py
@@ -46,6 +46,124 @@ def _resolve_model_read_timeout() -> float | None:
     return value
 
 
+# ---------------------------------------------------------------------------
+# Bedrock inference-profile auto-resolver
+# ---------------------------------------------------------------------------
+#
+# Anthropic Claude 4.x on AWS Bedrock requires a cross-region inference
+# profile prefix (`us.`, `eu.`, `apac.`, ...). The bare model id
+# `anthropic.claude-opus-4-7` returns `AccessDeniedException` even when
+# the account has model access granted in the console — AWS treats the
+# bare id as a request for on-demand throughput, which has been deprecated
+# for the Claude 4.x line.
+#
+# The auto-resolver below rewrites a bare `anthropic.*` id to the correct
+# regional prefix based on `AWS_REGION` / `AWS_DEFAULT_REGION` so users
+# who paste the platform.claude.com name into their config still land
+# on a working model. A warning is logged so the rewrite is visible in
+# `--debug` output and the user can switch to the explicit form.
+
+_BEDROCK_REGION_PROFILE_MAP: dict[str, str] = {
+    # US / Canada → us. profiles (work from us-east-1, us-east-2, us-west-2,
+    # ca-central-1).
+    "us": "us",
+    "ca": "us",
+    # Europe → eu. profiles (eu-west-1, eu-west-3, eu-central-1, eu-north-1).
+    "eu": "eu",
+    # Asia-Pacific → apac., with Japan as a separate `jp.` family.
+    "ap-northeast-1": "jp",  # Tokyo
+    "ap": "apac",
+    # South America → sa. (sa-east-1).
+    "sa": "sa",
+}
+
+
+def _resolve_bedrock_region_prefix(region: str | None) -> str:
+    """Map an AWS region to the matching inference-profile prefix.
+
+    Falls back to ``us`` when the region is missing or unknown — `us.` profiles
+    are available in the most regions and are the safest default.
+
+    Args:
+        region: AWS region string like ``us-east-1`` or ``None``.
+
+    Returns:
+        The profile prefix without the trailing dot (e.g. ``"us"``).
+    """
+    if not region:
+        return "us"
+    region = region.lower().strip()
+    # Try most specific first (full region match).
+    if region in _BEDROCK_REGION_PROFILE_MAP:
+        return _BEDROCK_REGION_PROFILE_MAP[region]
+    # Then the geo prefix (first segment before the first dash).
+    geo = region.split("-", 1)[0]
+    return _BEDROCK_REGION_PROFILE_MAP.get(geo, "us")
+
+
+_BEDROCK_PROFILE_PREFIXES: tuple[str, ...] = (
+    "us.",
+    "eu.",
+    "apac.",
+    "jp.",
+    "sa.",
+    "global.",
+)
+"""Recognised cross-region inference profile prefixes."""
+
+
+def _normalize_bedrock_model_id(model: str) -> str:
+    """Rewrite a bare Anthropic Claude Bedrock id to a regional profile id.
+
+    Only applies when:
+    1. The spec uses the ``bedrock:`` or ``bedrock_converse:`` provider.
+    2. The model id starts with ``anthropic.`` (bare, no regional prefix).
+    3. The model id matches Claude 4.x / 4.5+ (the family that requires
+       inference profiles on Bedrock).
+
+    All other inputs are returned unchanged. Logs the rewrite at WARNING
+    level so it's visible in `--debug` output.
+
+    Args:
+        model: Full spec like ``bedrock_converse:anthropic.claude-opus-4-7``.
+
+    Returns:
+        Possibly-rewritten spec.
+    """
+    if not model.startswith(("bedrock:", "bedrock_converse:")):
+        return model
+    provider, _, model_id = model.partition(":")
+    if not model_id:
+        return model
+    # Already has a regional / global profile prefix — nothing to do.
+    if model_id.lower().startswith(_BEDROCK_PROFILE_PREFIXES):
+        return model
+    # Only rewrite Anthropic Claude 4.x / 4.5+ family — those are the
+    # ones AWS gates behind inference profiles. Nova/Llama/Mistral
+    # bare ids still work for on-demand throughput.
+    if not model_id.lower().startswith("anthropic.claude-"):
+        return model
+    # Coarse Claude-4-or-newer check: matches `claude-opus-4-*`,
+    # `claude-sonnet-4-*`, `claude-haiku-4-*`, `claude-opus-5-*` (future).
+    # Older `claude-3-*` IDs still work bare on Bedrock and are left alone.
+    lowered = model_id.lower()
+    is_modern = any(f"claude-{variant}-{major}" in lowered for variant in ("opus", "sonnet", "haiku") for major in ("4", "5", "6", "7", "8", "9"))
+    if not is_modern:
+        return model
+    region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
+    prefix = _resolve_bedrock_region_prefix(region)
+    rewritten = f"{provider}:{prefix}.{model_id}"
+    logger.warning(
+        "Bedrock: rewrote bare Claude id %r to %r (AWS_REGION=%s). "
+        "Claude 4.x on Bedrock requires a cross-region inference profile; "
+        "pass the explicit form to silence this warning.",
+        model,
+        rewritten,
+        region or "<unset>",
+    )
+    return rewritten
+
+
 def _bedrock_config_kwarg(timeout_secs: float | None) -> dict[str, Any]:
     """Build a `config=` kwarg for a Bedrock-flavored chat model.
 
@@ -119,6 +237,7 @@ def resolve_model(model: str | BaseChatModel) -> BaseChatModel:
     """
     if isinstance(model, BaseChatModel):
         return model
+    model = _normalize_bedrock_model_id(model)
     timeout_secs = _resolve_model_read_timeout()
     kwargs = _model_init_kwargs(model, timeout_secs)
     try:

--- a/libs/bog-agents/tests/unit_tests/test_models.py
+++ b/libs/bog-agents/tests/unit_tests/test_models.py
@@ -2,9 +2,12 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from langchain_core.language_models import BaseChatModel
 
 from bog_agents._models import (
+    _normalize_bedrock_model_id,
+    _resolve_bedrock_region_prefix,
     _string_value,
     get_model_identifier,
     model_matches_spec,
@@ -133,3 +136,103 @@ class TestStringValue:
 
     def test_non_string(self) -> None:
         assert _string_value({"key": 42}, "key") is None
+
+
+class TestBedrockRegionPrefix:
+    """Tests for _resolve_bedrock_region_prefix."""
+
+    @pytest.mark.parametrize(
+        ("region", "expected"),
+        [
+            ("us-east-1", "us"),
+            ("us-east-2", "us"),
+            ("us-west-2", "us"),
+            ("ca-central-1", "us"),
+            ("eu-west-1", "eu"),
+            ("eu-central-1", "eu"),
+            ("ap-northeast-1", "jp"),
+            ("ap-northeast-2", "apac"),
+            ("ap-southeast-1", "apac"),
+            ("ap-southeast-2", "apac"),
+            ("sa-east-1", "sa"),
+            ("US-EAST-1", "us"),
+            ("", "us"),
+            (None, "us"),
+            ("af-south-1", "us"),
+        ],
+    )
+    def test_region_to_prefix(self, region: str | None, expected: str) -> None:
+        assert _resolve_bedrock_region_prefix(region) == expected
+
+
+class TestNormalizeBedrockModelId:
+    """Tests for _normalize_bedrock_model_id (the AccessDenied trap fix)."""
+
+    def test_non_bedrock_spec_unchanged(self) -> None:
+        assert _normalize_bedrock_model_id("anthropic:claude-opus-4-7") == "anthropic:claude-opus-4-7"
+
+    def test_bedrock_already_prefixed_unchanged(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
+        spec = "bedrock_converse:us.anthropic.claude-opus-4-7"
+        assert _normalize_bedrock_model_id(spec) == spec
+
+    def test_bedrock_nova_unchanged(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Nova works bare on Bedrock — must not be rewritten.
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
+        spec = "bedrock_converse:amazon.nova-pro-v1:0"
+        assert _normalize_bedrock_model_id(spec) == spec
+
+    def test_bedrock_llama_unchanged(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
+        spec = "bedrock_converse:meta.llama4-scout-17b-instruct-v1:0"
+        assert _normalize_bedrock_model_id(spec) == spec
+
+    def test_claude_3_unchanged(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Older Claude 3 IDs still accept on-demand throughput — leave them alone.
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
+        spec = "bedrock_converse:anthropic.claude-3-5-sonnet-20241022-v2:0"
+        assert _normalize_bedrock_model_id(spec) == spec
+
+    def test_claude_4_us_region_rewritten(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
+        assert _normalize_bedrock_model_id("bedrock_converse:anthropic.claude-opus-4-7") == "bedrock_converse:us.anthropic.claude-opus-4-7"
+
+    def test_claude_4_eu_region_rewritten(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AWS_REGION", "eu-west-1")
+        assert _normalize_bedrock_model_id("bedrock_converse:anthropic.claude-sonnet-4-6") == "bedrock_converse:eu.anthropic.claude-sonnet-4-6"
+
+    def test_claude_4_japan_rewritten(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AWS_REGION", "ap-northeast-1")
+        assert _normalize_bedrock_model_id("bedrock_converse:anthropic.claude-opus-4-7") == "bedrock_converse:jp.anthropic.claude-opus-4-7"
+
+    def test_claude_4_apac_rewritten(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AWS_REGION", "ap-southeast-2")
+        assert (
+            _normalize_bedrock_model_id("bedrock_converse:anthropic.claude-haiku-4-5-20251001-v1:0")
+            == "bedrock_converse:apac.anthropic.claude-haiku-4-5-20251001-v1:0"
+        )
+
+    def test_no_region_falls_back_to_us(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AWS_REGION", raising=False)
+        monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+        assert _normalize_bedrock_model_id("bedrock_converse:anthropic.claude-opus-4-7") == "bedrock_converse:us.anthropic.claude-opus-4-7"
+
+    def test_aws_default_region_honored(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AWS_REGION", raising=False)
+        monkeypatch.setenv("AWS_DEFAULT_REGION", "eu-central-1")
+        assert _normalize_bedrock_model_id("bedrock_converse:anthropic.claude-opus-4-7") == "bedrock_converse:eu.anthropic.claude-opus-4-7"
+
+    def test_legacy_bedrock_provider_also_rewritten(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The legacy `bedrock:` (InvokeModel) provider needs the same fix.
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
+        assert _normalize_bedrock_model_id("bedrock:anthropic.claude-opus-4-7") == "bedrock:us.anthropic.claude-opus-4-7"
+
+    def test_resolve_model_applies_rewrite(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """End-to-end: resolve_model() passes the rewritten id to init_chat_model."""
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
+        with patch("bog_agents._models.init_chat_model") as mock:
+            mock.return_value = MagicMock(spec=BaseChatModel)
+            resolve_model("bedrock_converse:anthropic.claude-opus-4-7")
+        # First positional arg is the rewritten spec.
+        call_args = mock.call_args
+        assert call_args.args[0] == "bedrock_converse:us.anthropic.claude-opus-4-7"

--- a/libs/cli/bog_agents_cli/_bedrock.py
+++ b/libs/cli/bog_agents_cli/_bedrock.py
@@ -643,6 +643,192 @@ def iter_probe_lines(steps: list[ProbeStep]) -> Iterator[str]:
     yield from render_probe_report(steps).splitlines()
 
 
+# ---------------------------------------------------------------------------
+# /bedrock fix — turn each probe failure into a copy-paste command
+# ---------------------------------------------------------------------------
+
+# Maps each BedrockErrorKind to (one-line headline, command(s) the user
+# can copy-paste). The commands are intentionally minimal — the goal is
+# "press Ctrl+C, run this, try again" rather than a 6-step recipe. The
+# bedrock URLs and CLI commands are stable enough that hardcoding them
+# is fine; if AWS reorganises a console URL we update one constant.
+_FIX_ACTIONS: dict[BedrockErrorKind, tuple[str, tuple[str, ...]]] = {
+    BedrockErrorKind.PACKAGE_MISSING: (
+        "Install the AWS extra.",
+        ("pip install --upgrade 'bog-agents-cli[bedrock]'",),
+    ),
+    BedrockErrorKind.CREDENTIALS_MISSING: (
+        "Set up AWS credentials (pick the one that matches your account).",
+        (
+            "aws configure                  # long-lived keys",
+            "aws sso login                  # AWS SSO",
+            "export AWS_ACCESS_KEY_ID=...   # one-shot env vars",
+            "export AWS_SECRET_ACCESS_KEY=...",
+        ),
+    ),
+    BedrockErrorKind.CREDENTIALS_EXPIRED: (
+        "Refresh your AWS session.",
+        (
+            "aws sso login                  # if SSO",
+            "# or re-export AWS_SESSION_TOKEN with a fresh value",
+        ),
+    ),
+    BedrockErrorKind.REGION_INVALID: (
+        "Set an AWS region (Bedrock requires one).",
+        (
+            "export AWS_REGION=us-east-1    # or your target region",
+            "# or: aws configure set region us-east-1",
+        ),
+    ),
+    BedrockErrorKind.MODEL_ACCESS_DENIED: (
+        "Request model access in the Bedrock console (per region).",
+        (
+            "# 1. open https://console.aws.amazon.com/bedrock/",
+            "# 2. switch to your target region (top-right)",
+            "# 3. left sidebar → 'Model access' → 'Modify model access'",
+            "# 4. tick the model(s), submit, wait ~1 minute",
+        ),
+    ),
+    BedrockErrorKind.MODEL_ID_INVALID: (
+        "The model id was rejected — try the cross-region inference profile id.",
+        (
+            "# Claude 4.x on Bedrock requires a prefix: us. / eu. / apac.",
+            "/model bedrock_converse:us.anthropic.claude-opus-4-7",
+            "# or list what your account can invoke:",
+            "bog-agents test-bedrock",
+        ),
+    ),
+    BedrockErrorKind.THROTTLED: (
+        "Bedrock is throttling — retry, switch model, or request a quota bump.",
+        (
+            "# Service Quotas → Amazon Bedrock → request increase",
+            "# https://console.aws.amazon.com/servicequotas/home/services/bedrock/",
+        ),
+    ),
+    BedrockErrorKind.NETWORK: (
+        "Network or TLS error — check connectivity and system clock.",
+        (
+            "curl -v https://bedrock-runtime.us-east-1.amazonaws.com",
+            "# if behind a corp proxy: export HTTPS_PROXY=http://proxy.corp:8080",
+        ),
+    ),
+    BedrockErrorKind.UNKNOWN: (
+        "Unrecognised error — capture the raw message and open an issue.",
+        ("bog-agents test-bedrock        # structured probe with verbose output",),
+    ),
+}
+
+
+def render_settings_report() -> str:
+    """Render a human-readable view of the active Bedrock configuration.
+
+    Surfaces the effective auth mode, AWS profile, region, and the
+    config file path so a user can see at a glance what's wired up
+    before they call `/bedrock test`. Renders an example ``config.toml``
+    block at the bottom so a user can copy-paste the minimum settings
+    they need to change.
+
+    Returns:
+        Multi-line report.
+    """
+    # Lazy imports to keep _bedrock importable in envs where the heavier
+    # model_config module isn't ready (e.g. unit tests for fix_report).
+    try:
+        from bog_agents_cli.model_config import (
+            DEFAULT_CONFIG_PATH,
+            _bedrock_auth_mode,
+        )
+    except ImportError:
+        return "Bedrock settings unavailable (model_config import failed)."
+
+    try:
+        mode, profile = _bedrock_auth_mode()
+    except Exception as exc:  # diagnostic only
+        return f"Bedrock settings: error reading config — {exc}"
+
+    region = (
+        os.environ.get("AWS_REGION")
+        or os.environ.get("AWS_DEFAULT_REGION")
+        or "<unset>"
+    )
+    aws_profile_env = os.environ.get("AWS_PROFILE", "<unset>")
+    config_path = DEFAULT_CONFIG_PATH
+
+    lines = [
+        "",
+        "Bedrock settings",
+        "=" * 40,
+        f"  auth_mode      : {mode}",
+        f"  aws_profile    : {profile or '<unset>'}",
+        f"  AWS_PROFILE env: {aws_profile_env}",
+        f"  region         : {region}",
+        f"  config file    : {config_path}",
+        "",
+        "To change, edit the config file above and add:",
+        "",
+        "  [models.providers.bedrock_converse]",
+        '  auth_mode   = "auto"        # auto | iam | profile | sso | env',
+        '  aws_profile = "my-profile"  # only when auth_mode = profile',
+        "",
+        "Or set the equivalent env vars:",
+        "",
+        "  export BOG_AGENTS_BEDROCK_AUTH_MODE=sso",
+        "  export BOG_AGENTS_BEDROCK_PROFILE=my-profile",
+        "  export AWS_REGION=us-east-1",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def render_fix_report(steps: list[ProbeStep]) -> str:
+    """Render probe failures as a list of copy-paste actions.
+
+    Sister to :func:`render_probe_report`, but optimised for the "I'm
+    stuck, what do I run next?" path. Successful steps are summarised in
+    one line; each failure gets a numbered block with a headline and
+    one or more shell commands the user can copy verbatim.
+
+    Args:
+        steps: Probe steps from :func:`probe_bedrock`.
+
+    Returns:
+        Multi-line report with shell-ready commands. When no failures
+        occurred, returns a short "All clear" block instead.
+    """
+    failures = [s for s in steps if not s.ok and s.error is not None]
+    if not failures:
+        return (
+            "\n"
+            "Bedrock /bedrock fix\n"
+            "=" * 40 + "\n"
+            "All probe steps passed — no action needed.\n"
+            f"Steps OK: {', '.join(s.name for s in steps if s.ok)}\n"
+        )
+
+    lines: list[str] = ["", "Bedrock /bedrock fix", "=" * 40, ""]
+    # Brief summary line up top so the user knows the scope.
+    ok_names = [s.name for s in steps if s.ok]
+    if ok_names:
+        lines.append(f"OK: {', '.join(ok_names)}")
+    lines.append(f"Failed: {', '.join(s.name for s in failures)}")
+    lines.append("")
+    for idx, step in enumerate(failures, start=1):
+        err = step.error
+        if err is None:  # defensive — already filtered above
+            continue
+        headline, commands = _FIX_ACTIONS.get(
+            err.kind,
+            _FIX_ACTIONS[BedrockErrorKind.UNKNOWN],
+        )
+        lines.append(f"[{idx}] {step.name} — {err.title}")
+        lines.append(f"    {headline}")
+        for cmd in commands:
+            lines.append(f"      {cmd}")
+        lines.append("")
+    lines.append("After the fix, re-run /bedrock test (or press Ctrl+T in /model).")
+    return "\n".join(lines)
+
+
 __all__ = [
     "BedrockError",
     "BedrockErrorKind",
@@ -650,5 +836,7 @@ __all__ = [
     "categorize_bedrock_error",
     "iter_probe_lines",
     "probe_bedrock",
+    "render_fix_report",
     "render_probe_report",
+    "render_settings_report",
 ]

--- a/libs/cli/bog_agents_cli/agent.py
+++ b/libs/cli/bog_agents_cli/agent.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import shutil
+import sys
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -1681,6 +1682,18 @@ def create_cli_agent(
     from bog_agents.middleware.notifications import NotificationsMiddleware
 
     agent_middleware.append(NotificationsMiddleware())
+
+    # Bedrock credential auto-refresh — only attached when a Bedrock
+    # model is in use, to keep the middleware list lean for everyone
+    # else. Detects ExpiredTokenException / SSOTokenLoadError on model
+    # calls and runs `aws sso login` to refresh, then retries. See
+    # docs/providers/bedrock.md and bog_agents_cli.bedrock_refresh.
+    if isinstance(model, str) and model.startswith(("bedrock:", "bedrock_converse:")):
+        from bog_agents_cli.bedrock_refresh import BedrockRefreshMiddleware
+
+        agent_middleware.append(
+            BedrockRefreshMiddleware(interactive=sys.stdin.isatty())
+        )
 
     # Create the agent
     agent = create_agent(

--- a/libs/cli/bog_agents_cli/app.py
+++ b/libs/cli/bog_agents_cli/app.py
@@ -3742,25 +3742,37 @@ class BogAgentsApp(App):
         user wants a structured diagnosis instead of a one-line
         ``RuntimeError`` from the welcome banner.
         """
-        from bog_agents_cli._bedrock import probe_bedrock, render_probe_report
+        from bog_agents_cli._bedrock import (
+            probe_bedrock,
+            render_fix_report,
+            render_probe_report,
+            render_settings_report,
+        )
 
         await self._mount_message(UserMessage(command))
 
-        # Optional: ``/bedrock test <model_id>`` lets the user pin the
-        # inference probe to a specific model id. Bare ``/bedrock`` or
-        # ``/bedrock test`` runs steps 1-5 (no inference).
+        # Subcommand parsing — the picker shows these via SlashCommandSpec.
+        # ``test`` / ``status`` → probe + render_probe_report
+        # ``fix``               → probe + render_fix_report (numbered actions)
+        # ``config``            → render_settings_report (no probe)
         raw_arg = command.strip()[len("/bedrock") :].strip()
-        # Drop a leading ``test`` / ``status`` keyword so users can write
-        # either ``/bedrock test`` or ``/bedrock test <model-id>``.
-        for prefix in ("test", "status"):
+        mode = "test"
+        for prefix in ("test", "status", "fix", "config"):
             if raw_arg.lower().startswith(prefix):
+                mode = prefix
                 raw_arg = raw_arg[len(prefix) :].strip()
                 break
+        if mode == "config":
+            # No probe — just print the resolved settings.
+            await self._mount_message(AppMessage(render_settings_report()))
+            return
         model_id = raw_arg or None
         # Probe runs synchronously (boto3 is sync); offload to a thread
         # so the TUI's event loop stays responsive.
         steps = await asyncio.to_thread(probe_bedrock, model_id, None)
-        report = render_probe_report(steps)
+        report = (
+            render_fix_report(steps) if mode == "fix" else render_probe_report(steps)
+        )
         await self._mount_message(AppMessage(report))
 
     async def _handle_review_command(self, command: str) -> None:

--- a/libs/cli/bog_agents_cli/bedrock_refresh.py
+++ b/libs/cli/bog_agents_cli/bedrock_refresh.py
@@ -1,0 +1,335 @@
+"""Auto-refresh middleware for expired Bedrock credentials.
+
+The motivating user complaint: "if bedrock is selected and it fails, it
+should try to login/refresh/help the user refresh/login, it shouldnt just
+fail — we need resiliency."
+
+This middleware sits in front of Bedrock model calls and catches the
+``CREDENTIALS_EXPIRED`` shape (``ExpiredTokenException`` /
+``SSOTokenLoadError`` / ``UnauthorizedSSOTokenError``). On a hit it
+attempts to refresh the local credentials cache:
+
+- **SSO mode (or `auto` resolved to SSO)** — spawn ``aws sso login``
+  as a subprocess. AWS opens a browser tab for the OAuth approval; we
+  block until the subprocess exits, then retry the model call once.
+- **Profile mode** — reload the profile section from
+  ``~/.aws/credentials`` / ``~/.aws/config``. Boto3's profile-based
+  refresh handles ``role_arn`` chains automatically when present.
+- **Static / IAM modes** — we cannot safely re-derive STS tokens
+  without knowing the upstream tool (aws-vault, Granted, Vault, the
+  user's CI). Surface the categorized ``BedrockError`` so the user
+  sees the exact next step and the failure mode is loud, not silent.
+
+Budget: one refresh per failed call, three refreshes per Python
+process. After three, further failures bypass the refresh path —
+something is wrong with the SSO configuration and looping won't
+unbreak it.
+
+Non-interactive mode: ``interactive=False`` (the default in `bog-agents
+-p` and the daemon) prints the actionable error banner to stderr and
+re-raises without spawning a subprocess. Headless callers see the
+same fix command they would have seen pre-Wave-4, just with a clearer
+signal at the right layer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shutil
+import subprocess  # noqa: S404 — only used for `aws sso login`, never user input
+import sys
+from typing import TYPE_CHECKING, Any
+
+from langchain.agents.middleware.types import AgentMiddleware
+
+from bog_agents_cli._bedrock import (
+    BedrockErrorKind,
+    categorize_bedrock_error,
+)
+
+if TYPE_CHECKING:
+    from langchain.agents.middleware.types import ModelRequest, ModelResponse
+
+logger = logging.getLogger(__name__)
+
+
+# Session-wide counters. Module-level so they persist across middleware
+# instances within a single Python process. A fresh `bog-agents`
+# invocation gets a fresh budget.
+_SESSION_REFRESH_COUNT: int = 0
+_USER_PROMPTED_THIS_SESSION: bool = False
+_DEFAULT_MAX_REFRESHES_PER_SESSION: int = 3
+
+
+def _reset_session_state_for_tests() -> None:
+    """Test-only: reset the module-level counters between cases.
+
+    Pytest doesn't isolate module state across tests, so test files
+    that exercise the refresh budget must call this in setup/teardown.
+    """
+    global _SESSION_REFRESH_COUNT, _USER_PROMPTED_THIS_SESSION  # noqa: PLW0603
+    _SESSION_REFRESH_COUNT = 0
+    _USER_PROMPTED_THIS_SESSION = False
+
+
+def _can_run_aws_cli() -> bool:
+    """Return True when the `aws` CLI is on PATH.
+
+    The refresh path needs ``aws sso login``; without the CLI we can
+    only surface the actionable error.
+    """
+    return shutil.which("aws") is not None
+
+
+def _resolved_profile() -> str:
+    """Return the AWS profile name that ``aws sso login`` should target.
+
+    Precedence: ``BOG_AGENTS_BEDROCK_PROFILE`` > ``AWS_PROFILE`` >
+    ``"default"``. Returning the empty string would make ``aws sso
+    login`` operate on the implicit default profile, which is fine but
+    less self-documenting in logs.
+    """
+    return (
+        os.environ.get("BOG_AGENTS_BEDROCK_PROFILE")
+        or os.environ.get("AWS_PROFILE")
+        or "default"
+    )
+
+
+def _attempt_sso_login(profile: str, *, timeout_s: float = 120.0) -> bool:
+    """Spawn ``aws sso login --profile <profile>`` and wait for it to exit.
+
+    Returns:
+        True when the subprocess exits 0 (browser approval completed
+        and credentials were cached). False on timeout, non-zero exit,
+        missing CLI, or any other failure.
+    """
+    if not _can_run_aws_cli():
+        logger.warning(
+            "bedrock_refresh: cannot run 'aws sso login' — `aws` CLI not on PATH"
+        )
+        return False
+    cmd = ["aws", "sso", "login", "--profile", profile]
+    logger.info("bedrock_refresh: running %s", " ".join(cmd))
+    try:
+        # subprocess.run with timeout — `aws sso login` blocks until the
+        # user approves in the browser. 2 minutes is enough for the
+        # average human; users with slow networks can re-run manually.
+        result = subprocess.run(  # noqa: S603 — argv is a fixed list, no shell, no user-injected args
+            cmd,
+            check=False,
+            timeout=timeout_s,
+            text=True,
+            capture_output=False,  # let the user see the browser prompt
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning("bedrock_refresh: aws sso login timed out after %ss", timeout_s)
+        return False
+    except (OSError, ValueError) as exc:
+        logger.warning("bedrock_refresh: aws sso login launch failed (%s)", exc)
+        return False
+    if result.returncode != 0:
+        logger.warning(
+            "bedrock_refresh: aws sso login exited %d for profile=%s",
+            result.returncode,
+            profile,
+        )
+        return False
+    return True
+
+
+def _print_refresh_banner_to_stderr(profile: str) -> None:
+    """Write a copy-paste fix to stderr when we won't auto-refresh.
+
+    Used by:
+      - Headless / non-interactive callers (where spawning a browser
+        would hang).
+      - First-time interactive use, so the user sees what's about to
+        happen before we spawn the subprocess.
+    """
+    banner = (
+        "\n"
+        + "=" * 70
+        + "\n"
+        + "BEDROCK: SSO credentials expired\n"
+        + "=" * 70
+        + "\n"
+        + f"  Run: aws sso login --profile {profile}\n"
+        + "  Or:  export AWS_PROFILE=<your-profile>; aws sso login\n"
+        + "  Or:  re-export AWS_SESSION_TOKEN with a fresh value\n"
+        + "=" * 70
+        + "\n"
+    )
+    print(banner, file=sys.stderr, flush=True)  # noqa: T201 — intentional banner
+
+
+class BedrockRefreshMiddleware(AgentMiddleware[Any, Any, Any]):
+    """Catches expired-credential failures on Bedrock and retries once.
+
+    Use::
+
+        from bog_agents_cli.bedrock_refresh import BedrockRefreshMiddleware
+
+        agent = create_agent(
+            model="bedrock_converse:us.anthropic.claude-opus-4-7",
+            middleware=[BedrockRefreshMiddleware(interactive=True)],
+        )
+
+    The CLI wires this in automatically when a Bedrock model is in
+    use; SDK callers opt in by adding the middleware to their list.
+
+    Args:
+        interactive: When True (default for TTY callers), spawn
+            ``aws sso login`` on a credential-expired hit. When False
+            (headless / `bog-agents -p`), print the fix to stderr and
+            re-raise without spawning a subprocess.
+        max_refreshes_per_session: Hard cap on refresh attempts across
+            the lifetime of this process. Default 3.
+    """
+
+    def __init__(
+        self,
+        *,
+        interactive: bool = True,
+        max_refreshes_per_session: int = _DEFAULT_MAX_REFRESHES_PER_SESSION,
+    ) -> None:
+        super().__init__()
+        self._interactive = interactive
+        self._max_refreshes = max(0, int(max_refreshes_per_session))
+
+    async def awrap_model_call(  # type: ignore[override]
+        self,
+        request: ModelRequest,
+        call_next: Any,  # noqa: ANN401 — langchain middleware contract
+        runtime: Any,  # noqa: ANN401 — langchain middleware contract
+    ) -> ModelResponse:
+        """Async wrap — catch expired creds, refresh, retry once.
+
+        Raises:
+            KeyboardInterrupt: Propagated unchanged.
+            SystemExit: Propagated unchanged.
+            asyncio.CancelledError: Propagated unchanged.
+        """
+        try:
+            return await call_next(request, runtime)
+        except (KeyboardInterrupt, SystemExit, asyncio.CancelledError):
+            raise
+        except BaseException as exc:
+            if not self._should_attempt_refresh(exc):
+                raise
+            refreshed = await asyncio.to_thread(self._refresh_credentials)
+            if not refreshed:
+                raise
+            logger.info("bedrock_refresh: SSO refreshed, retrying model call")
+            return await call_next(request, runtime)
+
+    def wrap_model_call(  # type: ignore[override]
+        self,
+        request: ModelRequest,
+        call_next: Any,  # noqa: ANN401 — langchain middleware contract
+        runtime: Any,  # noqa: ANN401 — langchain middleware contract
+    ) -> ModelResponse:
+        """Sync wrap — catch expired creds, refresh, retry once.
+
+        Raises:
+            KeyboardInterrupt: Propagated unchanged.
+            SystemExit: Propagated unchanged.
+        """
+        try:
+            return call_next(request, runtime)
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except BaseException as exc:
+            if not self._should_attempt_refresh(exc):
+                raise
+            if not self._refresh_credentials():
+                raise
+            logger.info("bedrock_refresh: SSO refreshed, retrying model call (sync)")
+            return call_next(request, runtime)
+
+    @staticmethod
+    def _should_attempt_refresh(exc: BaseException) -> bool:
+        """True when the exception is a Bedrock CREDENTIALS_EXPIRED hit.
+
+        Falls back to safe (no-refresh) when the error doesn't look
+        like a Bedrock-credentials problem — we don't want to spawn
+        `aws sso login` for a generic 5xx.
+        """
+        # Cheap shape check first to avoid running the full categoriser
+        # on unrelated errors.
+        type_name = type(exc).__name__
+        bedrock_shaped = (
+            type_name
+            in {
+                "ExpiredTokenException",
+                "SSOTokenLoadError",
+                "UnauthorizedSSOTokenError",
+                "TokenRetrievalError",
+                "ClientError",
+                "NoCredentialsError",
+            }
+            or "expired" in str(exc).lower()
+        )
+        if not bedrock_shaped:
+            return False
+        try:
+            err = categorize_bedrock_error(exc)
+        except Exception:  # diagnostic — never mask the original error
+            return False
+        return err.kind == BedrockErrorKind.CREDENTIALS_EXPIRED
+
+    def _refresh_credentials(self) -> bool:
+        """Attempt one credential refresh. Returns success.
+
+        Honors the session budget, prints first-time hint, runs the
+        subprocess in interactive mode only, updates module counters.
+        """
+        global _SESSION_REFRESH_COUNT, _USER_PROMPTED_THIS_SESSION  # noqa: PLW0603
+
+        if _SESSION_REFRESH_COUNT >= self._max_refreshes:  # noqa: SIM300 — natural ordering for budget check
+            logger.warning(
+                "bedrock_refresh: session budget exhausted "
+                "(%d/%d) — not attempting refresh",
+                _SESSION_REFRESH_COUNT,
+                self._max_refreshes,
+            )
+            return False
+
+        profile = _resolved_profile()
+
+        if not self._interactive:
+            # Headless: print the fix and re-raise. No subprocess.
+            _print_refresh_banner_to_stderr(profile)
+            return False
+
+        # First refresh of the session: show the banner so the user
+        # sees what's about to happen before a browser tab pops up.
+        if not _USER_PROMPTED_THIS_SESSION:
+            _print_refresh_banner_to_stderr(profile)
+            _USER_PROMPTED_THIS_SESSION = True
+
+        ok = _attempt_sso_login(profile)
+        _SESSION_REFRESH_COUNT += 1
+        if ok:
+            logger.info(
+                "bedrock_refresh: refresh #%d succeeded for profile=%s",
+                _SESSION_REFRESH_COUNT,
+                profile,
+            )
+        else:
+            logger.warning(
+                "bedrock_refresh: refresh #%d FAILED for profile=%s",
+                _SESSION_REFRESH_COUNT,
+                profile,
+            )
+        return ok
+
+
+__all__ = [
+    "BedrockRefreshMiddleware",
+    "_attempt_sso_login",
+    "_reset_session_state_for_tests",
+    "_resolved_profile",
+]

--- a/libs/cli/bog_agents_cli/commands/config.py
+++ b/libs/cli/bog_agents_cli/commands/config.py
@@ -36,6 +36,14 @@ COMMANDS: tuple[SlashCommand, ...] = (
             subcommands=(
                 ("test", "Run the Bedrock connection probe"),
                 ("status", "Same as `test` — quick view of credentials + region"),
+                (
+                    "fix",
+                    "Probe + show one copy-paste command per failure (set region, sso login, request model access, …)",
+                ),
+                (
+                    "config",
+                    "Show active Bedrock settings (auth mode, profile, region, config path)",
+                ),
             ),
         ),
         handler_method="_handle_bedrock_command",

--- a/libs/cli/bog_agents_cli/provider_catalog.py
+++ b/libs/cli/bog_agents_cli/provider_catalog.py
@@ -82,41 +82,18 @@ DEFAULT_MODEL_CANDIDATES: Mapping[str, tuple[str, ...]] = MappingProxyType(
             "gpt-5",
         ),
         "bedrock": (
-            # AWS Bedrock model IDs as of 2026-04-30. The us.* / eu.* /
-            # apac.* prefixes are cross-region inference profile IDs;
-            # use those when calling from a region that supports them.
-            # Anthropic (latest first)
-            "us.anthropic.claude-opus-4-7",
-            "anthropic.claude-opus-4-7",
-            "us.anthropic.claude-sonnet-4-6",
-            "anthropic.claude-sonnet-4-6",
-            "us.anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
-            "us.anthropic.claude-opus-4-6-v1",
-            "anthropic.claude-opus-4-6-v1",
-            "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "us.anthropic.claude-opus-4-5-20251101-v1:0",
-            "anthropic.claude-opus-4-5-20251101-v1:0",
-            "us.anthropic.claude-opus-4-1-20250805-v1:0",
-            "anthropic.claude-opus-4-1-20250805-v1:0",
-            # Amazon Nova
-            "us.amazon.nova-premier-v1:0",
-            "us.amazon.nova-pro-v1:0",
-            "us.amazon.nova-lite-v1:0",
-            "us.amazon.nova-micro-v1:0",
-            # Meta Llama 4 + 3.3
-            "us.meta.llama4-maverick-17b-instruct-v1:0",
-            "us.meta.llama4-scout-17b-instruct-v1:0",
-            "us.meta.llama3-3-70b-instruct-v1:0",
-            # Mistral
-            "us.mistral.mistral-large-3-2411-v1:0",
-            "us.mistral.pixtral-large-2502-v1:0",
-        ),
-        # bedrock_converse is the modern wrapper; recommends the same IDs.
-        "bedrock_converse": (
-            # Cross-region inference profile IDs (preferred — higher quota,
-            # on-demand throughput is being deprecated for newer Anthropic models).
+            # AWS Bedrock model IDs, refreshed 2026-05-19.
+            #
+            # Anthropic Claude 4.x on Bedrock REQUIRES a cross-region
+            # inference profile prefix (us./eu./apac./...); the bare
+            # `anthropic.claude-opus-4-7` IDs return AccessDenied even
+            # when the account has model access granted. The auto-
+            # resolver in `bog_agents._models` rewrites bare→regional
+            # based on AWS_REGION as a safety net, but the catalog lists
+            # the regional profile IDs directly so the picker surfaces
+            # them as first-class entries. See docs/providers/bedrock.md.
+            #
+            # ─── ANTHROPIC CLAUDE (inference profiles required) ─────
             "us.anthropic.claude-opus-4-7",
             "eu.anthropic.claude-opus-4-7",
             "apac.anthropic.claude-opus-4-7",
@@ -126,26 +103,51 @@ DEFAULT_MODEL_CANDIDATES: Mapping[str, tuple[str, ...]] = MappingProxyType(
             "us.anthropic.claude-haiku-4-5-20251001-v1:0",
             "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
             "apac.anthropic.claude-haiku-4-5-20251001-v1:0",
-            "us.anthropic.claude-opus-4-6-v1",
             "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
             "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
             "us.anthropic.claude-opus-4-1-20250805-v1:0",
-            # Base IDs (work in single-region calls without an inference profile).
-            "anthropic.claude-opus-4-7",
-            "anthropic.claude-sonnet-4-6",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
-            # Amazon Nova
+            # ─── AMAZON NOVA ─────────────────────────────────────────
             "us.amazon.nova-premier-v1:0",
             "us.amazon.nova-pro-v1:0",
             "us.amazon.nova-lite-v1:0",
             "us.amazon.nova-micro-v1:0",
-            # Meta / Mistral / DeepSeek
+            # ─── META LLAMA ──────────────────────────────────────────
             "us.meta.llama4-maverick-17b-instruct-v1:0",
             "us.meta.llama4-scout-17b-instruct-v1:0",
             "us.meta.llama3-3-70b-instruct-v1:0",
+            # ─── MISTRAL ─────────────────────────────────────────────
             "us.mistral.mistral-large-3-2411-v1:0",
             "us.mistral.pixtral-large-2502-v1:0",
+        ),
+        # bedrock_converse is the modern Converse API wrapper. Same model
+        # IDs as bedrock (above) plus DeepSeek which is converse-only.
+        "bedrock_converse": (
+            # ─── ANTHROPIC CLAUDE (inference profiles required) ─────
+            "us.anthropic.claude-opus-4-7",
+            "eu.anthropic.claude-opus-4-7",
+            "apac.anthropic.claude-opus-4-7",
+            "us.anthropic.claude-sonnet-4-6",
+            "eu.anthropic.claude-sonnet-4-6",
+            "apac.anthropic.claude-sonnet-4-6",
+            "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
+            "apac.anthropic.claude-haiku-4-5-20251001-v1:0",
+            "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            "us.anthropic.claude-opus-4-1-20250805-v1:0",
+            # ─── AMAZON NOVA ─────────────────────────────────────────
+            "us.amazon.nova-premier-v1:0",
+            "us.amazon.nova-pro-v1:0",
+            "us.amazon.nova-lite-v1:0",
+            "us.amazon.nova-micro-v1:0",
+            # ─── META LLAMA ──────────────────────────────────────────
+            "us.meta.llama4-maverick-17b-instruct-v1:0",
+            "us.meta.llama4-scout-17b-instruct-v1:0",
+            "us.meta.llama3-3-70b-instruct-v1:0",
+            # ─── MISTRAL ─────────────────────────────────────────────
+            "us.mistral.mistral-large-3-2411-v1:0",
+            "us.mistral.pixtral-large-2502-v1:0",
+            # ─── DEEPSEEK (converse-only) ────────────────────────────
             "us.deepseek.deepseek-r1-v1:0",
         ),
         "google_genai": (

--- a/libs/cli/bog_agents_cli/widgets/model_selector.py
+++ b/libs/cli/bog_agents_cli/widgets/model_selector.py
@@ -37,6 +37,14 @@ from bog_agents_cli.provider_catalog import (
 logger = logging.getLogger(__name__)
 
 
+# Tracks which Bedrock model specs have been probed in this process. The
+# picker uses this to switch the Ctrl+T hint between "press to test" and
+# "tested this session" so users see the diagnostic state at a glance
+# without having to remember whether they already ran the probe. Cleared
+# on process restart — a fresh `bog-agents` invocation gets fresh hints.
+_BEDROCK_PROBED_SPECS: set[str] = set()
+
+
 class ModelOption(Static):
     """A clickable model option in the selector."""
 
@@ -814,6 +822,25 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         except Exception:  # Resilient footer rendering
             logger.debug("Failed to format footer for %s", spec, exc_info=True)
             text = "[dim]Could not load profile details[/dim]\n\n\n"
+        # Bedrock-specific hint: surface the deep probe affordance so the
+        # 6-step diagnostic ([Package, Credentials, Region, Identity,
+        # ListModels, Inference]) is one keystroke away when the user has
+        # a Bedrock model highlighted. The Ctrl+T binding is also in the
+        # bottom help bar; this line makes it obvious where it leads.
+        if spec.startswith(("bedrock:", "bedrock_converse:")):
+            if spec in _BEDROCK_PROBED_SPECS:
+                hint = (
+                    "[bold cyan]Bedrock[/bold cyan] [dim]·[/dim]"
+                    " [green]✓[/green] tested this session"
+                    " [dim](Ctrl+T to re-run)[/dim]"
+                )
+            else:
+                hint = (
+                    "[bold cyan]Bedrock[/bold cyan] [dim]·[/dim] press"
+                    " [bold]Ctrl+T[/bold] to run the 6-step probe"
+                    " [dim](creds → region → identity → access → inference)[/dim]"
+                )
+            text = f"{text}\n{hint}"
         footer.update(text)
 
     def _move_selection(self, delta: int) -> None:
@@ -1094,6 +1121,12 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
 
             result = await asyncio.to_thread(smoketest_model, model_spec)
             help_widget.update(result.summary_markup())
+            # Record that this Bedrock spec has been probed in this
+            # session so the next focus on the same model shows the
+            # ✓-tested hint instead of the press-to-test hint.
+            if model_spec.startswith(("bedrock:", "bedrock_converse:")):
+                _BEDROCK_PROBED_SPECS.add(model_spec)
+                self._update_footer()
         except Exception as exc:
             logger.warning("Smoketest failed for %s", model_spec, exc_info=True)
             help_widget.update(f"[bold red]Smoketest crashed: {exc}[/bold red]")

--- a/libs/cli/tests/unit_tests/test_bedrock.py
+++ b/libs/cli/tests/unit_tests/test_bedrock.py
@@ -2,15 +2,20 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
-import pytest
+if TYPE_CHECKING:
+    import pytest
 
 from bog_agents_cli._bedrock import (
     BedrockErrorKind,
+    ProbeStep,
     categorize_bedrock_error,
     probe_bedrock,
+    render_fix_report,
     render_probe_report,
+    render_settings_report,
 )
 
 
@@ -115,8 +120,6 @@ class TestProbeBedrock:
 
     def test_render_report_lists_each_step(self) -> None:
         """The renderer produces a recognisable header + per-step rows."""
-        from bog_agents_cli._bedrock import ProbeStep
-
         steps = [
             ProbeStep(name="Package", ok=True, detail="boto3 available"),
             ProbeStep(
@@ -137,3 +140,144 @@ class TestProbeBedrock:
         # Failure section must include the actionable hint.
         assert "Failure details" in report
         assert "aws configure" in report.lower()
+
+
+class TestRenderFixReport:
+    """``render_fix_report`` produces copy-paste actions, not banners."""
+
+    def test_all_ok_short_circuits(self) -> None:
+        steps = [
+            ProbeStep(name="Package", ok=True, detail="boto3 available"),
+            ProbeStep(name="Credentials", ok=True, detail="env"),
+            ProbeStep(name="Region", ok=True, detail="us-east-1"),
+        ]
+        report = render_fix_report(steps)
+        assert "All probe steps passed" in report
+        assert "no action needed" in report.lower()
+
+    def test_missing_credentials_emits_aws_configure(self) -> None:
+        steps = [
+            ProbeStep(name="Package", ok=True, detail="boto3 available"),
+            ProbeStep(
+                name="Credentials",
+                ok=False,
+                detail="None found",
+                error=categorize_bedrock_error(
+                    Exception("Unable to locate credentials")
+                ),
+            ),
+        ]
+        report = render_fix_report(steps)
+        # Numbered failure block.
+        assert "[1] Credentials" in report
+        # Concrete command, not a paragraph.
+        assert "aws configure" in report
+        assert "aws sso login" in report
+        # Tail invitation to re-run.
+        assert "Ctrl+T" in report or "/bedrock test" in report
+
+    def test_model_access_denied_emits_console_link(self) -> None:
+        steps = [
+            ProbeStep(
+                name="Inference",
+                ok=False,
+                detail="converse() failed",
+                error=categorize_bedrock_error(
+                    Exception(
+                        "An error occurred (AccessDeniedException): "
+                        "You don't have access to the model"
+                    )
+                ),
+            ),
+        ]
+        report = render_fix_report(steps)
+        assert "console.aws.amazon.com/bedrock" in report
+        assert "Model access" in report or "model access" in report.lower()
+
+    def test_region_invalid_emits_export(self) -> None:
+        steps = [
+            ProbeStep(
+                name="Region",
+                ok=False,
+                detail="No region",
+                error=categorize_bedrock_error(Exception("You must specify a region")),
+            ),
+        ]
+        report = render_fix_report(steps)
+        assert "AWS_REGION" in report
+        assert "us-east-1" in report
+
+    def test_validation_emits_inference_profile_hint(self) -> None:
+        steps = [
+            ProbeStep(
+                name="Inference",
+                ok=False,
+                detail="converse() failed",
+                error=categorize_bedrock_error(
+                    Exception(
+                        "An error occurred (ValidationException): "
+                        "The provided model identifier is invalid"
+                    )
+                ),
+            ),
+        ]
+        report = render_fix_report(steps)
+        # The fix should steer them to the inference-profile-prefixed id.
+        assert "us." in report
+        assert "claude" in report.lower()
+
+    def test_multiple_failures_numbered_independently(self) -> None:
+        steps = [
+            ProbeStep(name="Package", ok=True, detail="boto3 available"),
+            ProbeStep(
+                name="Credentials",
+                ok=False,
+                detail="None",
+                error=categorize_bedrock_error(
+                    Exception("Unable to locate credentials")
+                ),
+            ),
+            ProbeStep(
+                name="Region",
+                ok=False,
+                detail="None",
+                error=categorize_bedrock_error(Exception("You must specify a region")),
+            ),
+        ]
+        report = render_fix_report(steps)
+        assert "[1]" in report
+        assert "[2]" in report
+        assert report.index("[1]") < report.index("[2]")
+
+
+class TestRenderSettingsReport:
+    """``render_settings_report`` surfaces the active Bedrock config."""
+
+    def test_default_auth_mode_visible(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BOG_AGENTS_BEDROCK_AUTH_MODE", raising=False)
+        monkeypatch.delenv("BOG_AGENTS_BEDROCK_PROFILE", raising=False)
+        monkeypatch.delenv("AWS_REGION", raising=False)
+        monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+        monkeypatch.delenv("AWS_PROFILE", raising=False)
+        report = render_settings_report()
+        assert "Bedrock settings" in report
+        assert "auth_mode" in report
+        # Default auth mode when nothing configured is "auto".
+        assert "auto" in report
+        assert "<unset>" in report  # region / profile
+
+    def test_env_overrides_visible(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BOG_AGENTS_BEDROCK_AUTH_MODE", "sso")
+        monkeypatch.setenv("BOG_AGENTS_BEDROCK_PROFILE", "my-team-sso")
+        monkeypatch.setenv("AWS_REGION", "eu-west-1")
+        report = render_settings_report()
+        assert "sso" in report
+        assert "my-team-sso" in report
+        assert "eu-west-1" in report
+
+    def test_includes_toml_example_block(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        report = render_settings_report()
+        assert "[models.providers.bedrock_converse]" in report
+        assert "auth_mode" in report
+        # Env-var alternatives are also shown.
+        assert "BOG_AGENTS_BEDROCK_AUTH_MODE" in report

--- a/libs/cli/tests/unit_tests/test_bedrock_auth.py
+++ b/libs/cli/tests/unit_tests/test_bedrock_auth.py
@@ -1,0 +1,189 @@
+"""Tests for the Bedrock credential-detection + auth-mode chain.
+
+These were uncovered until the Bedrock-seamless wave — the SSO →
+static-creds fallback and the env-vs-config-vs-default precedence
+for ``_bedrock_auth_mode`` had no regression guards.
+
+All mocks. No live AWS calls.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from bog_agents_cli.model_config import (
+    _bedrock_auth_mode,
+    _check_bedrock_boto3,
+    _check_bedrock_files,
+)
+
+
+def _clear_aws_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip every AWS-related env var so each test starts from zero."""
+    for var in (
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "AWS_PROFILE",
+        "AWS_WEB_IDENTITY_TOKEN_FILE",
+        "AWS_REGION",
+        "AWS_DEFAULT_REGION",
+        "BOG_AGENTS_BEDROCK_AUTH_MODE",
+        "BOG_AGENTS_BEDROCK_PROFILE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+class TestCheckBedrockFiles:
+    """``_check_bedrock_files`` — fast existence check, no boto3."""
+
+    def test_no_creds_anywhere(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _clear_aws_env(monkeypatch)
+        # Point Path.home() at a fresh temp dir so ~/.aws/credentials
+        # doesn't leak in from the developer's real home.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        assert _check_bedrock_files() is False
+
+    def test_env_access_key_detected(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _clear_aws_env(monkeypatch)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIA...")
+        assert _check_bedrock_files() is True
+
+    def test_aws_profile_detected(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _clear_aws_env(monkeypatch)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("AWS_PROFILE", "my-profile")
+        assert _check_bedrock_files() is True
+
+    def test_credentials_file_detected(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _clear_aws_env(monkeypatch)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        aws_dir = tmp_path / ".aws"
+        aws_dir.mkdir()
+        (aws_dir / "credentials").write_text("[default]\n", encoding="utf-8")
+        assert _check_bedrock_files() is True
+
+    def test_sso_cache_detected(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _clear_aws_env(monkeypatch)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        sso_cache = tmp_path / ".aws" / "sso" / "cache"
+        sso_cache.mkdir(parents=True)
+        (sso_cache / "abc.json").write_text("{}", encoding="utf-8")
+        assert _check_bedrock_files() is True
+
+    def test_web_identity_token_detected(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # EKS / GitHub Actions OIDC path.
+        _clear_aws_env(monkeypatch)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("AWS_WEB_IDENTITY_TOKEN_FILE", str(tmp_path / "token.jwt"))
+        assert _check_bedrock_files() is True
+
+
+class TestCheckBedrockBoto3:
+    """``_check_bedrock_boto3`` — delegate to boto3.Session.get_credentials."""
+
+    def test_creds_found(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Mock boto3.Session to return a session whose get_credentials
+        # returns a non-None Credentials placeholder.
+        class _FakeCreds:
+            pass
+
+        class _FakeSession:
+            def get_credentials(self) -> object:
+                return _FakeCreds()
+
+        fake_boto3 = type("FakeBoto3", (), {"Session": _FakeSession})()
+        with patch.dict("sys.modules", {"boto3": fake_boto3}):
+            assert _check_bedrock_boto3() is True
+
+    def test_no_creds(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class _FakeSession:
+            def get_credentials(self) -> None:
+                return None
+
+        fake_boto3 = type("FakeBoto3", (), {"Session": _FakeSession})()
+        with patch.dict("sys.modules", {"boto3": fake_boto3}):
+            assert _check_bedrock_boto3() is False
+
+    def test_session_raises_returns_false(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class _FakeSession:
+            def get_credentials(self) -> None:
+                raise RuntimeError("expired")
+
+        fake_boto3 = type("FakeBoto3", (), {"Session": _FakeSession})()
+        with patch.dict("sys.modules", {"boto3": fake_boto3}):
+            assert _check_bedrock_boto3() is False
+
+
+class TestBedrockAuthMode:
+    """``_bedrock_auth_mode`` precedence: env > config > default."""
+
+    def test_env_overrides_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _clear_aws_env(monkeypatch)
+        monkeypatch.setenv("BOG_AGENTS_BEDROCK_AUTH_MODE", "sso")
+        mode, _ = _bedrock_auth_mode()
+        assert mode == "sso"
+
+    def test_env_profile_overrides_aws_profile(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _clear_aws_env(monkeypatch)
+        monkeypatch.setenv("AWS_PROFILE", "default-aws-profile")
+        monkeypatch.setenv("BOG_AGENTS_BEDROCK_PROFILE", "bog-team")
+        _, profile = _bedrock_auth_mode()
+        assert profile == "bog-team"
+
+    def test_aws_profile_fallback_when_no_bog_override(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _clear_aws_env(monkeypatch)
+        monkeypatch.setenv("AWS_PROFILE", "my-aws-prof")
+        _, profile = _bedrock_auth_mode()
+        assert profile == "my-aws-prof"
+
+    def test_default_is_auto(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _clear_aws_env(monkeypatch)
+        mode, profile = _bedrock_auth_mode()
+        assert mode == "auto"
+        assert profile == ""
+
+    def test_unknown_mode_falls_back_to_auto(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _clear_aws_env(monkeypatch)
+        monkeypatch.setenv("BOG_AGENTS_BEDROCK_AUTH_MODE", "telepathy")
+        mode, _ = _bedrock_auth_mode()
+        assert mode == "auto"
+
+    @pytest.mark.parametrize("valid", ["auto", "sso", "static", "profile", "iam"])
+    def test_all_valid_modes_pass_through(
+        self, monkeypatch: pytest.MonkeyPatch, valid: str
+    ) -> None:
+        _clear_aws_env(monkeypatch)
+        monkeypatch.setenv("BOG_AGENTS_BEDROCK_AUTH_MODE", valid)
+        mode, _ = _bedrock_auth_mode()
+        assert mode == valid
+
+    def test_env_mode_is_case_normalised(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _clear_aws_env(monkeypatch)
+        monkeypatch.setenv("BOG_AGENTS_BEDROCK_AUTH_MODE", "  SSO  ")
+        mode, _ = _bedrock_auth_mode()
+        assert mode == "sso"

--- a/libs/cli/tests/unit_tests/test_bedrock_refresh.py
+++ b/libs/cli/tests/unit_tests/test_bedrock_refresh.py
@@ -1,0 +1,274 @@
+"""Tests for the Bedrock credential auto-refresh middleware (Wave 4)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bog_agents_cli.bedrock_refresh import (
+    BedrockRefreshMiddleware,
+    _attempt_sso_login,
+    _reset_session_state_for_tests,
+    _resolved_profile,
+)
+
+
+class _ExpiredTokenException(Exception):  # noqa: N818 — boto3 names its real class this way; mimic that
+    """Stand-in for the boto exception class — avoids importing boto in tests."""
+
+
+@pytest.fixture(autouse=True)
+def _clean_session() -> None:
+    """Reset module-level counters between tests."""
+    _reset_session_state_for_tests()
+    yield
+    _reset_session_state_for_tests()
+
+
+class TestResolvedProfile:
+    """Profile resolution honors the documented precedence."""
+
+    def test_bog_profile_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AWS_PROFILE", "shared-aws")
+        monkeypatch.setenv("BOG_AGENTS_BEDROCK_PROFILE", "bog-only")
+        assert _resolved_profile() == "bog-only"
+
+    def test_aws_profile_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BOG_AGENTS_BEDROCK_PROFILE", raising=False)
+        monkeypatch.setenv("AWS_PROFILE", "shared-aws")
+        assert _resolved_profile() == "shared-aws"
+
+    def test_default_when_nothing_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BOG_AGENTS_BEDROCK_PROFILE", raising=False)
+        monkeypatch.delenv("AWS_PROFILE", raising=False)
+        assert _resolved_profile() == "default"
+
+
+class TestAttemptSsoLogin:
+    """``_attempt_sso_login`` runs the right command + reports success."""
+
+    def test_runs_aws_sso_login_with_profile(self) -> None:
+        with patch(
+            "bog_agents_cli.bedrock_refresh.shutil.which", return_value="/usr/bin/aws"
+        ):
+            with patch("bog_agents_cli.bedrock_refresh.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                ok = _attempt_sso_login("my-profile")
+        assert ok is True
+        # Argv must contain the profile we passed.
+        args = mock_run.call_args.args[0]
+        assert args[:3] == ["aws", "sso", "login"]
+        assert "--profile" in args
+        assert args[args.index("--profile") + 1] == "my-profile"
+
+    def test_returns_false_when_aws_cli_missing(self) -> None:
+        with patch("bog_agents_cli.bedrock_refresh.shutil.which", return_value=None):
+            assert _attempt_sso_login("anything") is False
+
+    def test_returns_false_on_non_zero_exit(self) -> None:
+        with patch(
+            "bog_agents_cli.bedrock_refresh.shutil.which", return_value="/usr/bin/aws"
+        ):
+            with patch("bog_agents_cli.bedrock_refresh.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=1)
+                assert _attempt_sso_login("p") is False
+
+    def test_returns_false_on_timeout(self) -> None:
+        import subprocess as _subprocess
+
+        with patch(
+            "bog_agents_cli.bedrock_refresh.shutil.which", return_value="/usr/bin/aws"
+        ):
+            with patch("bog_agents_cli.bedrock_refresh.subprocess.run") as mock_run:
+                mock_run.side_effect = _subprocess.TimeoutExpired(
+                    cmd="aws", timeout=120
+                )
+                assert _attempt_sso_login("p") is False
+
+
+class TestRefreshHits:
+    """``_should_attempt_refresh`` classifies the right errors."""
+
+    def test_expired_token_triggers_refresh(self) -> None:
+        mw = BedrockRefreshMiddleware()
+        exc = Exception("The security token included in the request is expired")
+        assert mw._should_attempt_refresh(exc) is True
+
+    def test_generic_5xx_does_not_trigger(self) -> None:
+        mw = BedrockRefreshMiddleware()
+        exc = RuntimeError("InternalServerError: 500")
+        assert mw._should_attempt_refresh(exc) is False
+
+    def test_missing_creds_does_not_trigger(self) -> None:
+        # Missing creds is a different category — print the banner via
+        # the normal error path, don't try to refresh.
+        mw = BedrockRefreshMiddleware()
+        exc = Exception("Unable to locate credentials")
+        assert mw._should_attempt_refresh(exc) is False
+
+    def test_access_denied_does_not_trigger(self) -> None:
+        mw = BedrockRefreshMiddleware()
+        exc = Exception("An error occurred (AccessDeniedException)")
+        assert mw._should_attempt_refresh(exc) is False
+
+
+class TestRefreshFlow:
+    """End-to-end refresh + retry, with subprocess mocked."""
+
+    def test_sync_path_refreshes_and_retries(self) -> None:
+        mw = BedrockRefreshMiddleware(interactive=True)
+        call_next = MagicMock(
+            side_effect=[
+                Exception("ExpiredTokenException: token is expired"),
+                "RECOVERED",
+            ]
+        )
+        with patch(
+            "bog_agents_cli.bedrock_refresh._attempt_sso_login", return_value=True
+        ):
+            result = mw.wrap_model_call(
+                request=MagicMock(), call_next=call_next, runtime=MagicMock()
+            )
+        assert result == "RECOVERED"
+        assert call_next.call_count == 2
+
+    def test_sync_path_no_refresh_when_subprocess_fails(self) -> None:
+        mw = BedrockRefreshMiddleware(interactive=True)
+        original = Exception("ExpiredTokenException: token is expired")
+        call_next = MagicMock(side_effect=original)
+        with patch(
+            "bog_agents_cli.bedrock_refresh._attempt_sso_login", return_value=False
+        ):
+            with pytest.raises(Exception, match="ExpiredTokenException"):
+                mw.wrap_model_call(
+                    request=MagicMock(), call_next=call_next, runtime=MagicMock()
+                )
+        # No retry attempted when subprocess failed.
+        assert call_next.call_count == 1
+
+    def test_headless_mode_does_not_run_subprocess(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mw = BedrockRefreshMiddleware(interactive=False)
+        original = Exception("ExpiredTokenException: token is expired")
+        call_next = MagicMock(side_effect=original)
+        with patch("bog_agents_cli.bedrock_refresh._attempt_sso_login") as mock_login:
+            with pytest.raises(Exception, match="ExpiredTokenException"):
+                mw.wrap_model_call(
+                    request=MagicMock(), call_next=call_next, runtime=MagicMock()
+                )
+            # Headless mode must NEVER spawn the subprocess.
+            mock_login.assert_not_called()
+        # But it must print the actionable banner to stderr.
+        captured = capsys.readouterr()
+        assert "aws sso login" in captured.err
+        assert "BEDROCK" in captured.err
+
+    def test_session_budget_caps_refreshes(self) -> None:
+        # Three refreshes allowed, fourth must NOT spawn subprocess.
+        mw = BedrockRefreshMiddleware(interactive=True, max_refreshes_per_session=3)
+        expired = Exception("ExpiredTokenException: token is expired")
+        with patch(
+            "bog_agents_cli.bedrock_refresh._attempt_sso_login", return_value=True
+        ) as mock_login:
+            for _ in range(3):
+                call_next = MagicMock(side_effect=[expired, "OK"])
+                result = mw.wrap_model_call(
+                    request=MagicMock(), call_next=call_next, runtime=MagicMock()
+                )
+                assert result == "OK"
+            # First three calls each spawned the subprocess.
+            assert mock_login.call_count == 3
+            # Fourth: budget exhausted, must NOT spawn, must re-raise.
+            call_next = MagicMock(side_effect=expired)
+            with pytest.raises(Exception, match="ExpiredTokenException"):
+                mw.wrap_model_call(
+                    request=MagicMock(), call_next=call_next, runtime=MagicMock()
+                )
+            # Subprocess count unchanged from the third refresh.
+            assert mock_login.call_count == 3
+
+    def test_first_call_prompts_banner(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # First interactive refresh of the session should print a
+        # banner so the user knows a browser tab is about to open.
+        mw = BedrockRefreshMiddleware(interactive=True)
+        call_next = MagicMock(
+            side_effect=[
+                Exception("ExpiredTokenException"),
+                "OK",
+            ]
+        )
+        with patch(
+            "bog_agents_cli.bedrock_refresh._attempt_sso_login", return_value=True
+        ):
+            mw.wrap_model_call(
+                request=MagicMock(), call_next=call_next, runtime=MagicMock()
+            )
+        captured = capsys.readouterr()
+        assert "BEDROCK" in captured.err
+        assert "aws sso login" in captured.err
+
+    def test_keyboard_interrupt_propagates(self) -> None:
+        # KeyboardInterrupt must NEVER be swallowed by the refresh path.
+        mw = BedrockRefreshMiddleware(interactive=True)
+        call_next = MagicMock(side_effect=KeyboardInterrupt)
+        with pytest.raises(KeyboardInterrupt):
+            mw.wrap_model_call(
+                request=MagicMock(), call_next=call_next, runtime=MagicMock()
+            )
+
+    def test_non_credential_error_passes_through(self) -> None:
+        # Unrelated errors must propagate unchanged — no refresh, no retry.
+        mw = BedrockRefreshMiddleware(interactive=True)
+        original = RuntimeError("ServiceUnavailable: 503")
+        call_next = MagicMock(side_effect=original)
+        with patch("bog_agents_cli.bedrock_refresh._attempt_sso_login") as mock_login:
+            with pytest.raises(RuntimeError, match="ServiceUnavailable"):
+                mw.wrap_model_call(
+                    request=MagicMock(), call_next=call_next, runtime=MagicMock()
+                )
+            mock_login.assert_not_called()
+        # Single attempt — no retry on non-credential errors.
+        assert call_next.call_count == 1
+
+
+class TestAsyncRefreshFlow:
+    """Async path mirrors the sync path."""
+
+    async def test_async_refreshes_and_retries(self) -> None:
+        mw = BedrockRefreshMiddleware(interactive=True)
+
+        call_count = 0
+
+        async def call_next(request: object, runtime: object) -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise _ExpiredTokenException("ExpiredTokenException: token expired")
+            return "RECOVERED"
+
+        with patch(
+            "bog_agents_cli.bedrock_refresh._attempt_sso_login", return_value=True
+        ):
+            result = await mw.awrap_model_call(
+                request=MagicMock(), call_next=call_next, runtime=MagicMock()
+            )
+        assert result == "RECOVERED"
+        assert call_count == 2
+
+    async def test_async_propagates_when_refresh_fails(self) -> None:
+        mw = BedrockRefreshMiddleware(interactive=True)
+
+        async def call_next(request: object, runtime: object) -> str:
+            raise _ExpiredTokenException("ExpiredTokenException: token expired")
+
+        with patch(
+            "bog_agents_cli.bedrock_refresh._attempt_sso_login", return_value=False
+        ):
+            with pytest.raises(Exception, match="ExpiredTokenException"):
+                await mw.awrap_model_call(
+                    request=MagicMock(), call_next=call_next, runtime=MagicMock()
+                )

--- a/libs/cli/tests/unit_tests/test_provider_catalog_display.py
+++ b/libs/cli/tests/unit_tests/test_provider_catalog_display.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import pytest
 
 from bog_agents_cli.provider_catalog import (
+    DEFAULT_MODEL_CANDIDATES,
     ModelDisplay,
     clear_cached_catalog,
     derive_model_display,
@@ -188,6 +189,46 @@ class TestCachedCatalog:
         assert not cache_file.exists()
         # Second clear is a no-op.
         assert clear_cached_catalog(path=cache_file) is False
+
+
+class TestBedrockCatalogIntegrity:
+    """Guard rails on the curated Bedrock model lists.
+
+    Claude 4.x on Bedrock requires a cross-region inference profile
+    prefix (us./eu./apac.). The bare ``anthropic.claude-4*`` ids return
+    AccessDenied even when model access is granted, so they must NOT
+    appear in either Bedrock catalog — otherwise the model picker
+    surfaces a guaranteed-failure entry. The SDK has a runtime auto-
+    resolver that rewrites bare → regional for users who hand-type
+    the bare id, but the catalog itself only lists working ids.
+    """
+
+    @pytest.mark.parametrize("provider", ["bedrock", "bedrock_converse"])
+    def test_no_bare_claude_4_ids(self, provider: str) -> None:
+        models = DEFAULT_MODEL_CANDIDATES[provider]
+        offenders = [
+            m
+            for m in models
+            if m.startswith("anthropic.claude-")
+            and any(f"claude-{v}-4-" in m for v in ("opus", "sonnet", "haiku"))
+        ]
+        assert not offenders, (
+            f"{provider} catalog contains bare Claude 4.x ids that return "
+            f"AccessDenied on Bedrock: {offenders}. Add a regional prefix "
+            f"(us./eu./apac.) or drop the entry entirely."
+        )
+
+    @pytest.mark.parametrize("provider", ["bedrock", "bedrock_converse"])
+    def test_us_inference_profiles_present(self, provider: str) -> None:
+        models = DEFAULT_MODEL_CANDIDATES[provider]
+        # Every Bedrock catalog must offer at least one us-prefixed
+        # Anthropic option so a fresh user on us-east-1 can pick a
+        # working model without diagnostics.
+        us_anthropic = [m for m in models if m.startswith("us.anthropic.claude-")]
+        assert us_anthropic, (
+            f"{provider} catalog has no us.anthropic.* entries — a fresh "
+            f"user on us-east-1 won't find a working Claude model."
+        )
 
 
 class TestModelDisplayDataclass:


### PR DESCRIPTION
## Summary

Bedrock onboarding was the rough edge: confusing model IDs that returned AccessDenied, no obvious way to test connectivity, opaque errors, no automatic recovery when SSO expired mid-session. This branch closes those gaps in four waves.

### Wave 1 — Fix the model-ID trap
- **Drop bare \`anthropic.claude-4*\` IDs** from \`bedrock\` + \`bedrock_converse\` catalogs. Claude 4.x on Bedrock requires a cross-region inference profile prefix (\`us.\` / \`eu.\` / \`apac.\` / \`jp.\` / \`sa.\`); the bare ID returns AccessDeniedException even when model access is granted.
- **Auto-resolver** in \`bog_agents._models._normalize_bedrock_model_id()\` rewrites bare \`anthropic.claude-4*\` → regional based on \`AWS_REGION\` at agent creation, with a WARNING log so the rewrite is visible in \`--debug\`. Nova/Llama/Mistral IDs are left alone (they work bare).
- **27 new tests** (region-mapping + normalization, all mocked).

### Wave 2 — Surface the test button
- Model picker now shows a Bedrock-specific hint when a \`bedrock*:\` spec is highlighted: \"press Ctrl+T to run the 6-step probe\" / \"✓ tested this session\" (tracked in a module-level set per process).
- **\`/bedrock fix\`** subcommand: runs the probe, turns each failure into a numbered copy-paste command (set region, \`aws sso login\`, console URL for model-access grant, inference-profile id hint).
- 6 new tests for \`render_fix_report\`.

### Wave 3 — Settings + docs + auth-chain tests
- **\`/bedrock config\`** subcommand: prints the active \`auth_mode\`, \`aws_profile\`, region, config-file path, plus example \`[models.providers.bedrock_converse]\` block and env-var equivalents.
- **\`docs/providers/bedrock.md\`**: single-page end-to-end walkthrough — install → IAM → model access → inference profiles → six-step probe → fix recipes → \`bedrock\` vs \`bedrock_converse\`. Cross-linked from getting-started / troubleshooting / docs/README.
- **20 new tests** for the previously-uncovered auth chain (\`_check_bedrock_files\`, \`_check_bedrock_boto3\`, \`_bedrock_auth_mode\` precedence).

### Wave 4 — Auto-refresh expired SSO credentials
- New **\`BedrockRefreshMiddleware\`** catches \`ExpiredTokenException\` / \`SSOTokenLoadError\` / \`UnauthorizedSSOTokenError\` on Bedrock calls.
- **Interactive (TTY)**: spawns \`aws sso login --profile <resolved>\` as a subprocess (120s timeout, never shell-injected), retries the call once on success.
- **Headless** (\`-p\` / daemon): prints the actionable banner to stderr and fails fast — no subprocess.
- **Budget**: one refresh per call, three per session. After three, the categorized error surfaces (looping won't unbreak misconfigured SSO).
- Auto-wired in \`bog_agents_cli/agent.py\` when the model starts with \`bedrock:\` / \`bedrock_converse:\`. SDK callers can attach manually.
- **20 new tests** with subprocess mocked.

## Numbers

- **73 new tests** total, all green
- **All 4239 CLI + 1430 SDK + 113 daemon tests pass**
- \`ruff check\` + \`ruff format\` + \`ty check\` clean across all three packages
- No live AWS calls in the test suite

## Branch lineage

Builds on \`main\` at \`222a895\`. Two commits:
- \`5e0043b\` feat(sdk,cli): Bedrock seamless — Waves 1-3
- \`32ee5a6\` feat(cli): Bedrock seamless — Wave 4 (auto-refresh expired SSO tokens)

## Test plan

- [x] CI lint + test stages green across SDK / CLI / daemon
- [ ] Manual: \`/model\` → pick a Bedrock entry → press Ctrl+T → probe runs inline
- [ ] Manual: \`/bedrock fix\` with intentionally misconfigured region — verify copy-paste commands work
- [ ] Manual: \`/bedrock config\` — verify it prints the resolved auth_mode + region + config path
- [ ] Manual (with SSO): expire token, hit any Bedrock model — verify \`aws sso login\` spawns + call retries
- [ ] Manual (headless): \`bog-agents -p \"...\" --model bedrock_converse:us.anthropic.claude-opus-4-7\` with expired SSO — verify it fails fast with the actionable banner, no subprocess

🤖 Generated with [Claude Code](https://claude.com/claude-code)