### PR TITLE
docs(readme): refresh all READMEs for v0.9.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,24 @@
 
 > *Pass through in harmony. Opinionated where it matters.*
 
-**v0.8.7** — a production-ready AI agent framework built on LangGraph,
-deliberately calm by design.
+**v0.9.4** — a production-ready AI agent framework built on LangGraph.
+Patient by design, watchful by default. It does the careful work so you
+don't have to wire it up yourself.
 
 Three packages, one philosophy:
 
 - **[`bog-agents`](libs/bog-agents)** — the Python SDK. `create_agent()` returns a
-  compiled LangGraph agent with file tools, a shell, sub-agents, plan mode,
-  retry-with-backoff, and ~80 composable middlewares.
+  compiled LangGraph agent with file tools, a shell, git, sub-agents, plan mode,
+  retry-with-backoff, and ~80 composable middlewares. Drop-in
+  [deepagents](https://github.com/langchain-ai/deepagents) compatibility, too —
+  `create_deep_agent`, `DeepAgentState`, filesystem permissions, harness/provider
+  profiles.
 - **[`bog-agents-cli`](libs/cli)** — a coding agent that lives in your terminal.
   120+ slash commands, any LLM, persistent memory, MCP marketplace, `/peat`
   personal scheduler, `/qa` acceptance-criteria harness, `/record` + `/replay`,
-  in-memory secrets vault, `bog-agents drive` for non-interactive scripted
-  runs, matte-swamp / neon-green TUI.
+  in-memory secrets vault, `bog-agents drive` for scripted runs, and a full
+  **headless surface** so an AI agent or CI job can drive it without a human
+  at the keyboard. Matte-swamp TUI.
 - **[`bog-agents-daemon`](libs/daemon)** — the patient watcher. Runs your
   agents on cron / file-change / webhook / git-push triggers; survives
   reboots; reports back via Slack / email / GitHub / file / webhook.
@@ -25,22 +30,23 @@ Built on [LangGraph](https://github.com/langchain-ai/langgraph). MIT.
 
 ## Philosophy
 
-Most agent frameworks make you assemble the kit. We don't. Bog Agents starts
-you with a working agent — and lets you peel away or bolt on layers as you
-understand what you actually need.
+Out on the frontier a careful hand beats a fast one. Most agent frameworks
+hand you the parts and wish you luck. Bog Agents hands you a working agent —
+then lets you peel away or bolt on layers as you learn what the job actually
+asks for.
 
 - **Patient by default.** Failures retry with bounded backoff. Hung commands
-  time out. Provider hiccups don't kill the run. Crashes drop a redacted
-  panic dump for easy bug reports.
+  time out. Provider hiccups don't kill the run. A crash drops a redacted
+  panic dump so a bug report writes itself.
 - **Opinionated where it matters.** Secure-by-default backends. A
   memory-only secrets vault that never touches disk. Structured event
-  logging at every chokepoint. Tokens written atomically with `0o600`
+  logging at every chokepoint. Tokens written atomically at `0o600`
   before the rename — no world-readable race window.
-- **No ceremony.** `pipx install bog-agents-cli && bog-agents` and you have
-  a working agent in under a minute. `pip install bog-agents` and one
-  function call gets you a compiled agent.
-- **Composable.** 80+ middlewares snap on or off. Subagents nest.
-  Backends swap. The framework gets out of your way.
+- **No ceremony.** `pipx install bog-agents-cli && bog-agents` and you have a
+  working agent in under a minute. `pip install bog-agents` and one function
+  call gets you a compiled agent.
+- **Composable.** 80+ middlewares snap on or off. Subagents nest. Backends
+  swap. The framework gets out of your way.
 
 The bog is calm, deep, and unhurried. So is the agent.
 
@@ -48,7 +54,7 @@ The bog is calm, deep, and unhurried. So is the agent.
 
 ## Quick install
 
-### CLI (most users start here)
+### CLI (most folks start here)
 
 ```bash
 # pipx is recommended — isolated install, clean PATH
@@ -66,16 +72,21 @@ Provider extras:
 ```bash
 pip install 'bog-agents-cli[anthropic]'        # Claude
 pip install 'bog-agents-cli[openai]'           # GPT
+pip install 'bog-agents-cli[bedrock]'          # AWS Bedrock
 pip install 'bog-agents-cli[all-providers]'    # everything
 ```
 
-Then run:
+Set one provider key and ride:
 
 ```bash
-bog-agents --doctor-deep      # one-page health summary
-bog-agents                    # interactive TUI
+export ANTHROPIC_API_KEY=sk-ant-...     # or OPENAI_API_KEY, GOOGLE_API_KEY, AWS creds, ...
+bog-agents --doctor-deep                # one-page health check
+bog-agents                              # interactive TUI
 bog-agents -p "explain this module" < src/agent.py   # one-shot
 ```
+
+No key handy? Point it at a local [Ollama](https://ollama.com/) model and
+nothing leaves the machine.
 
 ### Daemon (ambient runner)
 
@@ -85,7 +96,7 @@ bog-agents-daemon run --port 7878
 ```
 
 See the [daemon README](libs/daemon/README.md) for systemd / Windows-task /
-launchd installation, REST API, trigger types, and output targets.
+launchd installation, the REST API, trigger types, and output targets.
 
 ### SDK only (for embedding agents in your own app)
 
@@ -101,40 +112,38 @@ result = await agent.ainvoke({"messages": [{"role": "user", "content": "hi"}]})
 ```
 
 See the [SDK README](libs/bog-agents/README.md) for backends, middlewares,
-and the full provider matrix.
+deepagents compatibility, and the full provider matrix.
 
 ---
 
-## What's new since 0.8.0
+## What's new in 0.9.x
 
-Successive waves have hardened the framework toward a credible 1.0:
+The 0.9 line is the run from a credible flagship toward 1.0. Each release
+hardened a different stretch of trail.
 
-- **Wave Y (0.8.8)** — Release-readiness hardening. Audit-trail strict
-  hook warnings, first-run no-API-key actionable error, preview-server
-  cap + cleanup tool, OAuth structured observability, opt-in
-  `MessageStore` JSONL persistence for crash recovery, `__all__` on
-  headline middleware modules, refreshed docs.
-- **Wave X (0.8.7)** — `merge_worktree` ref-injection fix,
-  `start_preview_server` `shlex` parsing + DEVNULL, daemon
-  `dispatch_errors` capture.
-- **Wave W (0.8.6)** — `bog-agents drive` scripted TUI runner with
-  YAML grammar + Pilot harness; tool-bundle pattern; canonical
-  middleware-ordering test; comprehensive resilience pass.
-- **Wave V (0.8.5)** — Stub middleware cleanup, ~7,900 lines net
-  deletion; `/causal` → `/trace-mind` rename.
-- **Wave U–T (0.8.4–0.8.3)** — architect-audit surgical fixes,
-  postmortem → dreamscape proposer feedback loop.
-- **Wave S–Q (0.8.2–0.8.0)** — TraceFile v1 (Ed25519 signed open
-  trace format), `/compliance` auditor, provable policies +
-  postmortem + time-travel replay.
+- **0.9.4 — deepagents parity, headless driving, provider resilience.**
+  A first-class [deepagents](https://github.com/langchain-ai/deepagents)
+  compatibility surface — `create_deep_agent`, `DeepAgentState`,
+  `FilesystemPermission`, `RubricMiddleware`, and `HarnessProfile` /
+  `ProviderProfile` keyed by `provider:model` — so a deepagents user can
+  switch over without rewriting, and back again. A **headless command
+  surface** (`bog-agents command "/help"`) plus `--jsonl` structured
+  streaming so agents and CI can drive the CLI non-interactively. Live-tested
+  resilience across Anthropic, AWS Bedrock, and OpenAI.
+- **0.9.1 — Bedrock, seamless.** Automatic inference-profile resolution,
+  `/bedrock fix` + `/bedrock config`, and auto SSO-credential refresh. Point
+  at a model id; the SDK sorts out the rest.
+- **0.9.0 — scriptable TUI, compliance, security sweep.** `bog-agents drive`
+  graduated to a full Pilot-backed runner; `/compliance` auditor with
+  HMAC-sealed reports; a repo-wide security pass.
 
-See [CHANGELOG.md](CHANGELOG.md) for the full history. The 0.8.0
-notes below cover the original flagship release.
+See [CHANGELOG.md](CHANGELOG.md) for the full history, including the 0.8.x
+flagship features (`/peat`, `/qa`, `/record` + `/replay`, the MCP
+marketplace) carried forward below.
 
-## What's new in 0.8.0
+---
 
-A genuine flagship release. Five top-line capabilities and a hundred small
-refinements.
+## The 0.8 flagship features (still here, still sharp)
 
 ### `/peat` — your personal assistant
 
@@ -147,7 +156,6 @@ five-phase plan, builds personalized digests from your `/qa` results and
 /peat schedule "0 9 * * 1-5 | summarize yesterday's QA results"
 /peat research "vector databases" --focus pricing,perf
 /peat digest --days 7
-/peat metrics
 ```
 
 ### `/qa` — adaptive QA harness
@@ -160,10 +168,9 @@ mcp — with verdicts (`exit_code`, `status`, `contains`, `regex`,
 ### `/record` + `/replay` — sessions you can edit and re-run
 
 `/record` captures user prompts, AI responses, and tool calls live.
-`/record stop` finalizes to a YAML file with auto-detected variables
-(Jira IDs, repo URLs, file paths) replaced by `${var}` placeholders.
-`/replay run` prompts for any unfilled variables and dispatches to the
-agent.
+`/record stop` finalizes to a YAML file with auto-detected variables (Jira
+IDs, repo URLs, file paths) replaced by `${var}` placeholders. `/replay run`
+prompts for any unfilled variables and dispatches to the agent.
 
 ### Vault + Vars
 
@@ -171,7 +178,7 @@ Typed variable system shared by `/replay` and `/qa`: `string`, `secret`,
 `enum`, `int`, `bool`. Secrets live only in process memory; nothing
 persists to disk. Optional read-only OS-keychain bridge.
 
-### MCP marketplace, expanded
+### MCP marketplace
 
 35+ curated servers across 9 categories: github, jira, gitlab, slack,
 postgres, mongodb, redis, bigquery, snowflake, supabase, aws, azure-devops,
@@ -184,45 +191,23 @@ discord, kubernetes, datadog, sentry, and more.
 /mcp add my-tool ...      # custom server
 ```
 
-### Plus, under the hood
-
-- **`ProviderRetryMiddleware`** — bounded exponential backoff with jitter
-  on transient provider errors. Never retries tool calls.
-- **`virtual_mode=True` is now the default** for `FilesystemBackend` and
-  `LocalShellBackend`. Path traversal blocked unless explicitly opted out
-  via `BOG_AGENTS_FS_UNSANDBOXED=1`.
-- **Subprocess `stdin=/dev/null`** — interactive commands like Windows
-  `date` get an immediate EOF instead of hanging the agent forever.
-- **Panic dumps** — uncaught exceptions land at
-  `~/.bog-agents/crash/<ts>.log` with redacted host info, versions,
-  traceback, and recent metrics. Attach the file when you open an issue.
-- **Structured event logging** at every chokepoint, ready for shippers
-  (Splunk, Loki, journald). Stable event names, prefixed `evt_*` fields.
-- **Mouse-tracking escape-sequence swallower** so moving the mouse over
-  the terminal during a long agent run no longer leaks `[<35;16;41M`
-  garbage into your input box.
-- **`--doctor-deep`** — runtime probes of every external dependency
-  (Python, dirs writable, settings parseable, git, provider envs, network
-  reachability, MCP config, recent crashes) in under a second.
-
-See [CHANGELOG.md](CHANGELOG.md) for the full 0.8.0 entry.
-
 ---
 
 ## Repository layout
 
 | Path | What |
 |---|---|
-| `libs/bog-agents/` | The Python SDK. Compiled LangGraph agents, ~80 middlewares, pluggable backends, tool bundles. |
-| `libs/cli/` | The terminal CLI. Textual TUI, 120+ slash commands, MCP marketplace, `bog-agents drive` scripted runner. |
-| `libs/daemon/` | The ambient daemon. Cron / file-watch / webhook triggers, REST API. |
+| `libs/bog-agents/` | The Python SDK. Compiled LangGraph agents, ~80 middlewares, pluggable backends, tool bundles, deepagents compatibility. |
+| `libs/cli/` | The terminal CLI. Textual TUI, 120+ slash commands, MCP marketplace, headless command surface, `bog-agents drive` scripted runner. |
+| `libs/daemon/` | The ambient daemon. Cron / file-watch / webhook / git-push triggers, REST API. |
 | `libs/acp/` | Agent Client Protocol bridge for the Zed editor. |
 | `libs/harbor/` | Evaluation / benchmark harness (Terminal Bench 2.0). |
-| `libs/partners/` | Sandbox provider integrations (today: Daytona). |
+| `libs/partners/` | Sandbox provider integrations (first-party source today: Daytona). |
 | `libs/vscode-extension/` | VS Code integration. |
 
 Each package has its own `pyproject.toml`, `Makefile`, and version. SDK / CLI /
-daemon are released together; the rest tag independently.
+daemon are released together on synchronized versions; the rest tag
+independently.
 
 ---
 
@@ -238,7 +223,7 @@ uv sync --reinstall
 uv run bog-agents
 ```
 
-Each package has the same Makefile targets:
+Every package answers the same Makefile targets:
 
 ```bash
 make test        # unit tests, no network
@@ -264,10 +249,11 @@ Start with **[`docs/`](docs/)** — the full documentation tree:
 - **[Security Model](docs/security.md)** — what's safe by default,
   what isn't, threat boundaries
 - **CLI deep dives**: [Drive runner](docs/cli/drive.md) ·
-  [Slash commands](docs/cli/slash-commands.md)
+  [Slash command reference](libs/cli/README.md#day-to-day-commands)
 - **SDK guides**: [Quickstart](docs/sdk/quickstart.md) ·
   [Middleware](docs/sdk/middleware.md) ·
   [Tool bundles](docs/sdk/tool-bundles.md)
+- **Providers**: [AWS Bedrock](docs/providers/bedrock.md)
 - **Daemon**: [Quickstart](docs/daemon/quickstart.md)
 - **Advanced**: [Expert Rules](docs/advanced/expert-rules.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,10 +21,8 @@ examples wherever possible.
 | | |
 |---|---|
 | [Drive runner](cli/drive.md) | Scripted non-interactive TUI runs. The whole point. |
-| [Modes](cli/modes.md) | Interactive, `-p`, `-n`, `--serve`, `--acp`, `--drive`, when to use which |
-| [Slash commands](cli/slash-commands.md) | The 120+ slash command surface, grouped by intent |
-| [MCP](cli/mcp.md) | Marketplace, custom servers, trust, OAuth |
-| [Observability](cli/observability.md) | Logs, panic dumps, structured events, `--doctor-deep` |
+| [Slash command reference](../libs/cli/README.md#day-to-day-commands) | The 120+ slash command surface, grouped by intent (in the CLI README) |
+| [Headless driving](../libs/cli/README.md#driving-it-headless) | `-n` / `-p`, `--json` / `--jsonl`, `bog-agents command`, when to use which |
 
 ## SDK (`bog-agents`)
 
@@ -32,8 +30,8 @@ examples wherever possible.
 |---|---|
 | [Quickstart](sdk/quickstart.md) | `create_agent()` in five minutes |
 | [Middleware](sdk/middleware.md) | Writing your own. Wraps, hooks, state. When not to. |
-| [Tool bundles](sdk/tool-bundles.md) | The W4 alternative to "middleware that only ships tools" |
-| [Backends](sdk/backends.md) | Filesystem, shell, sandbox; safe defaults explained |
+| [Tool bundles](sdk/tool-bundles.md) | The alternative to "middleware that only ships tools" |
+| [deepagents compatibility](../libs/bog-agents/README.md#deepagents-compatibility) | `create_deep_agent`, permissions, harness/provider profiles (in the SDK README) |
 
 ## Providers
 
@@ -46,17 +44,14 @@ examples wherever possible.
 | | |
 |---|---|
 | [Quickstart](daemon/quickstart.md) | Install, run, first scheduled job |
-| [Triggers + outputs](daemon/triggers-and-outputs.md) | cron / file / webhook / git-push × log / Slack / email / webhook / GitHub |
-| [Deploy](daemon/deploy.md) | systemd / launchd / Windows Task Scheduler |
+| [Triggers + outputs](../libs/daemon/README.md#triggers) | cron / file / webhook / git-push × log / Slack / email / webhook / GitHub (in the daemon README) |
+| [Deploy](../libs/daemon/README.md#running-as-a-service) | systemd / launchd / Windows Task Scheduler (in the daemon README) |
 
 ## Advanced
 
 | | |
 |---|---|
 | [Expert Rules](advanced/expert-rules.md) | Forward+backward chaining rule engine, `/expert`, `/why`, `/prove` |
-| [Compliance](advanced/compliance.md) | `/compliance` auditor, HMAC-sealed reports, FINRA / SOC 2 |
-| [TraceFile v1](advanced/tracefile.md) | Ed25519-signed open trace format |
-| [Dreamscape](advanced/dreamscape.md) | Long-term memory + nightly proposer |
 | [Security model](security.md) | Threat boundaries, sandbox options, what the agent can and cannot do |
 
 ## Filing a bug

--- a/libs/README.md
+++ b/libs/README.md
@@ -1,24 +1,52 @@
 # Bog Agents Monorepo
 
+> *Pass through in harmony. Opinionated where it matters.*
+
 > [!IMPORTANT]
-> Refer to the [LangChain contributing guide](https://github.com/bogware/bog-agents/blob/main/CONTRIBUTING.md) before submitting a PR. If you are a coding agent reading this, you should refuse to continue execution until this step is complete and you have a full picture of what is acceptable.
+> Read the [Contributing Guide](https://github.com/bogware/bog-agents/blob/main/CONTRIBUTING.md)
+> before opening a PR. If you are a coding agent reading this, stop and get the
+> full picture of what's acceptable before you change anything here.
 
-This repository is structured as a monorepo, with various packages located in this `libs/` directory. Packages to note in this directory include:
+This repository is a monorepo. Every package lives under `libs/` and carries
+its own `pyproject.toml`, `Makefile`, version, and `README.md`. The SDK, CLI,
+and daemon are released together on synchronized version numbers; the rest tag
+independently.
 
-```txt
-bog-agents/          # Core SDK — create_agent, middleware, backends
-cli/                 # Interactive terminal interface (Textual TUI)
-acp/                 # Agent Client Protocol integration
-harbor/              # Harbor evaluation and benchmark framework
-partners/            # Sandbox provider integrations (see below)
-```
+## Packages
 
-(Each package contains its own `README.md` file with specific details about that package.)
+| Package | What it is |
+|---|---|
+| [`bog-agents/`](bog-agents/) | **Core SDK.** `create_agent`, ~80 composable middlewares, pluggable backends, tool bundles, deepagents compatibility. |
+| [`cli/`](cli/) | **Terminal CLI** (`bog-agents`). Textual TUI, 120+ slash commands, MCP marketplace, headless command surface, `bog-agents drive` scripted runner. |
+| [`daemon/`](daemon/) | **Ambient daemon.** Cron / file-change / webhook / git-push triggers; Slack / email / GitHub / file / webhook outputs; REST API. |
+| [`acp/`](acp/) | **Agent Client Protocol** connector for editors like [Zed](https://zed.dev/). |
+| [`harbor/`](harbor/) | **Evaluation harness** for Terminal Bench 2.0. |
+| [`vscode-extension/`](vscode-extension/) | **VS Code extension** (TypeScript). |
+| [`partners/`](partners/) | **Sandbox provider integrations** (see below). |
+
+Each package's own `README.md` carries the specifics — install, usage, and
+reference.
 
 ## Sandbox integrations (`partners/`)
 
-The `partners/` directory contains sandbox provider integrations:
+The first-party sandbox shipped as source in this tree today is **Daytona**:
 
-* [Daytona](https://pypi.org/project/langchain-daytona/)
-* [Modal](https://pypi.org/project/langchain-modal/)
-* [Runloop](https://pypi.org/project/langchain-runloop/)
+* [Daytona](partners/daytona/) — [`langchain-daytona`](https://pypi.org/project/langchain-daytona/) on PyPI
+
+The SDK's `SandboxBackend` can also target Modal, RunLoop, and LangSmith
+sandboxes at runtime via their respective extras; those providers are not
+shipped as first-party source packages here. See the
+[SDK README](bog-agents/README.md#backends) for the backend matrix.
+
+## Working from source
+
+```bash
+# from a package directory, e.g. libs/cli
+uv sync          # install dependencies
+make test        # unit tests, no network
+make lint        # ruff check + ruff format --diff + ty
+make format      # ruff fix + ruff format
+```
+
+CI runs `make lint` + `make test` per package on every PR
+(`.github/workflows/ci.yml`).

--- a/libs/acp/README.md
+++ b/libs/acp/README.md
@@ -1,6 +1,8 @@
 # Bog Agents ACP integration
 
-This directory contains an [Agent Client Protocol (ACP)](https://agentclientprotocol.com/overview/introduction) connector that allows you to run a Python [Bog Agents](https://github.com/bogware/bog-agents) within a text editor that supports ACP such as [Zed](https://zed.dev/).
+> *Pass through in harmony. Opinionated where it matters.*
+
+Bring the agent in off the trail and into your editor. This directory contains an [Agent Client Protocol (ACP)](https://agentclientprotocol.com/overview/introduction) connector that runs a Python [Bog Agents](https://github.com/bogware/bog-agents) agent inside any editor that speaks ACP — such as [Zed](https://zed.dev/).
 
 ![Bog Agents ACP Demo](./static/img/bog-agents-acp.gif)
 

--- a/libs/bog-agents/README.md
+++ b/libs/bog-agents/README.md
@@ -9,8 +9,10 @@ SDK in its own right when you want to build agents that aren't a CLI.
 One `create_agent()` call gets you a compiled LangGraph agent with file tools, a shell,
 git, sub-agents, plan mode, auto-quality checks, retry-with-backoff against transient
 provider failures, and ~80 composable middlewares. Pluggable backends. Tool bundles
-for callers who don't want middleware overhead. Any tool-calling LLM. The defaults
-are deliberate — you ship something that works on day one without writing scaffolding.
+for callers who don't want middleware overhead. Drop-in
+[deepagents](https://github.com/langchain-ai/deepagents) compatibility. Any
+tool-calling LLM. The defaults are deliberate — you ship something that works on
+day one without writing scaffolding.
 
 [![PyPI](https://img.shields.io/pypi/v/bog-agents)](https://pypi.org/project/bog-agents/)
 [![Python](https://img.shields.io/pypi/pyversions/bog-agents)](https://pypi.org/project/bog-agents/)
@@ -21,9 +23,9 @@ are deliberate — you ship something that works on day one without writing scaf
 
 ## Philosophy
 
-Most agent frameworks make you assemble the kit. We don't. Bog Agents starts you
-with a working agent and lets you peel away or bolt on layers as you understand
-what you actually need.
+A careful hand beats a fast one. Most agent frameworks make you assemble the
+kit. We don't. Bog Agents starts you with a working agent and lets you peel
+away or bolt on layers as you understand what the job actually asks for.
 
 - **Patient by default.** Failures retry with bounded backoff. Hung commands time out.
   Provider hiccups don't kill the run.
@@ -32,9 +34,9 @@ what you actually need.
 - **No ceremony.** `create_agent()` returns a compiled `CompiledStateGraph` you can
   invoke. Plug it into your app. Done.
 - **Composable.** ~80 middlewares snap on or off. Subagents nest. Backends swap. The
-  framework gets out of your way. New in 0.8.6: **tool bundles** —
-  free-function factories that return `list[BaseTool]` for callers who
-  only want a set of tools without the middleware machinery.
+  framework gets out of your way. **Tool bundles** — free-function factories
+  that return `list[BaseTool]` — serve callers who only want a set of tools
+  without the middleware machinery.
 
 The bog is calm, deep, and unhurried. So is the agent.
 
@@ -110,6 +112,44 @@ agent = create_agent(
 
 ---
 
+## deepagents compatibility
+
+Coming from [deepagents](https://github.com/langchain-ai/deepagents)? You can
+switch over without rewriting — and switch back if you ever want to. We ship a
+compatibility surface that speaks the same dialect.
+
+```python
+from bog_agents import create_deep_agent, DeepAgentState, FilesystemPermission
+
+agent = create_deep_agent(
+    model="anthropic:claude-sonnet-4-6",
+    tools=[...],
+    # Confine the agent's filesystem reach with allow/deny/interrupt rules
+    permissions=[
+        FilesystemPermission(operations=["write", "delete"], paths=["./src/**"], mode="allow"),
+        FilesystemPermission(operations=["write"], paths=["./secrets/**"], mode="deny"),
+    ],
+)
+```
+
+What's in the box:
+
+| Symbol | What it gives you |
+|---|---|
+| `create_deep_agent` | `create_agent` with `state_schema=DeepAgentState` defaulted on. |
+| `DeepAgentState` | The deepagents state shape, backed by a `DeltaChannel` messages reducer (O(N) checkpoints, not O(N²)). |
+| `FilesystemPermission` | Per-operation, per-path `allow` / `deny` / `interrupt` rules. `deny` is enforced in `wrap_tool_call`; `interrupt` routes through human-in-the-loop. |
+| `RubricMiddleware` | The grader self-evaluation loop — score the agent's own output against a rubric and retry. |
+| `HarnessProfile` / `HarnessProfileConfig` | Per-`provider:model` overlays: prompt, extra middleware, tool-description overrides, excluded tools/middleware, general-purpose subagent. |
+| `ProviderProfile` | Per-provider `init_kwargs` / `pre_init` / `init_kwargs_factory`, applied during model resolution. |
+| `register_harness_profile` / `register_provider_profile` | Register your own profiles. |
+
+Permissions and a typed `response_format` are also accepted on `SubAgent`
+specs, so sub-agents can be sandboxed independently of their parent. Every
+addition is opt-in: existing `create_agent` callers see no behavior change.
+
+---
+
 ## What's in the box
 
 ### Backends
@@ -119,15 +159,18 @@ Pluggable filesystems and shells. Pick one or compose them.
 | Backend | Use when |
 |---|---|
 | `StateBackend` (default) | Agent reads / writes happen in graph state. Great for sandboxed tests. |
-| `FilesystemBackend` | Real filesystem. Path traversal blocked by `virtual_mode=True` (the default since 0.8.0). |
+| `FilesystemBackend` | Real filesystem. Path traversal blocked by `virtual_mode=True` (the default). |
 | `LocalShellBackend` | Filesystem + shell execution on the host. UTF-8 stdout decoding, configurable timeouts, `stdin=/dev/null` so interactive prompts can't hang the agent. |
 | `CompositeBackend` | Route different path prefixes to different backends. |
-| `SandboxBackend` | Modal / Daytona / RunLoop / LangSmith remote sandboxes. |
+| `SandboxBackend` | Daytona / Modal / RunLoop / LangSmith remote sandboxes. |
 
 ### Middlewares (selected)
 
 - **`ProviderRetryMiddleware`** — bounded exponential backoff with jitter on transient
   provider errors (5xx, timeouts, connection resets). Never retries tool calls.
+- **`FilesystemPermissionsMiddleware`** — enforce `FilesystemPermission` rules
+  (allow / deny / interrupt) on file tools.
+- **`RubricMiddleware`** — grade the agent's output against a rubric and loop.
 - **`MemoryMiddleware`** — load `AGENTS.md` files into the system prompt. 64 KiB cap;
   `</agent_memory>` close-tags neutralized to prevent prompt-injection forgery.
 - **`SkillsMiddleware`** — bundle reusable agent skills with metadata.
@@ -154,7 +197,7 @@ from bog_agents import create_agent
 from bog_agents.tools import git_tools_bundle
 
 agent = create_agent(
-    model="anthropic:claude-sonnet-4-7",
+    model="anthropic:claude-sonnet-4-6",
     tools=[*git_tools_bundle(working_dir=".")],
 )
 ```
@@ -169,9 +212,9 @@ as thin backwards-compatible shims that delegate to the bundles.
 
 | Provider | Extra | Notes |
 |---|---|---|
-| Anthropic | `anthropic` | Default. Claude 4.6 / 4.7 with prompt caching. |
+| Anthropic | `anthropic` | Default. Claude 4.x with prompt caching. |
 | OpenAI | `openai` | Responses API by default. |
-| AWS Bedrock | `bedrock` | Claude / Llama / Titan via `bedrock:` prefix. |
+| AWS Bedrock | `bedrock` | Claude / Llama / Titan via `bedrock:` prefix. Auto inference-profile resolution + SSO refresh. |
 | Google | `google-genai` | Gemini family. |
 | Mistral | `mistralai` | |
 | Groq | `groq` | |
@@ -182,6 +225,7 @@ as thin backwards-compatible shims that delegate to the bundles.
 | Ollama | `ollama` | Local models. |
 
 Pass `model="provider:model-id"` and `create_agent` does the rest.
+Per-provider initialization can be tuned with a `ProviderProfile`.
 
 ---
 
@@ -199,31 +243,20 @@ Streaming is supported via the standard LangGraph stream APIs.
 
 ---
 
-## What's new since 0.8.0
+## What's new in 0.9.x
 
-- **0.8.7 (Wave X)** — `merge_worktree` ref-injection fix,
-  `start_preview_server` shlex parsing + interactive-command DEVNULL,
-  daemon `JobRun.dispatch_errors` per-target failure capture.
-- **0.8.6 (Wave W)** — **Tool bundles** (`bog_agents.tools.bundles`),
-  canonical middleware-ordering test that locks `graph.py`'s
-  sequence, `AuditTrailMiddleware.strict_hooks` flag + hook-failure
-  counter, fixed server log handle leak on `Popen` failure.
-- **0.8.5 (Wave V)** — Stub middleware cleanup: 17 modules deleted,
-  ~7,900 lines net deletion.
-
-## What's new in 0.8.0
-
-- **`ProviderRetryMiddleware`** — bounded retries on transient provider failures.
-- **`virtual_mode=True` is now the default** for `FilesystemBackend` (and
-  `LocalShellBackend`). Path traversal blocked unless explicitly opted out.
-- **Subprocess `stdin=/dev/null`** in `LocalShellBackend.execute()` — interactive
-  commands like Windows `date` get an immediate EOF instead of hanging.
-- **Typed subagent validation** at `create_agent()` — typo'd `name` /
-  `description` / `system_prompt` fails fast instead of surfacing as a
-  `KeyError` later.
-- **`FileOperationError` Literal** extended with `parent_not_found`.
-- **`MemoryMiddleware`** caps each AGENTS.md source at 64 KiB and neutralizes
-  `</agent_memory>` close-tags (prompt-injection defense).
+- **0.9.4** — **deepagents parity**: `create_deep_agent`, `DeepAgentState`
+  (with an O(N) `DeltaChannel` messages reducer), `FilesystemPermission`,
+  `RubricMiddleware`, `HarnessProfile` / `ProviderProfile`, plus
+  `SubAgent.permissions` / `response_format`. Provider resilience
+  live-tested across Anthropic, AWS Bedrock, and OpenAI; `bedrock` /
+  `openai` / `all-providers` extras added.
+- **0.9.1** — **Bedrock, seamless**: automatic inference-profile resolution
+  and auto SSO-credential refresh in `resolve_model`.
+- **0.9.0** — scriptable TUI groundwork, compliance auditing, repo-wide
+  security sweep.
+- **0.8.6** — **tool bundles** (`bog_agents.tools.bundles`) and the
+  canonical middleware-ordering test that locks `graph.py`'s sequence.
 
 See [`CHANGELOG.md`](https://github.com/bogware/bog-agents/blob/main/CHANGELOG.md)
 for the full release history.

--- a/libs/cli/README.md
+++ b/libs/cli/README.md
@@ -26,19 +26,20 @@ You can have an agent in your terminal in under a minute. You can also build
 one out from there for years. The CLI is shaped to support both.
 
 - **Patient by default.** Provider hiccups retry. Hung commands time out.
-  Mouse-tracking escape sequences don't leak into your input box. Crashes
-  drop a redacted panic dump for easy bug reports.
+  Mouse-tracking escape sequences don't leak into your input box. A crash
+  drops a redacted panic dump so a bug report writes itself.
 - **Secure-by-default.** Filesystem confined to the project root unless you
   explicitly opt out. Secrets live in an in-memory vault that's never
-  persisted to disk. OAuth tokens written atomically with `0o600` mode
-  set before the rename — no world-readable race window.
+  persisted to disk. OAuth tokens written atomically at `0o600` mode set
+  before the rename — no world-readable race window.
 - **Discoverable.** Type `/` and a fuzzy menu shows you 120+ commands. The
   MCP marketplace browses 35+ servers across 9 categories. `--doctor-deep`
   probes every external dependency in under a second.
-- **Scriptable.** `bog-agents drive <script.yaml>` runs the TUI
-  non-interactively against a YAML grammar — slash commands, typed
-  prompts, modal interactions, snapshots, assertions — so you can
-  exercise every TUI surface in CI without a human at the keyboard.
+- **Drivable by machines.** Run it without a human at the keyboard:
+  one-shot prompts, `--json` / `--jsonl` structured output, a headless
+  slash-command surface (`bog-agents command`), and `bog-agents drive`
+  for scripting the whole TUI. Built so an AI agent or CI job can operate
+  the CLI end to end.
 - **A *bog* aesthetic.** Matte swamp palette — muted moss, lichen-grey,
   firefly-amber warnings, heather-rust errors. Ultima-inspired heavy-serif
   splash banner with rune anchors. A still pool, not a neon arcade.
@@ -50,6 +51,9 @@ one out from there for years. The CLI is shaped to support both.
 ```bash
 # pipx is recommended (isolates dependencies, gives you a clean PATH entry)
 pipx install bog-agents-cli
+
+# or with uv
+uv tool install bog-agents-cli
 
 # or plain pip
 pip install bog-agents-cli
@@ -98,32 +102,62 @@ bog-agents -n "fix the failing test in tests/test_auth.py" --auto-approve
 
 ---
 
-## What's new since 0.8.0
+## Driving it headless
 
-The most recent waves (post-flagship) have hardened the CLI toward a
-credible 1.0:
+When the operator is another program, you want clean exits and machine-readable
+output. The CLI gives you three levels of that.
 
-- **Wave Y (0.8.8)** — Audit-trail strict-hook warnings, first-run
-  no-API-key actionable error, preview-server cap (5/instance) +
-  `stop_all_preview_servers` tool, OAuth structured observability,
-  opt-in `MessageStore` JSONL persistence for crash recovery,
-  `__all__` declarations on headline middleware modules.
-- **Wave X (0.8.7)** — `merge_worktree` ref-injection fix,
-  `start_preview_server` shlex parsing + DEVNULL, daemon dispatch
-  errors captured on the run record.
-- **Wave W (0.8.6)** — **`bog-agents drive`** scripted TUI runner
-  (YAML grammar, Pilot harness, deterministic `fake:`/`replay:` model
-  shims, SVG + text snapshots); tool-bundle pattern; canonical
-  middleware-ordering test.
+### One-shot agent runs
+
+```bash
+bog-agents -n "summarize the diff on this branch" --json
+```
+
+`--json` wraps the run in a single envelope (final text + tool calls);
+`--jsonl` streams one event per line (`start`, `text`, `tool_call`,
+`tool_result`, `final`) so a caller can follow the run live.
+
+### Headless slash commands
+
+Informational and configuration slash commands run without booting the TUI:
+
+```bash
+bog-agents command "/help"          # full command reference
+bog-agents command "/commands"      # list commands; * marks headless-capable
+bog-agents command "/version" --json
+bog-agents command "/model"         # show the configured model
+bog-agents command "/config"        # resolved config + file path
+```
+
+Exit codes: `0` success, `1` ran-but-failed, `2` unknown or not-available-headless.
+Commands that are inherently interactive return a clear message listing the ones that
+aren't — no silent hangs.
+
+### Scripted TUI (`bog-agents drive`)
+
+For exercising the *interactive* surface non-interactively — typed prompts,
+modal interactions, snapshots, assertions — see [Drive](#bog-agents-drive-example) below.
+
+---
+
+## What's new in 0.9.x
+
+- **0.9.4 — headless driving + provider resilience.** A headless
+  slash-command surface (`bog-agents command "/help"`), `--jsonl`
+  structured streaming with tool-call events, and deepagents parity
+  carried up from the SDK. Live-tested across Anthropic, AWS Bedrock,
+  and OpenAI.
+- **0.9.1 — Bedrock, seamless.** Automatic inference-profile resolution,
+  `/bedrock fix` + `/bedrock config`, auto SSO-credential refresh. Point
+  at a model id and ride.
+- **0.9.0 — scriptable TUI, compliance, security sweep.** `bog-agents drive`
+  graduated to a full Pilot-backed runner; `/compliance` auditor with
+  HMAC-sealed reports; a repo-wide security pass.
 
 See [CHANGELOG.md](https://github.com/bogware/bog-agents/blob/main/CHANGELOG.md)
-for the full history. The 0.8.0 notes below cover the original
-flagship release.
+for the full history. The flagship 0.8.0 capabilities below are all still here.
 
-## What's new in 0.8.0
-
-A genuine flagship release. Five top-line capabilities and a hundred small
-refinements.
+## Flagship capabilities (0.8.0, carried forward)
 
 ### `/peat` — your personal assistant
 
@@ -206,6 +240,7 @@ discord, kubernetes, datadog, sentry — and more.
 |---|---|
 | `/help` | Full command reference |
 | `/model` | Switch model on the fly |
+| `/bedrock` | Bedrock inference-profile status, `fix`, `config` |
 | `/profile` | Apply a saved configuration preset |
 | `/plan` | Toggle plan-mode (think-then-act) |
 | `/effort` | Adjust thinking budget for the current model |
@@ -220,6 +255,7 @@ discord, kubernetes, datadog, sentry — and more.
 | `/audit` | Dependency vulnerability audit |
 | `/test` | Test generation, coverage, audit |
 | `/build` | Pipeline / recipe builder |
+| `/compliance` | Compliance auditor with HMAC-sealed reports |
 | `/peat` | Personal assistant + scheduler (see above) |
 | `/qa` | Acceptance-criteria QA harness (see above) |
 | `/record` / `/replay` | Capture and re-run sessions (see above) |
@@ -271,19 +307,21 @@ bog-agents --sandbox runloop     # RunLoop sandbox (when installed)
 bog-agents --sandbox langsmith   # LangSmith hosted sandbox
 ```
 
-Today's first-party sandbox is **Daytona** (`libs/partners/daytona/`).
-The other providers are configurable via their respective extras; see
-the SDK docs for credentials and limits.
+The first-party sandbox shipped as source today is **Daytona**
+(`libs/partners/daytona/`). The other providers are configurable via their
+respective extras; see the SDK docs for credentials and limits.
 
 ---
 
-## Headless modes
+## Headless modes at a glance
 
-| Flag | Use when |
+| Flag / subcommand | Use when |
 |---|---|
 | `-n MSG` | Run a task and exit. Great for CI / scripts. |
 | `-p MSG` | Same as `-n` but quiet — clean stdout for pipes. |
-| `--json` | Emit the result as a JSON envelope. |
+| `--json` | Emit the result as a single JSON envelope (text + tool calls). |
+| `--jsonl` | Stream one JSON event per line (start / text / tool_call / tool_result / final). |
+| `command "/…"` | Run a headless-capable slash command (`/help`, `/version`, `/model`, `/config`, `/commands`, `/changelog`). |
 | `--prompt NAME` | Run a saved prompt from your prompt library. |
 | `--prompt-vars JSON` | Pass variable bindings to a saved prompt. |
 | `--pipeline NAME` | Run a saved pipeline from `.bog-agents/pipelines/`. |

--- a/libs/daemon/README.md
+++ b/libs/daemon/README.md
@@ -7,7 +7,8 @@ Schedules. File watches. Inbound webhooks. Git pushes. Sits in the
 background, fires the agent when something happens, writes the result
 wherever you point it.
 
-No terminal needed. No hand-holding. Goes the distance.
+No terminal needed. No hand-holding. It keeps watch through the night and
+goes the distance.
 
 [![PyPI](https://img.shields.io/pypi/v/bog-agents-daemon)](https://pypi.org/project/bog-agents-daemon/)
 [![Python](https://img.shields.io/pypi/pyversions/bog-agents-daemon)](https://pypi.org/project/bog-agents-daemon/)
@@ -209,18 +210,23 @@ launchctl load ~/Library/LaunchAgents/com.bogware.bog-agents-daemon.plist
 
 ---
 
-## What's new since 0.8.0
+## What's new in 0.9.x
 
-- **0.8.8 (Wave Y)** — `JobRun.dispatch_errors` capped at 20 entries
-  with an `(overflow)` summary so a wide-fanout outage (e.g. 100
-  Slack recipients hit during an API outage) doesn't blow up the
-  run record JSON.
-- **0.8.7 (Wave X)** — Per-target output dispatch failures (email,
-  webhook, Slack) are captured on `JobRun.dispatch_errors` so
-  operators can tell from the runs table that delivery failed even
-  when the agent itself completed.
-- **0.8.0** — Patient by default (provider retries, `stdin=/dev/null`
-  for interactive commands, `virtual_mode=True` filesystem confinement,
+The daemon rides the synchronized monorepo version, so it inherits every
+SDK hardening as it lands.
+
+- **0.9.4** — deepagents parity and provider resilience flow up from the
+  SDK: Anthropic, AWS Bedrock, and OpenAI are live-tested, so scheduled
+  jobs survive a provider's bad night.
+- **0.9.1** — **Bedrock, seamless.** Automatic inference-profile
+  resolution and auto SSO-credential refresh mean a long-lived daemon
+  keeps firing Bedrock jobs without a stale-credential outage.
+- **0.9.0** — repo-wide security sweep; compliance auditing groundwork.
+- **Carried forward** — `JobRun.dispatch_errors` per-target capture
+  (capped at 20 entries with an `(overflow)` summary) so a wide-fanout
+  outage shows up in the runs table without blowing up the record JSON;
+  patient-by-default execution (provider retries, `stdin=/dev/null` for
+  interactive commands, `virtual_mode=True` filesystem confinement,
   structured event logs ready for log shippers).
 
 ---

--- a/libs/harbor/README.md
+++ b/libs/harbor/README.md
@@ -1,8 +1,10 @@
 # Building Bog Agents Harnesses for Terminal Bench 2.0 with Harbor
 
+> *Measure twice. The benchmark doesn't grade on charm.*
+
 ## Overview
 
-This repository demonstrates how to evaluate and improve your Bog Agents agent harness using [Harbor](https://harborframework.com/) and [LangSmith](https://www.langchain.com/langsmith/observability).
+This package shows how to evaluate and harden your Bog Agents harness using [Harbor](https://harborframework.com/) and [LangSmith](https://www.langchain.com/langsmith/observability) — run the agent against a hard benchmark, read where it stumbled, fix the harness, run it again.
 
 ### What is Harbor?
 

--- a/libs/vscode-extension/README.md
+++ b/libs/vscode-extension/README.md
@@ -1,6 +1,8 @@
 # Bog Agents for VS Code
 
-A VS Code extension that brings Bog Agents AI coding assistance directly into your editor.
+> *Pass through in harmony. Opinionated where it matters.*
+
+A VS Code extension that brings the Bog Agents coding agent right into your editor — chat, review, explain, and fix without leaving the file you're in.
 
 ## Features
 


### PR DESCRIPTION
## What

Docs-only refresh of every first-party README to match the current **v0.9.4**
release, with a consistent professional voice and a measured touch of frontier
grit layered over the existing bog-calm aesthetic.

## Why

The READMEs had drifted: they advertised **v0.8.7**, their "what's new"
sections topped out at 0.8.x, and none mentioned the 0.9.x headline work
(deepagents parity, headless driving, provider resilience, Bedrock seamless).
A few also carried inaccurate or dead links.

## Changes

- **root / SDK / CLI / daemon** — version bumped to 0.9.4; stale 0.8.x
  "what's new" replaced with accurate 0.9.x highlights.
- **SDK** — new first-class **deepagents compatibility** section
  (`create_deep_agent`, `DeepAgentState`, `FilesystemPermission`,
  `RubricMiddleware`, `HarnessProfile` / `ProviderProfile`).
- **CLI** — documents the headless surface (`bog-agents command`) and
  `--jsonl` structured streaming so agents/CI can drive it without a TUI.
- **libs/README** — partners section corrected: only **Daytona** ships as
  first-party source; Modal/RunLoop/LangSmith are runtime sandbox targets.
  Added the daemon/cli/vscode packages that were missing from the table.
- **docs/README + root** — fixed nine dead documentation links (now point at
  existing pages or anchored README sections).
- **acp / harbor / vscode-extension** — consistent epigraph + intro.

## Accuracy notes

Grounded against the per-package `CHANGELOG.md` files (0.9.0–0.9.4) and the
actual repo state (git-tracked partners, existing `docs/` pages). Example and
internal-test READMEs were left untouched — they are accurate and
purpose-specific, and Western-grit styling would only reduce their clarity.

## Safety

**Docs only — no code, no version bumps.** Branched off `origin/main`. As
`docs:` commits they do not trigger release-please, and `release.yml` /
`vscode-extension.yml` are `workflow_call` / `workflow_dispatch` only. Only
`ci.yml` (lint + test) runs on this PR. **No deployment is triggered.**
