### PR TITLE
fix(sdk): git_tools_bundle — rename _runtime → runtime for ToolRuntime injection

### DIFF
--- a/docs/sdk/tool-bundles.md
+++ b/docs/sdk/tool-bundles.md
@@ -81,14 +81,16 @@ def vegetable_tools_bundle(
     """Return tools that talk to a vegetable database bound to ``db_path``."""
 
     def add_vegetable(
-        _runtime: ToolRuntime[None, Any],
+        runtime: ToolRuntime[None, Any],
         name: Annotated[str, "Vegetable name"],
         color: Annotated[str, "Hex color"] = "#3a5",
     ) -> str:
+        del runtime  # closure uses db_path; runtime present for injection
         # ... write to db_path ...
         return f"Added {name}."
 
-    def list_vegetables(_runtime: ToolRuntime[None, Any]) -> str:
+    def list_vegetables(runtime: ToolRuntime[None, Any]) -> str:
+        del runtime
         # ... read from db_path ...
         return "carrot, beet, parsnip"
 
@@ -107,9 +109,10 @@ def vegetable_tools_bundle(
 
     if include_destructive:
         def delete_vegetable(
-            _runtime: ToolRuntime[None, Any],
+            runtime: ToolRuntime[None, Any],
             name: Annotated[str, "Vegetable to delete"],
         ) -> str:
+            del runtime
             # ... delete from db_path ...
             return f"Deleted {name}."
 
@@ -145,9 +148,14 @@ That's it. No class, no `__init__`, no hooks, no state schema.
 - **Bundles are pure.** Two calls with the same arguments return
   independent tool lists with equivalent behavior. No shared
   mutable state between invocations.
-- **Use `ToolRuntime[None, Any]` for the first parameter.** That's
-  the LangChain convention. Pyright will accept it. The agent
-  injects the runtime automatically.
+- **Name the runtime parameter exactly `runtime`** — `ToolRuntime`
+  injection in LangGraph/LangChain identifies the slot by the
+  parameter **name** (not just the type). Underscore-prefixed names
+  like `_runtime` are silently dropped from the args schema by
+  pydantic AND not injected by LangGraph's `ToolNode`, so the tool
+  fails at invocation time with a misleading `missing positional
+  argument` error. If your closure doesn't actually use the runtime
+  value, follow the bundle pattern: `def my_tool(runtime: ToolRuntime[None, Any], ...): del runtime; ...`
 
 ## When to keep a middleware class instead
 

--- a/libs/bog-agents/bog_agents/tools/bundles.py
+++ b/libs/bog-agents/bog_agents/tools/bundles.py
@@ -87,16 +87,26 @@ def git_tools_bundle(
     def _git(*args: str, timeout: int = 30) -> str:
         return _run_git(wd, *args, timeout=timeout)
 
-    def git_status(_runtime: ToolRuntime[None, Any]) -> str:
+    # NB: every tool below takes ``runtime: ToolRuntime[None, Any]`` as its
+    # first parameter because LangChain identifies the runtime-injection
+    # slot by the *parameter's type annotation* — and pydantic only sees
+    # the parameter if its name does NOT start with an underscore. The
+    # closures here don't actually need the runtime value (they bind ``wd``
+    # at construction time), so each body opens with ``del runtime`` to
+    # silence the unused-argument warning without hiding the contract.
+
+    def git_status(runtime: ToolRuntime[None, Any]) -> str:
         """Show the working tree status including staged, unstaged, and untracked files."""
+        del runtime
         return _git("status", "--short", "--branch")
 
     def git_diff(
-        _runtime: ToolRuntime[None, Any],
+        runtime: ToolRuntime[None, Any],
         staged: bool = False,
         path: str | None = None,
     ) -> str:
         """Show changes in the working directory. Use staged=True for staged changes only."""
+        del runtime
         args: list[str] = ["diff"]
         if staged:
             args.append("--cached")
@@ -105,18 +115,19 @@ def git_tools_bundle(
         return _git(*args)
 
     def git_log(
-        _runtime: ToolRuntime[None, Any],
+        runtime: ToolRuntime[None, Any],
         count: int = 10,
         oneline: bool = True,
     ) -> str:
         """Show recent commit history. Default 10 commits in oneline format."""
+        del runtime
         args = ["log", f"-{count}"]
         if oneline:
             args.append("--oneline")
         return _git(*args)
 
     def git_commit(
-        _runtime: ToolRuntime[None, Any],
+        runtime: ToolRuntime[None, Any],
         message: Annotated[str, "Commit message following Conventional Commits format"],
         files: Annotated[
             list[str] | None,
@@ -124,16 +135,18 @@ def git_tools_bundle(
         ] = None,
     ) -> str:
         """Create a git commit. Optionally specify files to stage first."""
+        del runtime
         if files:
             for fp in files:
                 _git("add", fp)
         return _git("commit", "-m", message)
 
     def git_add(
-        _runtime: ToolRuntime[None, Any],
+        runtime: ToolRuntime[None, Any],
         paths: Annotated[list[str], "File paths to stage"],
     ) -> str:
         """Stage files for commit."""
+        del runtime
         results: list[str] = []
         for path in paths:
             result = _git("add", path)
@@ -142,11 +155,12 @@ def git_tools_bundle(
         return "\n".join(results) if results else f"Staged {len(paths)} file(s)"
 
     def git_branch(
-        _runtime: ToolRuntime[None, Any],
+        runtime: ToolRuntime[None, Any],
         name: str | None = None,
         checkout: bool = False,
     ) -> str:
         """List branches, create a new branch, or checkout an existing one."""
+        del runtime
         if name is not None:
             from bog_agents.middleware.worktree import _validate_git_ref
 
@@ -163,11 +177,12 @@ def git_tools_bundle(
         return _git("branch", "-a", "--sort=-committerdate")
 
     def git_stash(
-        _runtime: ToolRuntime[None, Any],
+        runtime: ToolRuntime[None, Any],
         action: str = "list",
         message: str | None = None,
     ) -> str:
         """Manage git stash. action: 'push', 'pop', 'list', 'show', 'drop'."""
+        del runtime
         if action == "push":
             args = ["stash", "push"]
             if message:
@@ -182,12 +197,13 @@ def git_tools_bundle(
         return _git("stash", "list")
 
     def git_blame(
-        _runtime: ToolRuntime[None, Any],
+        runtime: ToolRuntime[None, Any],
         path: Annotated[str, "File path to blame"],
         start_line: int | None = None,
         end_line: int | None = None,
     ) -> str:
         """Show who last modified each line of a file."""
+        del runtime
         args = ["blame", "--no-pager"]
         if start_line and end_line:
             args.append(f"-L{start_line},{end_line}")
@@ -195,10 +211,11 @@ def git_tools_bundle(
         return _git(*args)
 
     def git_show(
-        _runtime: ToolRuntime[None, Any],
+        runtime: ToolRuntime[None, Any],
         ref: str = "HEAD",
     ) -> str:
         """Show details of a commit. Default shows the latest commit."""
+        del runtime
         return _git("show", "--stat", ref)
 
     return [

--- a/libs/bog-agents/tests/unit_tests/test_tool_bundles.py
+++ b/libs/bog-agents/tests/unit_tests/test_tool_bundles.py
@@ -12,6 +12,7 @@ emitted tool surface.
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -62,6 +63,95 @@ class TestGitToolsBundle:
         b = git_tools_bundle(working_dir=tmp_path)
         assert a is not b
         assert {t.name for t in a} == {t.name for t in b}
+
+
+class TestGitToolsInvocation:
+    """The tools must be callable with the runtime kwarg langgraph injects.
+
+    This catches the class of bug that shipped in 0.9.0: every tool in
+    ``git_tools_bundle`` declared its runtime parameter as ``_runtime``
+    (underscore-prefixed). Pydantic silently dropped underscore params
+    from the args schema AND langgraph's ToolNode didn't inject them, so
+    every git tool failed at agent invocation with
+    ``TypeError: missing 1 required positional argument: '_runtime'``.
+
+    The previous tests only asserted tool *names* — never invoked one —
+    so the bug slipped through CI. These tests close that gap by calling
+    every tool's underlying ``func`` with a mock runtime kwarg, exactly
+    the way ToolNode does it in production.
+    """
+
+    @staticmethod
+    def _mock_runtime() -> MagicMock:
+        from langchain.tools import ToolRuntime
+
+        runtime = MagicMock(spec=ToolRuntime)
+        runtime.tool_call_id = "tc-test"
+        runtime.state = {}
+        runtime.config = {}
+        return runtime
+
+    def test_every_tool_accepts_runtime_kwarg(self, tmp_path: Path) -> None:
+        """No tool may raise on a baseline runtime-only invocation."""
+        from bog_agents.tools import git_tools_bundle
+
+        with patch("bog_agents.middleware.git_tools._run_git", return_value="(mocked)"):
+            tools = git_tools_bundle(working_dir=tmp_path)
+            runtime = self._mock_runtime()
+            # Tools that need only the runtime kwarg (no required args).
+            no_arg_tools = {"git_status", "git_diff", "git_log", "git_branch", "git_stash", "git_show"}
+            for tool in tools:
+                if tool.name not in no_arg_tools:
+                    continue
+                result = tool.func(runtime=runtime)
+                assert result == "(mocked)", f"{tool.name} returned {result!r}"
+
+    def test_tools_with_required_args(self, tmp_path: Path) -> None:
+        """Tools that take additional args still receive the runtime."""
+        from bog_agents.tools import git_tools_bundle
+
+        with patch("bog_agents.middleware.git_tools._run_git", return_value="(mocked)") as run:
+            tools = git_tools_bundle(working_dir=tmp_path)
+            by_name = {t.name: t for t in tools}
+            runtime = self._mock_runtime()
+
+            # git_commit needs a message.
+            r = by_name["git_commit"].func(runtime=runtime, message="feat: x")
+            assert "(mocked)" in r
+
+            # git_add needs paths.
+            r = by_name["git_add"].func(runtime=runtime, paths=["a.py", "b.py"])
+            assert r  # any non-empty return is fine
+
+            # git_blame needs a path.
+            r = by_name["git_blame"].func(runtime=runtime, path="a.py")
+            assert r == "(mocked)"
+
+            # _run_git was actually called — the closure works.
+            assert run.call_count >= 1
+
+    def test_runtime_param_named_runtime_not_underscored(self) -> None:
+        """Regression guard: every tool's first parameter must be
+        named ``runtime``, exactly, with no leading underscore.
+
+        Pydantic drops underscore-prefixed params from the args schema
+        and langgraph's ToolNode only injects parameters with the
+        literal name ``runtime``. Anything else and the tool dies at
+        invocation time.
+        """
+        import inspect
+        from pathlib import Path as _Path
+
+        from bog_agents.tools import git_tools_bundle
+
+        for tool in git_tools_bundle(working_dir=_Path.cwd()):
+            sig = inspect.signature(tool.func)
+            first_param = next(iter(sig.parameters))
+            assert first_param == "runtime", (
+                f"{tool.name}: first param is {first_param!r}, expected 'runtime'. "
+                f"Underscore-prefixed names break ToolRuntime injection — see "
+                f"docs/sdk/tool-bundles.md for the rules."
+            )
 
 
 class TestPublicExports:


### PR DESCRIPTION
## What broke

\`/review\` and every other slash command that uses the git tools was crashing with:

\`\`\`
Agent error: {'error': 'TypeError', 'message': \"git_tools_bundle..git_diff() missing 1 required positional argument: '_runtime'\"}
\`\`\`

## Root cause

Each tool in \`git_tools_bundle\` declared its runtime parameter as **\`_runtime: ToolRuntime[None, Any]\`** (underscore-prefixed). Two compounding effects:

1. **Pydantic silently drops underscore-prefixed parameters** from a \`StructuredTool\` args schema — they're conventionally \"private\" and never expected to be filled.
2. **LangGraph's \`ToolNode\` does \`ToolRuntime\` injection by parameter *name*** — it looks for a parameter literally named \`runtime\` (per the langgraph docs / \`_DirectlyInjectedToolArg\` semantics). \`_runtime\` doesn't match, so no injection happens.

Net effect: the function signature requires the parameter, but nothing provides it. Every git tool dies before it runs. The bug shipped in **0.9.0** with the W4 tool-bundle refactor — the existing tests only asserted tool *names* without ever invoking one, so CI missed it.

## Fix

- All 9 tool functions now declare \`runtime: ToolRuntime[None, Any]\` (no underscore). Each body opens with \`del runtime\` to mark the parameter as deliberately unused by the closure (the closures bind \`wd\` directly) while keeping the contract loud.
- A comment block above the tool definitions explains the constraint so the next contributor can't reintroduce it.

## Deep-dive sweep

Grep-swept \`libs/bog-agents\`, \`libs/cli\`, \`libs/daemon\` for any other \`_<name>: ToolRuntime\` parameter shape — **only \`bog_agents/tools/bundles.py\` had it**. The other \`StructuredTool.from_function\` sites (\`air_gapped\`, \`approval_gates\`, \`architect\`, \`audit_trail\`, \`automations\`, \`multi_edit\`, \`read_many_files\`, \`async_subagents\`) all use \`runtime:\` (no underscore) correctly.

Two doc examples in **\`docs/sdk/tool-bundles.md\`** also propagated the buggy pattern (where users copy from) — fixed, plus a new \"name the runtime parameter exactly \`runtime\`\" rule of thumb explaining the trap.

## Regression tests

Added \`TestGitToolsInvocation\` (3 cases) that actually **invokes** the tools — closing the gap that let the bug ship:

- \`test_every_tool_accepts_runtime_kwarg\` — every tool callable via \`tool.func(runtime=mock_runtime)\` exactly as ToolNode calls it in production; \`_run_git\` mocked.
- \`test_tools_with_required_args\` — \`git_commit\`, \`git_add\`, \`git_blame\` invoked with their required args alongside runtime.
- \`test_runtime_param_named_runtime_not_underscored\` — inspect-based regression guard. The first parameter of every git tool must be named exactly \`runtime\`. The same class of bug will fail this assertion immediately if it ever returns.

## Verification

Full CI emulation across all three packages, all green:

| Package | Lint | ty | Tests |
|---|---|---|---|
| SDK | clean | clean | **1433 passed**, 128 skipped |
| CLI | clean | clean | **4249 passed**, 101 skipped |
| Daemon | clean | n/a | **113 passed**, 1 skipped |

End-to-end smoke test confirmed:
\`\`\`
git_status via tool.func(runtime=mock):  '## main\n M file.py'
git_diff   via tool.func(runtime=mock):  '## main\n M file.py'
\`\`\`
