### PR TITLE
fix(cli): disable per-chunk SSE timeout, add liveness watchdog for long jobs

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -137,25 +137,56 @@ bog-agents --shell-allow-list "git,npm,pytest,uv"
 bog-agents --shell-allow-list all          # disables the gate
 ```
 
-### Agent hangs on a long tool call
+### `ReadTimeout` on a long deep-research / multi-agent run
 
-Two timeouts at play:
+This was the most common long-job failure before 0.9.2. The fix
+shipped with the release — if you still hit it, read on.
 
-- **Per-tool**: shell commands hit a 60s default. Set
-  `BOG_AGENTS_SHELL_TIMEOUT_SECONDS` to extend.
-- **Per-chunk**: streaming chunks from the model hit a 600s default.
-  Set `BOG_AGENTS_STREAM_CHUNK_TIMEOUT_SECONDS` (=0 disables).
+**Why it happened.** A "read timeout" is an *inter-event* timeout: it
+fires when no data arrives for N seconds, and resets every time data
+*does* arrive. On a healthy token stream it never fires. But during a
+long tool call — a 30-minute build, a deep-research subagent, a slow
+init — the agent is *blocked inside the tool* and the stream emits
+zero events for the tool's whole duration. Any finite per-chunk
+deadline shorter than the longest tool call therefore killed
+legitimate work. There was no "correct" finite value.
 
-When the chunk timeout fires you'll see in the log:
+**What changed.** The per-chunk SSE deadline is now **disabled by
+default**. In its place, a *liveness watchdog* runs: when the stream
+goes quiet for a few minutes, the CLI side-channels the server to
+confirm it is still alive. A live server (busy in a tool) is left
+alone; an unreachable one aborts the run with a clear error. So long
+jobs run uninterrupted, and a genuinely dead connection is still
+caught — within ~5 minutes — instead of hanging forever.
 
+**The timeout layers, and their defaults:**
+
+| Env var | Governs | Default |
+|---|---|---|
+| `BOG_AGENTS_REMOTE_READ_TIMEOUT` | per-event SSE gap (CLI ↔ server) | disabled |
+| `BOG_AGENTS_MODEL_READ_TIMEOUT` | per-chunk gap on the model HTTP call | 600s |
+| `BOG_AGENTS_STREAM_CHUNK_TIMEOUT_SECONDS` | per-chunk gap in headless `-p` mode | disabled |
+| `BOG_AGENTS_TURN_TIMEOUT_SECONDS` | wall-clock cap on one whole turn | 21600s (6h) |
+| `BOG_AGENTS_TOOL_TIMEOUT` | a single shell command | 7200s (2h) |
+
+All are tunable. Set any to a positive number to impose a hard cap,
+or to `none` / `0` to disable. They also live in
+`~/.bog-agents/settings.json` under a `timeouts` block:
+
+```json
+{"timeouts": {"model_read_seconds": 600, "remote_read_seconds": 1800, "tool_seconds": "none"}}
 ```
-Agent stream stalled — no chunk received in 605s (timeout 600s).
-The remote may be unreachable or the model may be hung.
-```
 
-If your model genuinely needs more than 600s between chunks, raise
-the env var. If chunks should arrive faster, you've got a network
-problem.
+**When to re-impose a finite SSE deadline.** If you run in a tightly
+bounded CI job and want a hard ceiling rather than the watchdog's
+liveness behaviour, set `BOG_AGENTS_REMOTE_READ_TIMEOUT` to a positive
+number of seconds.
+
+### Agent hangs on a long shell command
+
+Shell commands hit `BOG_AGENTS_TOOL_TIMEOUT` (2h default). A genuine
+long build/test suite is fine; raise the env var if you need more, or
+set it to `none` to disable the per-command cap entirely.
 
 ### "Cost exceeded $X — continue?" but you set no budget
 

--- a/libs/cli/bog_agents_cli/app.py
+++ b/libs/cli/bog_agents_cli/app.py
@@ -80,12 +80,16 @@ configure_debug_logging(logger)
 _monotonic = time.monotonic
 
 
-_DEFAULT_TURN_TIMEOUT_SECONDS = 3600.0
+_DEFAULT_TURN_TIMEOUT_SECONDS = 21600.0
 """H1: default cap on one agent turn (model + tool calls + streaming).
 
-One hour is generous — legitimate long-running turns (deep research,
-large refactors) need headroom, but a literally-hung worker would
-otherwise lock the TUI indefinitely.
+Six hours. This is a backstop against a literally-hung worker locking
+the TUI forever — not a budget for normal work. The previous one-hour
+cap cut off legitimate long turns: a deep-research run or a multi-agent
+refactor with long builds can genuinely exceed an hour. Six hours sits
+comfortably above any plausible single turn while still guaranteeing
+the TUI eventually recovers from a wedged worker. Override with
+``BOG_AGENTS_TURN_TIMEOUT_SECONDS`` (``0``/``none`` removes the cap).
 """
 
 

--- a/libs/cli/bog_agents_cli/non_interactive.py
+++ b/libs/cli/bog_agents_cli/non_interactive.py
@@ -85,13 +85,27 @@ _MAX_HITL_ITERATIONS = 50
 loops (e.g. when the agent keeps retrying rejected commands)."""
 
 
-_DEFAULT_STREAM_CHUNK_TIMEOUT_SECONDS = 600.0
-"""H2: default cap on the gap between agent-stream chunks.
+_DEFAULT_STREAM_CHUNK_TIMEOUT_SECONDS: float | None = None
+"""H2: cap on the gap between agent-stream chunks — DISABLED by default.
 
-10 minutes is generous — a legitimate long-running tool call (lengthy
-LLM generation, large file scan) can take several minutes between
-chunks, but anything past that is almost certainly a hung remote.
-Distinct from total turn time so genuine long turns aren't penalised.
+This is the headless (`-p`) counterpart of the SSE read deadline, and
+it has the same flaw a finite value cannot escape: a long tool call
+(a 30-minute build, a deep-research subagent) legitimately emits no
+stream chunks for its whole duration, so any per-chunk cap shorter
+than the longest tool call cancels real work — and `asyncio.wait_for`
+cancels the stream destructively when it fires.
+
+Disabled by default. The genuine-hang backstops still apply:
+
+- The remote path (`RemoteAgent.astream`) carries a liveness watchdog
+  that side-channels the server during silence and aborts only when
+  the server is confirmed unreachable.
+- The model HTTP call keeps its own read deadline at the httpx layer,
+  so a wedged provider still surfaces.
+- CI runners impose their own job-level timeout.
+
+Set ``BOG_AGENTS_STREAM_CHUNK_TIMEOUT_SECONDS`` to a positive number to
+re-impose a hard per-chunk cap (useful for tightly-bounded CI jobs).
 """
 
 
@@ -739,10 +753,10 @@ async def _stream_agent(
         file_op_tracker: Tracker for file-operation diffs.
 
     Raises:
-        TimeoutError: When ``BOG_AGENTS_STREAM_CHUNK_TIMEOUT_SECONDS``
-            elapses between chunks (default 600s, configurable, off
-            when set to ``0``). Surfaces the stall so CI pipelines
-            don't hang silently.
+        TimeoutError: When ``BOG_AGENTS_STREAM_CHUNK_TIMEOUT_SECONDS`` is
+            set to a positive value and that many seconds elapse between
+            chunks. Disabled by default — set the env var to re-impose a
+            hard per-chunk cap (e.g. for tightly-bounded CI jobs).
     """
     # H2: a hung remote streaming call would pin CI pipelines
     # indefinitely. Cap the *gap between chunks* (rather than total

--- a/libs/cli/bog_agents_cli/remote_client.py
+++ b/libs/cli/bog_agents_cli/remote_client.py
@@ -9,8 +9,10 @@ Textual adapter expects.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import os
+import time
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -22,19 +24,41 @@ logger = logging.getLogger(__name__)
 configure_debug_logging(logger)
 
 # Default per-chunk read timeout for the langgraph SDK's underlying httpx
-# client. NB: httpx ``read`` is per-chunk, not total — a healthy SSE stream
-# that emits keepalives or token-streaming events stays alive indefinitely
-# under this deadline; only a *stall* longer than ``read`` fails. We pick
-# 600s (10 min): well above any legitimate inter-chunk gap (slow tool,
-# extended thinking) but tight enough that a hung stream surfaces as a
-# visible ``ReadTimeout`` rather than an open-ended stall. The previous
-# default of 7200s (2h) made a wedged subagent's model call effectively
-# permanent — the user always killed the run before the deadline fired,
-# leaving them with the cancel cascade as their only signal. Aligned with
-# ``BOG_AGENTS_MODEL_READ_TIMEOUT`` so the SSE side never fires before the
-# underlying model call has had its full budget. Override with
-# ``BOG_AGENTS_REMOTE_READ_TIMEOUT`` (seconds, or ``none``/``0`` to disable).
-_DEFAULT_READ_TIMEOUT_SECS: float = 600.0
+# client. ``None`` = DISABLED by default.
+#
+# Why disabled: httpx ``read`` is a per-chunk (inter-event) deadline, not a
+# total one. On a long tool call — a 30-minute build, a deep-research
+# subagent, a slow init — the graph node is *blocked inside the tool* and
+# the SSE stream emits zero events for the tool's entire duration. Any
+# finite read deadline shorter than the longest tool call therefore fires
+# on legitimate work, killing the run. There is no "correct" finite value:
+# the inter-event gap during a long tool call simply equals the tool's
+# runtime.
+#
+# Disabling the deadline removes that cliff. The cost — a genuinely dead
+# connection (server crash, host sleep, network drop) would otherwise hang
+# forever — is covered by the liveness watchdog below
+# (``_IDLE_HEALTHCHECK_SECS``): after a stretch of silence the client
+# side-channels the server to confirm it is still alive, and aborts only
+# when the server is confirmed unreachable. So a quiet-but-working stream
+# is never killed, while a dead one still surfaces a clear error.
+#
+# Override with ``BOG_AGENTS_REMOTE_READ_TIMEOUT`` (seconds) to re-impose a
+# finite per-chunk deadline; ``none``/``0`` keeps it disabled (the default).
+_DEFAULT_READ_TIMEOUT_SECS: float | None = None
+
+# Liveness watchdog. When the SSE stream emits no event for this many
+# seconds, the client runs a cheap side-channel health check against the
+# server before deciding whether to keep waiting. A live server (busy in a
+# long tool call) passes the check and the stream continues untouched; an
+# unreachable server fails it and the stream aborts with a clear error.
+# This is what makes a disabled read deadline safe — see the note above.
+_IDLE_HEALTHCHECK_SECS: float = 300.0
+
+# Timeout for the side-channel health-check request itself. Short, because
+# a healthy server answers a bare GET in milliseconds; anything slower than
+# this is itself a symptom of a dead/wedged server.
+_HEALTHCHECK_REQUEST_TIMEOUT_SECS: float = 15.0
 
 # Number of times to re-issue an astream() call when the SSE stream raises a
 # transient error *before any events have flowed*. The server has not yet
@@ -71,6 +95,7 @@ def _resolve_read_timeout() -> float | None:
 
     Returns:
         Read timeout in seconds, or `None` to disable the read deadline.
+        The default is `None` (disabled) — see `_DEFAULT_READ_TIMEOUT_SECS`.
     """
     raw = os.environ.get("BOG_AGENTS_REMOTE_READ_TIMEOUT")
     if raw is None:
@@ -81,9 +106,11 @@ def _resolve_read_timeout() -> float | None:
         value = float(raw)
     except ValueError:
         logger.warning(
-            "Invalid BOG_AGENTS_REMOTE_READ_TIMEOUT=%r, using default %ss",
+            "Invalid BOG_AGENTS_REMOTE_READ_TIMEOUT=%r, using default (%s)",
             raw,
-            _DEFAULT_READ_TIMEOUT_SECS,
+            "disabled"
+            if _DEFAULT_READ_TIMEOUT_SECS is None
+            else f"{_DEFAULT_READ_TIMEOUT_SECS}s",
         )
         return _DEFAULT_READ_TIMEOUT_SECS
     if value <= 0:
@@ -191,14 +218,20 @@ class RemoteAgent:
                 the environment.
             headers: Extra HTTP headers to include in every request
                 (e.g. bearer tokens, proxy headers).
-            read_timeout: Per-chunk SSE read timeout in seconds. When `None`,
-                the value from `BOG_AGENTS_REMOTE_READ_TIMEOUT` is used,
-                falling back to `_DEFAULT_READ_TIMEOUT_SECS` (7200s, i.e.
-                2 hours) when that env var is unset. Set the env var to
-                `none`/`0` to disable the deadline entirely.
+            read_timeout: Per-chunk SSE read timeout in seconds, or `None`
+                to disable the per-chunk deadline. When the argument itself
+                is `None`, the value from `BOG_AGENTS_REMOTE_READ_TIMEOUT`
+                is used, which itself defaults to disabled
+                (`_DEFAULT_READ_TIMEOUT_SECS`). To distinguish "use the
+                env/default" from "explicitly disabled", pass a positive
+                float to force a finite deadline; the disabled state is the
+                resolved default.
 
-                NB: this is a per-chunk read deadline, not a total
-                stream deadline — healthy streams stay alive indefinitely.
+                NB: this is a per-chunk read deadline, not a total stream
+                deadline. It is disabled by default because a long tool
+                call legitimately produces no SSE events for its whole
+                duration; dead connections are caught by the liveness
+                watchdog instead (see `_IDLE_HEALTHCHECK_SECS`).
         """
         self._url = url
         self._graph_name = graph_name
@@ -301,13 +334,14 @@ class RemoteAgent:
 
         while True:
             try:
-                async for ns, mode, data in graph.astream(
+                raw_stream = graph.astream(
                     input,
                     stream_mode=modes,
                     subgraphs=subgraphs,
                     config=config,
                     context=context,
-                ):
+                )
+                async for ns, mode, data in self._iter_with_watchdog(raw_stream):
                     async for converted in RemoteAgent._process_chunk(
                         ns, mode, data, BaseMessage
                     ):
@@ -376,6 +410,124 @@ class RemoteAgent:
                 "Dropped %d message(s) during stream due to conversion failures",
                 dropped_count,
             )
+
+    async def _iter_with_watchdog(self, agen: AsyncIterator[Any]) -> AsyncIterator[Any]:
+        """Yield from `agen`, health-checking the server when it goes quiet.
+
+        This is the safety net that makes a disabled per-chunk read deadline
+        sound. A long tool call legitimately emits no SSE events for its
+        whole duration, so we cannot tell "server busy in a 30-minute build"
+        apart from "connection dead" by silence alone — we have to ask.
+
+        Every `_IDLE_HEALTHCHECK_SECS` of silence, the watchdog side-channels
+        the server with a cheap GET. A live server (busy in a tool) passes;
+        the stream keeps waiting on the *same* in-flight read. A dead server
+        fails the check and we raise `ConnectionError`, which the caller's
+        retry loop treats as transient — giving a briefly-unreachable server
+        a chance to recover before the run finally surfaces the failure.
+
+        Crucially this uses `asyncio.wait` (not `asyncio.wait_for`): a
+        passing health check must NEVER cancel the pending stream read, or
+        we would tear down a perfectly healthy SSE connection every five
+        minutes. `wait` returns on timeout without touching the task.
+
+        Args:
+            agen: The raw `RemoteGraph.astream` async iterator.
+
+        Yields:
+            Items from `agen`, unchanged.
+
+        Raises:
+            ConnectionError: When the stream goes silent and the server
+                fails the side-channel health check.
+        """
+        ait = aiter(agen)
+        try:
+            while True:
+                next_task: asyncio.Task[Any] = asyncio.ensure_future(anext(ait))
+                try:
+                    while True:
+                        done, _pending = await asyncio.wait(
+                            {next_task}, timeout=_IDLE_HEALTHCHECK_SECS
+                        )
+                        if next_task in done:
+                            break
+                        # Silence longer than the idle window — is the
+                        # server actually still there?
+                        alive = await self._server_alive()
+                        if not alive:
+                            next_task.cancel()
+                            with contextlib.suppress(Exception, asyncio.CancelledError):
+                                await next_task
+                            msg = (
+                                f"langgraph server at {self._url} stopped "
+                                f"responding: no SSE events for "
+                                f"{_IDLE_HEALTHCHECK_SECS:.0f}s and the "
+                                f"liveness check could not reach it"
+                            )
+                            raise ConnectionError(msg)  # noqa: TRY301 — must raise inside the wait loop; outer try is for stream cleanup
+                        # Server healthy — a long tool call is in flight.
+                        # Keep waiting on the same read; do not disturb it.
+                        logger.debug(
+                            "remote stream idle %.0fs; server healthy, "
+                            "continuing to wait",
+                            _IDLE_HEALTHCHECK_SECS,
+                        )
+                except BaseException:
+                    # Caller cancelled us, or the health check failed —
+                    # tear down the in-flight read so we don't leak it.
+                    next_task.cancel()
+                    with contextlib.suppress(Exception, asyncio.CancelledError):
+                        await next_task
+                    raise
+                try:
+                    yield next_task.result()
+                except StopAsyncIteration:
+                    return
+        finally:
+            # Close the underlying RemoteGraph stream on any exit path so
+            # the SSE connection is released promptly.
+            aclose = getattr(agen, "aclose", None)
+            if aclose is not None:
+                with contextlib.suppress(Exception):
+                    await aclose()
+
+    async def _server_alive(self) -> bool:
+        """Side-channel liveness check — is the langgraph server reachable?
+
+        Issues a bare GET against the server root with a short timeout.
+        ANY HTTP response — 200, 401, 404, 500 — means the server process
+        is up and answering, so the stream silence is a busy tool call,
+        not a dead connection. Only a connection error or timeout counts
+        as dead.
+
+        Returns:
+            True when the server answered with any HTTP status; False on a
+            connection error or timeout.
+        """
+        import httpx
+
+        started = time.monotonic()
+        try:
+            async with httpx.AsyncClient(
+                timeout=_HEALTHCHECK_REQUEST_TIMEOUT_SECS
+            ) as client:
+                await client.get(self._url)
+        except Exception as exc:
+            logger.warning(
+                "remote liveness check FAILED for %s after %.1fs: %s: %s",
+                self._url,
+                time.monotonic() - started,
+                type(exc).__name__,
+                exc,
+            )
+            return False
+        logger.debug(
+            "remote liveness check OK for %s (%.0fms)",
+            self._url,
+            (time.monotonic() - started) * 1000,
+        )
+        return True
 
     @staticmethod
     async def _process_chunk(

--- a/libs/cli/bog_agents_cli/timeouts.py
+++ b/libs/cli/bog_agents_cli/timeouts.py
@@ -6,8 +6,13 @@ Three pieces of work fight against premature ReadTimeoutError on long turns:
   the LLM HTTP client will wait for the provider to respond.
 - The **remote** layer (``BOG_AGENTS_REMOTE_READ_TIMEOUT``) controls how
   long the CLI's ``RemoteGraph`` SSE stream will wait between chunks before
-  it gives up. NB: this is a per-chunk read deadline — a healthy stream
-  with regular keepalives stays alive forever under it.
+  it gives up. NB: this is a per-chunk read deadline. It is **disabled by
+  default** — a long tool call (a 30-minute build, a deep-research
+  subagent) legitimately emits no SSE events for its whole duration, so
+  any finite per-chunk deadline shorter than the longest tool call kills
+  real work. Dead connections are caught by a liveness watchdog in
+  ``remote_client.py`` instead. Set this to a positive number to re-impose
+  a finite deadline.
 - The **tool** layer (``LocalShellBackend(timeout=...)``) controls how
   long a single shell command can run before being killed.
 
@@ -21,13 +26,13 @@ Cascade precedence (highest first):
 1. The env var itself, if it was already set in the user's shell.
 2. ``<project>/.bog-agents/settings.json`` ``timeouts`` section.
 3. ``~/.bog-agents/settings.json`` ``timeouts`` section.
-4. Built-in defaults (2 hours for model + remote, 2 hours for tools).
+4. Built-in defaults: model read 10 min, remote SSE disabled, tools 2 hours.
 
 A value of ``"none"``, ``"off"``, or ``0`` disables that timeout entirely.
 
 Example ``settings.json``::
 
-    {"timeouts": {"model_read_seconds": 7200, "remote_read_seconds": 7200, "tool_seconds": "none"}}
+    {"timeouts": {"model_read_seconds": 600, "remote_read_seconds": 1800, "tool_seconds": "none"}}
 """
 
 from __future__ import annotations
@@ -56,17 +61,25 @@ logger = logging.getLogger(__name__)
 #   high-effort responses) while still giving the user a visible
 #   ``ReadTimeout`` rather than an open-ended stall.
 #
-# - ``remote_read_seconds`` is the SSE deadline between the CLI and
-#   the langgraph dev server. Same reasoning, same value.
+# - ``remote_read_seconds`` is the SSE deadline between the CLI and the
+#   langgraph dev server. DISABLED by default (``None``). Unlike a model
+#   HTTP stream — which sends tokens continuously once flowing — the SSE
+#   stream goes genuinely silent for the entire duration of a long tool
+#   call (the graph node is blocked inside the tool). Any finite per-chunk
+#   deadline therefore kills legitimate long-running work. ``remote_client``
+#   substitutes a liveness watchdog: when the stream is quiet it
+#   side-channels the server to confirm it is alive, and aborts only when
+#   the server is genuinely unreachable. Set a positive value here to
+#   re-impose a hard per-chunk deadline on top of the watchdog.
 #
 # - ``tool_seconds`` covers shell-tool execution. Long builds and
 #   test suites are legitimate; we keep this generous.
 #
-# Override any of these via env (``BOG_AGENTS_MODEL_READ_TIMEOUT=7200``
-# restores the previous behaviour) or per-project settings.json.
-_DEFAULT_MODEL_READ_SECS = 600
-_DEFAULT_REMOTE_READ_SECS = 600
-_DEFAULT_TOOL_SECS = 7200
+# Override any of these via env (e.g. ``BOG_AGENTS_REMOTE_READ_TIMEOUT=1800``
+# to re-impose a 30-minute SSE deadline) or per-project settings.json.
+_DEFAULT_MODEL_READ_SECS: int | None = 600
+_DEFAULT_REMOTE_READ_SECS: int | None = None
+_DEFAULT_TOOL_SECS: int | None = 7200
 
 _MODEL_ENV = "BOG_AGENTS_MODEL_READ_TIMEOUT"
 _REMOTE_ENV = "BOG_AGENTS_REMOTE_READ_TIMEOUT"

--- a/libs/cli/tests/unit_tests/test_app.py
+++ b/libs/cli/tests/unit_tests/test_app.py
@@ -3353,13 +3353,26 @@ class TestWaveNTimeoutResolvers:
         assert _resolve_turn_timeout() == _DEFAULT_TURN_TIMEOUT_SECONDS
 
     def test_stream_chunk_timeout_default(self, monkeypatch):
+        # The headless per-chunk cap is DISABLED by default: a long tool
+        # call legitimately produces no stream chunks for its duration,
+        # so any finite cap kills real work. The model-layer read
+        # deadline + the remote liveness watchdog are the genuine-hang
+        # backstops.
         monkeypatch.delenv("BOG_AGENTS_STREAM_CHUNK_TIMEOUT_SECONDS", raising=False)
         from bog_agents_cli.non_interactive import (
             _DEFAULT_STREAM_CHUNK_TIMEOUT_SECONDS,
             _resolve_stream_chunk_timeout,
         )
 
-        assert _resolve_stream_chunk_timeout() == _DEFAULT_STREAM_CHUNK_TIMEOUT_SECONDS
+        assert _DEFAULT_STREAM_CHUNK_TIMEOUT_SECONDS is None
+        assert _resolve_stream_chunk_timeout() is None
+
+    def test_stream_chunk_timeout_explicit_override(self, monkeypatch):
+        # A user who wants a hard per-chunk cap back can set one.
+        monkeypatch.setenv("BOG_AGENTS_STREAM_CHUNK_TIMEOUT_SECONDS", "300")
+        from bog_agents_cli.non_interactive import _resolve_stream_chunk_timeout
+
+        assert _resolve_stream_chunk_timeout() == 300.0
 
     def test_stream_chunk_timeout_disabled(self, monkeypatch):
         monkeypatch.setenv("BOG_AGENTS_STREAM_CHUNK_TIMEOUT_SECONDS", "off")

--- a/libs/cli/tests/unit_tests/test_remote_client.py
+++ b/libs/cli/tests/unit_tests/test_remote_client.py
@@ -1,7 +1,8 @@
 """Tests for RemoteAgent, _convert_message_data, and helpers."""
 
+import asyncio
 import uuid
-from typing import Any
+from typing import Any, Self
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -602,17 +603,20 @@ class TestRemoteAgentInit:
             assert g1 is g2
             mock_cls.assert_called_once()
 
-    def test_extended_read_timeout_applied_to_clients(self) -> None:
-        """Default 600s read timeout is configured on the underlying httpx clients.
+    def test_read_timeout_disabled_by_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The per-chunk SSE read deadline is DISABLED by default.
 
-        0.8.5: the default dropped from 7200s (2h) to 600s (10 min). A
-        2-hour per-chunk read deadline made hung Anthropic streams
-        effectively permanent — the user always killed the run before
-        the timeout fired, leaving them with the cancel cascade as the
-        only signal. 600s is well above any legitimate inter-chunk gap
-        (extended thinking, slow tool) but tight enough to surface a
-        real ``ReadTimeout`` to the user.
+        A long tool call (a 30-minute build, a deep-research subagent)
+        legitimately emits no SSE events for its whole duration, so any
+        finite per-chunk deadline kills real work. The deadline is off
+        by default; the liveness watchdog catches genuinely dead
+        connections instead. The connect timeout stays finite (5s) so an
+        unreachable server still fails fast.
         """
+        # Ensure no env override leaks in from the test environment.
+        monkeypatch.delenv("BOG_AGENTS_REMOTE_READ_TIMEOUT", raising=False)
         agent = RemoteAgent(url="http://localhost:8123")
         with (
             patch("langgraph.pregel.remote.RemoteGraph"),
@@ -624,7 +628,9 @@ class TestRemoteAgentInit:
                 _, kwargs = mock.call_args
                 timeout = kwargs.get("timeout")
                 assert timeout is not None
-                assert timeout.read == 600.0
+                assert timeout.read is None
+                # Connect timeout is still finite — fast-fail unreachable.
+                assert timeout.connect == 5.0
 
     def test_read_timeout_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """BOG_AGENTS_REMOTE_READ_TIMEOUT overrides the default."""
@@ -780,6 +786,153 @@ class TestRemoteAgentTransientRetry:
         ):
             async for _ in agent.astream({}, config=config):
                 pass
+
+
+class TestLivenessWatchdog:
+    """The watchdog that replaces the per-chunk read deadline.
+
+    When the SSE stream goes quiet, the watchdog side-channels the
+    server: a live server (busy in a long tool call) lets the stream
+    continue untouched; a dead server aborts it with ConnectionError.
+    """
+
+    @pytest.mark.asyncio
+    async def test_idle_stream_with_live_server_keeps_streaming(self) -> None:
+        """A quiet-but-alive stream is never killed by the watchdog."""
+        from bog_agents_cli import remote_client as rc
+
+        async def _slow_gen() -> Any:  # noqa: ANN401 - test async generator
+            # Each event is preceded by a gap longer than the (patched)
+            # idle window, so the watchdog health-checks before every one.
+            for i in range(3):
+                await asyncio.sleep(0.12)
+                yield ((), "updates", {"n": i})
+
+        agent = RemoteAgent(url="http://localhost:8123", graph_name="agent")
+        agent._server_alive = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+        with patch.object(rc, "_IDLE_HEALTHCHECK_SECS", 0.04):
+            events = [ev async for ev in agent._iter_with_watchdog(_slow_gen())]
+
+        assert events == [((), "updates", {"n": i}) for i in range(3)]
+        # The watchdog actually fired (server got health-checked).
+        assert agent._server_alive.await_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_idle_stream_with_dead_server_aborts(self) -> None:
+        """A quiet stream + unreachable server aborts with ConnectionError."""
+        from bog_agents_cli import remote_client as rc
+
+        async def _stalls_forever() -> Any:  # noqa: ANN401 - test async generator
+            yield ((), "updates", {"first": True})
+            # Second read never completes — simulates a dead connection.
+            await asyncio.Event().wait()
+            yield ((), "updates", {"never": True})  # pragma: no cover
+
+        agent = RemoteAgent(url="http://localhost:8123", graph_name="agent")
+        agent._server_alive = AsyncMock(return_value=False)  # type: ignore[method-assign]
+
+        collected: list[Any] = []
+        with patch.object(rc, "_IDLE_HEALTHCHECK_SECS", 0.04):
+            with pytest.raises(ConnectionError, match="stopped responding"):
+                async for ev in agent._iter_with_watchdog(_stalls_forever()):
+                    collected.append(ev)
+
+        # The event that did arrive before the stall was still delivered.
+        assert collected == [((), "updates", {"first": True})]
+
+    @pytest.mark.asyncio
+    async def test_watchdog_does_not_cancel_a_live_slow_read(self) -> None:
+        """A passing health check must not tear down the in-flight read.
+
+        This is the asyncio.wait (not wait_for) invariant: the single
+        slow event must survive multiple health-check cycles and still
+        be delivered intact.
+        """
+        from bog_agents_cli import remote_client as rc
+
+        async def _one_very_slow_event() -> Any:  # noqa: ANN401 - test async generator
+            # One event after a gap spanning several idle windows.
+            await asyncio.sleep(0.25)
+            yield ((), "updates", {"slow": True})
+
+        agent = RemoteAgent(url="http://localhost:8123", graph_name="agent")
+        agent._server_alive = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+        with patch.object(rc, "_IDLE_HEALTHCHECK_SECS", 0.04):
+            events = [
+                ev async for ev in agent._iter_with_watchdog(_one_very_slow_event())
+            ]
+
+        assert events == [((), "updates", {"slow": True})]
+        # Multiple health checks ran during the single slow read.
+        assert agent._server_alive.await_count >= 2
+
+    @pytest.mark.asyncio
+    async def test_watchdog_connectionerror_flows_into_retry(self) -> None:
+        """A watchdog abort is transient, so the retry loop re-streams it.
+
+        ConnectionError is in the transient-marker set, so a watchdog
+        abort gets the same checkpoint-resume retry treatment as a raw
+        network blip — giving a briefly-unreachable server a chance to
+        recover before the run finally fails.
+        """
+        from bog_agents_cli import remote_client as rc
+
+        assert rc._is_transient_stream_error(
+            ConnectionError("langgraph server stopped responding")
+        )
+
+
+class _FakeHttpxClient:
+    """Minimal async-context-manager httpx.AsyncClient stand-in.
+
+    `get` either raises a transport error or returns a response with the
+    configured status code — used to drive `_server_alive` both ways.
+    """
+
+    def __init__(self, *, raises: bool = False, status_code: int = 200) -> None:
+        self._raises = raises
+        self._status_code = status_code
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *_exc: object) -> bool:
+        return False
+
+    async def get(self, _url: str) -> Any:  # noqa: ANN401 — test stub
+        if self._raises:
+            msg = "connection refused"
+            raise ConnectionError(msg)
+        return MagicMock(status_code=self._status_code)
+
+
+class TestServerAlive:
+    """The side-channel liveness probe."""
+
+    @pytest.mark.asyncio
+    async def test_alive_when_server_answers(self) -> None:
+        agent = RemoteAgent(url="http://localhost:8123", graph_name="agent")
+        with patch("httpx.AsyncClient", return_value=_FakeHttpxClient(raises=False)):
+            assert await agent._server_alive() is True
+
+    @pytest.mark.asyncio
+    async def test_alive_even_on_http_error_status(self) -> None:
+        # Any HTTP *response* (404, 401, 500) means the server is up —
+        # only a transport-level failure counts as dead.
+        agent = RemoteAgent(url="http://localhost:8123", graph_name="agent")
+        with patch(
+            "httpx.AsyncClient",
+            return_value=_FakeHttpxClient(raises=False, status_code=500),
+        ):
+            assert await agent._server_alive() is True
+
+    @pytest.mark.asyncio
+    async def test_dead_on_connection_error(self) -> None:
+        agent = RemoteAgent(url="http://localhost:8123", graph_name="agent")
+        with patch("httpx.AsyncClient", return_value=_FakeHttpxClient(raises=True)):
+            assert await agent._server_alive() is False
 
 
 class TestTransientErrorClassifier:

--- a/libs/cli/tests/unit_tests/test_timeouts.py
+++ b/libs/cli/tests/unit_tests/test_timeouts.py
@@ -21,19 +21,22 @@ class TestTimeoutSettingsMerge:
     """Direct merge_dict semantics on a single layer."""
 
     def test_defaults_match_baseline(self) -> None:
-        # 0.8.5: model/remote read defaults dropped from 7200s (2h) to
-        # 600s (10 min) so a hung stream surfaces as ReadTimeout in
-        # bounded time. Tool remains 7200s for long builds/tests.
+        # Model read stays at 600s — a model HTTP stream sends tokens
+        # continuously, so a multi-minute gap is a genuine stall.
+        # Remote read is DISABLED by default: a long tool call emits no
+        # SSE events for its whole duration, so any finite per-chunk cap
+        # kills real work; the liveness watchdog in remote_client.py
+        # catches dead connections instead. Tool stays 7200s.
         settings = TimeoutSettings()
         assert settings.model_read_seconds == 600
-        assert settings.remote_read_seconds == 600
+        assert settings.remote_read_seconds is None
         assert settings.tool_seconds == 7200
 
     def test_int_override_replaces_default(self) -> None:
         settings = TimeoutSettings().merge_dict({"model_read_seconds": 300})
         assert settings.model_read_seconds == 300
-        # other fields unchanged
-        assert settings.remote_read_seconds == 600
+        # other fields unchanged — remote stays disabled by default
+        assert settings.remote_read_seconds is None
 
     def test_zero_disables_timeout(self) -> None:
         settings = TimeoutSettings().merge_dict({"tool_seconds": 0})
@@ -86,8 +89,8 @@ class TestLoadCascade:
         monkeypatch.setattr(Path, "home", lambda: home)
         settings = load_timeout_settings()
         assert settings.model_read_seconds == 1234
-        # Defaults preserved for unset fields.
-        assert settings.remote_read_seconds == 600
+        # Defaults preserved for unset fields — remote stays disabled.
+        assert settings.remote_read_seconds is None
 
     def test_project_overrides_user(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -137,6 +140,22 @@ class TestApplyToEnv:
         settings = TimeoutSettings(tool_seconds=None)
         apply_to_env(settings, env=env)
         assert env["BOG_AGENTS_TOOL_TIMEOUT"] == "none"
+
+    def test_default_remote_renders_as_none(self) -> None:
+        # The default TimeoutSettings has remote_read_seconds=None, so the
+        # env the SDK consumes must say "none" — that's what disables the
+        # per-chunk SSE deadline in remote_client._resolve_read_timeout.
+        env: dict[str, str] = {}
+        apply_to_env(TimeoutSettings(), env=env)
+        assert env["BOG_AGENTS_REMOTE_READ_TIMEOUT"] == "none"
+        # Model layer keeps its finite default.
+        assert env["BOG_AGENTS_MODEL_READ_TIMEOUT"] == "600"
+
+    def test_remote_positive_override_survives(self) -> None:
+        # A user who wants a hard SSE cap back can set a positive number.
+        env: dict[str, str] = {}
+        apply_to_env(TimeoutSettings(remote_read_seconds=1800), env=env)
+        assert env["BOG_AGENTS_REMOTE_READ_TIMEOUT"] == "1800"
 
 
 class TestResolveToolTimeout:


### PR DESCRIPTION
## Summary

Long deep-research queries, slow inits, and multi-agent runs were dying with `ReadTimeout`. This fixes the root cause and replaces the blunt timeout with a real liveness check.

**Why it happened.** The SSE read deadline is an *inter-event* timeout — it fires on silence and resets on every received chunk. During a long tool call (a 30-minute build, a deep-research subagent, a slow init) the agent is *blocked inside the tool* and the stream emits zero events for the tool's whole duration. Any finite per-chunk deadline shorter than the longest tool call therefore kills legitimate work. There is no correct finite value.

**The fix — disable the blunt timeout, add a liveness watchdog:**

| Change | File | Effect |
|---|---|---|
| SSE read timeout → disabled by default | `remote_client.py`, `timeouts.py` | Long jobs never killed by inter-event silence |
| Liveness watchdog added | `remote_client.py` | After 5 min of silence, side-channels the server; aborts *only* if it's genuinely unreachable |
| Turn-total cap 1h → 6h | `app.py` | Deep-research over an hour no longer cut off; finite backstop kept |
| Headless `-p` per-chunk cap → disabled | `non_interactive.py` | Same flaw fixed for the headless path |

The watchdog uses `asyncio.wait` (not `wait_for`) so a passing health check **never cancels the in-flight read** — a healthy slow stream survives any number of check cycles intact. A watchdog abort raises `ConnectionError`, which the existing retry loop treats as transient (checkpoint-resume), giving a briefly-down server a chance to recover.

The model-layer read timeout stays at **600s** — a model HTTP stream sends tokens continuously once flowing, so a multi-minute gap there is a genuine stall worth catching.

## How peer products handle this (researched)

- **Goose** — hardcoded aggressive 30s stream-idle timeout
- **Codex CLI** — ~150s idle SSE default, raisable
- **Gemini CLI** — relies on Node's 5-min default, no retry
- **Claude Code** — no inter-chunk watchdog at all; a dead stream can hang forever

The watchdog approach here is strictly better: long jobs are never killed, and a dead connection is still caught within ~5 minutes.

## A note on the design

The original plan was "disable + TCP keepalive." Injecting socket options requires rebuilding langgraph_sdk's httpx clients (couples to internals), and on Windows `SO_KEEPALIVE` can't be tuned below the OS default of 2 hours — so it wouldn't detect a dead peer fast on Windows. The application-level watchdog delivers the same intent, is platform-independent, and catches a wedged *server* (not just a dead *socket*).

## Config surface

All four timeouts remain tunable via env vars and `~/.bog-agents/settings.json` `[timeouts]`:

| Env var | Governs | Default |
|---|---|---|
| `BOG_AGENTS_REMOTE_READ_TIMEOUT` | per-event SSE gap | disabled |
| `BOG_AGENTS_MODEL_READ_TIMEOUT` | model HTTP chunk gap | 600s |
| `BOG_AGENTS_STREAM_CHUNK_TIMEOUT_SECONDS` | headless `-p` chunk gap | disabled |
| `BOG_AGENTS_TURN_TIMEOUT_SECONDS` | whole-turn wall clock | 21600s (6h) |