### PR TITLE
feat(sdk,cli): add street sweeper context-pruning with savings metrics

### DIFF
--- a/libs/bog-agents/bog_agents/__init__.py
+++ b/libs/bog-agents/bog_agents/__init__.py
@@ -86,6 +86,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "SelfImprovingMiddleware": ("bog_agents.middleware.self_improving", "SelfImprovingMiddleware"),
     "SmartApprovalsMiddleware": ("bog_agents.middleware.smart_approvals", "SmartApprovalsMiddleware"),
     "SmartContextMiddleware": ("bog_agents.middleware.smart_context", "SmartContextMiddleware"),
+    "StreetSweeperMiddleware": ("bog_agents.middleware.street_sweeper", "StreetSweeperMiddleware"),
     "SubAgent": ("bog_agents.middleware.subagents", "SubAgent"),
     "SubAgentMiddleware": ("bog_agents.middleware.subagents", "SubAgentMiddleware"),
     "TestGenerationMiddleware": ("bog_agents.middleware.test_generation", "TestGenerationMiddleware"),

--- a/libs/bog-agents/bog_agents/feature_config.py
+++ b/libs/bog-agents/bog_agents/feature_config.py
@@ -46,6 +46,9 @@ class FeatureConfig:
         max_agent_threads: Max concurrent agent threads (default 10).
         enable_smart_context: Enable smart context window management.
         max_context_tokens: Token budget for smart context (default 200 000).
+        enable_street_sweeper: Continuously prune dead context each turn.
+        street_sweeper_aggressive: Enable Tier 2 head/tail truncation of large old outputs.
+        street_sweeper_keep_recent: Trailing messages the sweeper never touches.
         enable_conversation_branching: Enable conversation branching.
         enable_image_input: Enable image input processing.
         enable_browser: Enable browser-agent tools.
@@ -136,6 +139,14 @@ class FeatureConfig:
     max_agent_threads: int = 10
     enable_smart_context: bool = False
     max_context_tokens: int = 200000
+    # Street sweeper — continuous, lossless-first context pruning. Disabled by
+    # default; runs on every model call to strip dead weight (ANSI/whitespace,
+    # duplicate + stale-read tool results, and — when aggressive — head/tail
+    # truncation of large old outputs) from the request the model sees, with
+    # originals offloaded to the backend for `recall_swept`.
+    enable_street_sweeper: bool = False
+    street_sweeper_aggressive: bool = True
+    street_sweeper_keep_recent: int = 6
     enable_conversation_branching: bool = False
     enable_image_input: bool = False
     enable_browser: bool = False

--- a/libs/bog-agents/bog_agents/graph.py
+++ b/libs/bog-agents/bog_agents/graph.py
@@ -720,6 +720,24 @@ def create_agent(  # Complex graph assembly logic with many conditional branches
 
         agents_middleware.append(SmartContextMiddleware(working_dir=_wd, max_context_tokens=f.max_context_tokens))
 
+    # Street sweeper — sits outer of the default SummarizationMiddleware (so it
+    # trims litter before summarization measures the threshold) and inner of
+    # CostTrackerMiddleware. It only edits message *content*, never count/order,
+    # so summarization's cutoff indices and prompt-caching's prefix stay aligned.
+    if f.enable_street_sweeper:
+        from bog_agents._models import get_model_identifier
+        from bog_agents.middleware.street_sweeper import StreetSweeperMiddleware
+
+        sweeper_model = get_model_identifier(model) or "" if isinstance(model, BaseChatModel) else str(model or "")
+        agents_middleware.append(
+            StreetSweeperMiddleware(
+                aggressive=f.street_sweeper_aggressive,
+                keep_recent=f.street_sweeper_keep_recent,
+                backend=backend,
+                model_name=sweeper_model,
+            )
+        )
+
     if f.enable_conversation_branching:
         from bog_agents.middleware.conversation_branch import ConversationBranchMiddleware
 

--- a/libs/bog-agents/bog_agents/middleware/__init__.py
+++ b/libs/bog-agents/bog_agents/middleware/__init__.py
@@ -148,6 +148,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "SkillsMiddleware": ("skills", "SkillsMiddleware"),
     "SmartApprovalsMiddleware": ("smart_approvals", "SmartApprovalsMiddleware"),
     "SmartContextMiddleware": ("smart_context", "SmartContextMiddleware"),
+    "StreetSweeperMiddleware": ("street_sweeper", "StreetSweeperMiddleware"),
     "SubAgent": ("subagents", "SubAgent"),
     "SubAgentMiddleware": ("subagents", "SubAgentMiddleware"),
     "SummarizationMiddleware": ("summarization", "SummarizationMiddleware"),

--- a/libs/bog-agents/bog_agents/middleware/street_sweeper.py
+++ b/libs/bog-agents/bog_agents/middleware/street_sweeper.py
@@ -1,0 +1,964 @@
+"""Street-sweeper middleware — continuous, lossless-first context pruning.
+
+Feature: Street Sweeper. Unlike `SummarizationMiddleware` (which fires a single
+LLM-based compaction once the context window is ~85% full), the street sweeper
+runs on *every* model call and mechanically removes dead weight from the
+messages *as they are sent to the model* — before the litter ever accumulates.
+
+The sweep is a **view transformation**: the canonical full history stays in
+LangGraph state untouched, and the sweeper only reshapes the per-call request
+via `request.override(messages=...)`. This means:
+
+- Token savings land on every API call (the provider only bills the swept view).
+- Nothing is destroyed — the full originals remain in state, and any content the
+    sweeper *drops from the view* (stale reads, duplicates, truncated tails) is
+    additionally offloaded to the backend so the model can pull it back with the
+    `recall_swept` tool.
+- The transformation is deterministic and **never changes message count or
+    order** — only the text *content* of individual messages — so it composes
+    safely with `SummarizationMiddleware` (whose cutoff indices stay aligned) and
+    keeps `AnthropicPromptCachingMiddleware`'s prefix stable across turns.
+
+## Tiers
+
+The sweep is organized into tiers matching the feature's configuration:
+
+- **Tier 0 — lossless mechanical** (always on): strip ANSI escapes, trailing
+    whitespace, collapse blank-line runs, and collapse long runs of identical
+    lines (e.g. repeated stack frames) into a single line with a count marker.
+- **Tier 1 — superseded content** (always on): replace a tool result with a
+    one-line stub when it is byte-identical to a later result (`dedup`), or when
+    a file read has been superseded by a later read/edit of the same path
+    (`stale_read`).
+- **Tier 2 — heuristic relevance** (`aggressive=True`): truncate large, old tool
+    outputs to a head + tail window with an elision marker.
+
+Recent messages (the last `keep_recent`) and all `HumanMessage`/system content
+are never swept, so live working context and user intent stay intact.
+
+## Observability
+
+Every sweep records structured `SweepAction` entries into an in-memory
+`SweepLog` (cumulative tokens saved, per-technique breakdown, recent actions),
+exposed via the `sweep_log` property for the CLI `/sweep status` / `/sweep log`
+surface and for tests.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, cast
+
+from langchain.agents.middleware.types import AgentMiddleware
+from langchain.tools import ToolRuntime
+from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, ToolMessage
+from langchain_core.messages.utils import count_tokens_approximately
+from langgraph.config import get_config
+from typing_extensions import TypedDict
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from langchain.agents.middleware.types import ModelRequest, ModelResponse
+    from langchain_core.runnables.config import RunnableConfig
+    from langchain_core.tools import BaseTool
+    from langgraph.runtime import Runtime
+
+    from bog_agents.backends.protocol import BACKEND_TYPES, BackendProtocol
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "StreetSweeperMiddleware",
+    "SweepAction",
+    "SweepLog",
+]
+
+# A conservative default set of tool names. ``read`` / ``read_file`` produce
+# file content; the mutating set invalidates any earlier read of the same path.
+# These match the canonical bog-agents tool names (see ``summarization.py``'s
+# ``write_file`` / ``edit_file`` truncation logic).
+_DEFAULT_READ_TOOLS = frozenset({"read_file", "read"})
+_DEFAULT_MUTATE_TOOLS = frozenset({"write_file", "edit_file", "multi_edit", "apply_patch"})
+
+# Common path argument keys across the filesystem tools.
+_PATH_ARG_KEYS = ("file_path", "path", "filename", "target_file")
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+_BLANK_RUN_RE = re.compile(r"\n{3,}")
+
+# Collapse this many or more consecutive identical lines into one + a marker.
+_IDENTICAL_LINE_RUN = 4
+
+
+class SweepAction(TypedDict):
+    """One pruning action taken during a sweep.
+
+    Attributes:
+        technique: The sweep technique applied — one of `whitespace`, `dedup`,
+            `stale_read`, or `truncate`.
+        tool_name: The originating tool name (or `""` for non-tool messages).
+        tokens_before: Approximate token count of the message content before the sweep.
+        tokens_after: Approximate token count after the sweep.
+    """
+
+    technique: str
+    tool_name: str
+    tokens_before: int
+    tokens_after: int
+
+
+def _input_usd_per_token(model_name: str | None) -> float:
+    """Estimate the USD cost of a single input token for `model_name`.
+
+    Reuses `cost_tracker._MODEL_COSTS` as the single source of truth for pricing
+    so the sweeper's dollar figures stay consistent with the cost tracker. The
+    table is keyed by bare model name, so we strip any provider prefix
+    (`anthropic:`) and fall back to a substring match, then to a conservative
+    default for unknown models.
+
+    Args:
+        model_name: The model spec (e.g. `anthropic:claude-sonnet-4-6`), or `None`.
+
+    Returns:
+        Estimated USD per input token.
+    """
+    default = 5.0 / 1_000_000
+    if not model_name:
+        return default
+    try:
+        from bog_agents.middleware.cost_tracker import _MODEL_COSTS
+    except Exception:  # pragma: no cover - defensive: pricing is best-effort
+        return default
+    name = model_name.split(":")[-1]
+    costs = _MODEL_COSTS.get(name)
+    if costs is None:
+        for key, candidate in _MODEL_COSTS.items():
+            if key in name or name in key:
+                costs = candidate
+                break
+    if costs is None:
+        costs = (5.0, 15.0)
+    return costs[0] / 1_000_000
+
+
+@dataclass
+class SweepLog:
+    """Cumulative record of everything the street sweeper has removed.
+
+    Token totals accumulate *per model call* — a message swept on three
+    successive calls is counted three times, because the swept tokens are not
+    billed on each of those three requests. That per-call accumulation is what
+    makes `tokens_saved` (and `dollars_saved`) map directly to money not spent.
+
+    Attributes:
+        actions_total: Total number of sweep actions applied across the session.
+        calls_swept: Number of model calls on which at least one action fired.
+        tokens_before_total: Summed pre-sweep tokens across all swept messages.
+        tokens_after_total: Summed post-sweep tokens across all swept messages.
+        by_technique: Tokens saved, keyed by technique name.
+        counts_by_technique: Action counts, keyed by technique name.
+        recent: A capped ring of the most recent `SweepAction` entries.
+        usd_per_input_token: Price used to convert saved tokens to dollars.
+    """
+
+    actions_total: int = 0
+    calls_swept: int = 0
+    tokens_before_total: int = 0
+    tokens_after_total: int = 0
+    by_technique: dict[str, int] = field(default_factory=dict)
+    counts_by_technique: dict[str, int] = field(default_factory=dict)
+    recent: list[SweepAction] = field(default_factory=list)
+    usd_per_input_token: float = 0.0
+    _recent_cap: int = 200
+
+    @property
+    def tokens_saved(self) -> int:
+        """Approximate total tokens removed from model requests so far."""
+        return max(0, self.tokens_before_total - self.tokens_after_total)
+
+    @property
+    def dollars_saved(self) -> float:
+        """Estimated USD not spent — `tokens_saved` priced at the input rate.
+
+        This is a pre-cache-discount upper bound: tokens that would have been
+        served from the prompt cache are billed at a fraction of the input rate,
+        so the realized saving is somewhat lower.
+        """
+        return self.tokens_saved * self.usd_per_input_token
+
+    @property
+    def reduction_pct(self) -> float:
+        """Tokens saved as a percentage of the swept content's original size."""
+        if self.tokens_before_total <= 0:
+            return 0.0
+        return 100.0 * self.tokens_saved / self.tokens_before_total
+
+    def record(self, action: SweepAction) -> None:
+        """Accumulate a single sweep action into the running totals.
+
+        Args:
+            action: The action to record.
+        """
+        self.actions_total += 1
+        self.tokens_before_total += action["tokens_before"]
+        self.tokens_after_total += action["tokens_after"]
+        saved = max(0, action["tokens_before"] - action["tokens_after"])
+        technique = action["technique"]
+        self.by_technique[technique] = self.by_technique.get(technique, 0) + saved
+        self.counts_by_technique[technique] = self.counts_by_technique.get(technique, 0) + 1
+        self.recent.append(action)
+        if len(self.recent) > self._recent_cap:
+            del self.recent[: len(self.recent) - self._recent_cap]
+
+    def record_call(self) -> None:
+        """Mark that one model call was swept (>= 1 action)."""
+        self.calls_swept += 1
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a serializable snapshot of the metrics (for export/persistence).
+
+        Returns:
+            A plain dict of all cumulative metrics.
+        """
+        return {
+            "actions_total": self.actions_total,
+            "calls_swept": self.calls_swept,
+            "tokens_before_total": self.tokens_before_total,
+            "tokens_after_total": self.tokens_after_total,
+            "tokens_saved": self.tokens_saved,
+            "dollars_saved": self.dollars_saved,
+            "reduction_pct": self.reduction_pct,
+            "by_technique": dict(self.by_technique),
+            "counts_by_technique": dict(self.counts_by_technique),
+        }
+
+    def format_summary(self) -> str:
+        """Render a human-readable summary of cumulative savings.
+
+        Returns:
+            A multi-line string suitable for the CLI `/sweep status` output.
+        """
+        if self.actions_total == 0:
+            return "Street sweeper: no context pruned yet this session."
+        lines = [
+            f"Tokens removed: ~{self.tokens_saved:,} ({self.reduction_pct:.0f}% of swept content) over {self.calls_swept} model calls, {self.actions_total} actions.",
+        ]
+        if self.usd_per_input_token > 0:
+            lines.append(f"Estimated savings: ~${self.dollars_saved:,.4f} (input-rate, pre cache-discount).")
+        for technique, saved in sorted(self.by_technique.items(), key=lambda kv: kv[1], reverse=True):
+            count = self.counts_by_technique.get(technique, 0)
+            lines.append(f"  - {technique}: ~{saved:,} tokens ({count} actions)")
+        return "\n".join(lines)
+
+
+@dataclass
+class _Plan:
+    """Result of planning a sweep over a message list.
+
+    Attributes:
+        messages: The reshaped message list (same length/order as the input).
+        actions: The sweep actions that were applied.
+        offloads: `(marker, header, original_content)` tuples for dropped content.
+    """
+
+    messages: list[AnyMessage]
+    actions: list[SweepAction]
+    offloads: list[tuple[str, str, str]]
+
+
+def _content_to_text(content: Any) -> str | None:
+    """Return plain text for message content, or `None` if not safely sweepable.
+
+    Only `str` content is swept. List/structured content (multimodal blocks,
+    tool-use blocks) is left untouched to avoid corrupting non-text payloads.
+
+    Args:
+        content: The raw `message.content` value.
+
+    Returns:
+        The text to sweep, or `None` when the content should be skipped.
+    """
+    if isinstance(content, str):
+        return content
+    return None
+
+
+def _collapse_identical_runs(lines: list[str]) -> list[str]:
+    """Collapse runs of >= `_IDENTICAL_LINE_RUN` identical lines into one + a marker.
+
+    Targets repeated stack frames and repeated log lines. The replacement notes
+    how many lines were collapsed so the signal ("this repeated a lot") is kept.
+
+    Args:
+        lines: The already-rstripped lines.
+
+    Returns:
+        The collapsed line list.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(lines)
+    while i < n:
+        j = i
+        while j < n and lines[j] == lines[i]:
+            j += 1
+        run = j - i
+        if run >= _IDENTICAL_LINE_RUN and lines[i].strip():
+            out.append(lines[i])
+            out.append(f"... (x{run} identical lines)")
+        else:
+            out.extend(lines[i:j])
+        i = j
+    return out
+
+
+def _normalize_text(text: str) -> str:
+    """Apply Tier 0 lossless mechanical cleanup to a block of text.
+
+    Strips ANSI escapes and trailing per-line whitespace, collapses long runs of
+    identical lines, and squeezes 3+ blank lines down to one. Deterministic and
+    idempotent — running it twice yields the same result, which keeps the prompt
+    cache prefix stable.
+
+    Args:
+        text: The text to normalize.
+
+    Returns:
+        The normalized text.
+    """
+    text = _ANSI_RE.sub("", text)
+    lines = [ln.rstrip() for ln in text.split("\n")]
+    lines = _collapse_identical_runs(lines)
+    out = "\n".join(lines)
+    return _BLANK_RUN_RE.sub("\n\n", out)
+
+
+def _truncate_head_tail(text: str, head_lines: int, tail_lines: int) -> str:
+    """Keep the first `head_lines` and last `tail_lines`, eliding the middle.
+
+    Args:
+        text: The text to truncate.
+        head_lines: Number of leading lines to keep.
+        tail_lines: Number of trailing lines to keep.
+
+    Returns:
+        The truncated text with an elision marker noting how many lines were cut.
+    """
+    lines = text.split("\n")
+    if len(lines) <= head_lines + tail_lines:
+        return text
+    cut = len(lines) - head_lines - tail_lines
+    head = lines[:head_lines]
+    tail = lines[-tail_lines:]
+    marker = f"... ({cut} lines swept - use recall_swept to retrieve the full output) ..."
+    return "\n".join([*head, marker, *tail])
+
+
+class StreetSweeperMiddleware(AgentMiddleware):
+    """Continuously prune dead weight from each model request.
+
+    See the module docstring for the full design. This middleware preserves
+    message count and order, mutating only the text content of `ToolMessage` and
+    `AIMessage` objects outside the protected recent window.
+
+    Args:
+        enabled: When `False`, the middleware is a transparent pass-through.
+        aggressive: Enable Tier 2 (head/tail truncation of large old outputs).
+        keep_recent: Number of trailing messages never swept.
+        head_lines: Leading lines kept when truncating (Tier 2).
+        tail_lines: Trailing lines kept when truncating (Tier 2).
+        truncate_min_lines: Minimum line count before a tool output is eligible
+            for Tier 2 truncation.
+        backend: Backend (instance or factory) used to offload dropped content
+            for `recall_swept`. When `None`, offload is disabled and dropped
+            content is recoverable only from raw LangGraph state.
+        history_path_prefix: Path prefix for the per-thread offload file.
+        read_tools: Tool names whose results are file reads (for stale-read detection).
+        mutate_tools: Tool names that invalidate earlier reads of the same path.
+    """
+
+    def __init__(
+        self,
+        *,
+        enabled: bool = True,
+        aggressive: bool = True,
+        keep_recent: int = 6,
+        head_lines: int = 16,
+        tail_lines: int = 16,
+        truncate_min_lines: int = 40,
+        backend: BACKEND_TYPES | None = None,
+        model_name: str | None = None,
+        on_commit: Callable[[dict[str, Any]], None] | None = None,
+        history_path_prefix: str = "/swept_context",
+        read_tools: frozenset[str] = _DEFAULT_READ_TOOLS,
+        mutate_tools: frozenset[str] = _DEFAULT_MUTATE_TOOLS,
+    ) -> None:
+        self.enabled = enabled
+        self.aggressive = aggressive
+        self.keep_recent = max(0, keep_recent)
+        self.head_lines = max(1, head_lines)
+        self.tail_lines = max(1, tail_lines)
+        self.truncate_min_lines = max(head_lines + tail_lines + 1, truncate_min_lines)
+        self._backend = backend
+        self._model_name = model_name
+        # Fired once per swept model call with a per-turn delta dict; used by the
+        # CLI to accumulate a persistent, cross-session savings ledger.
+        self.on_commit = on_commit
+        self._history_path_prefix = history_path_prefix
+        self._read_tools = read_tools
+        self._mutate_tools = mutate_tools
+        self.sweep_log = SweepLog(usd_per_input_token=_input_usd_per_token(model_name))
+        # tool_call_ids whose original has already been offloaded this session,
+        # so we don't re-append the same content to the offload file each turn.
+        self._offloaded: set[str] = set()
+        self.tools: list[BaseTool] = [self._build_recall_tool()]
+
+    def set_backend(self, backend: BACKEND_TYPES | None) -> None:
+        """Point the sweeper at a backend for offload/recall.
+
+        Used by long-lived (singleton) instances that are constructed before the
+        agent's backend exists and re-attached on each agent rebuild.
+
+        Args:
+            backend: The backend instance or factory, or `None` to disable offload.
+        """
+        self._backend = backend
+
+    def set_pricing(self, model_name: str | None) -> None:
+        """Update the model used to price saved tokens into dollars.
+
+        Args:
+            model_name: The model spec to price against (e.g. `anthropic:claude-sonnet-4-6`).
+        """
+        self._model_name = model_name
+        self.sweep_log.usd_per_input_token = _input_usd_per_token(model_name)
+
+    # ------------------------------------------------------------------ planning
+
+    @staticmethod
+    def _tool_call_index(messages: list[AnyMessage]) -> dict[str, tuple[str, dict[str, Any]]]:
+        """Map each tool_call_id to its (tool_name, args) from AIMessage tool calls.
+
+        Args:
+            messages: The full message list.
+
+        Returns:
+            A dict keyed by tool_call_id.
+        """
+        index: dict[str, tuple[str, dict[str, Any]]] = {}
+        for msg in messages:
+            if isinstance(msg, AIMessage):
+                for call in msg.tool_calls or []:
+                    call_id = call.get("id")
+                    if call_id:
+                        index[call_id] = (call.get("name", ""), call.get("args", {}) or {})
+        return index
+
+    @staticmethod
+    def _path_of(args: dict[str, Any]) -> str | None:
+        """Extract a file path from tool-call args, trying common key names.
+
+        Args:
+            args: The tool call argument dict.
+
+        Returns:
+            The path string, or `None` if no recognizable path key is present.
+        """
+        for key in _PATH_ARG_KEYS:
+            value = args.get(key)
+            if isinstance(value, str) and value:
+                return value
+        return None
+
+    def _superseded_read_indices(
+        self,
+        messages: list[AnyMessage],
+        call_index: dict[str, tuple[str, dict[str, Any]]],
+    ) -> set[int]:
+        """Find message indices of file reads that a later read/edit has superseded.
+
+        A read of path X at index i is stale if any later message (j > i) is a
+        read of X (re-read) or a mutation of X (write/edit). The most recent read
+        of each path is always kept.
+
+        Args:
+            messages: The full message list.
+            call_index: Map from tool_call_id to (tool_name, args).
+
+        Returns:
+            The set of message indices whose content should be replaced with a stub.
+        """
+        # Collect (index, path, is_read) events in order.
+        events: list[tuple[int, str, bool]] = []
+        for i, msg in enumerate(messages):
+            if not isinstance(msg, ToolMessage):
+                continue
+            name, args = call_index.get(msg.tool_call_id, ("", {}))
+            tool_name = msg.name or name
+            path = self._path_of(args)
+            if path is None:
+                continue
+            if tool_name in self._read_tools:
+                events.append((i, path, True))
+            elif tool_name in self._mutate_tools:
+                events.append((i, path, False))
+
+        stale: set[int] = set()
+        for k, (idx, path, is_read) in enumerate(events):
+            if not is_read:
+                continue
+            # Stale if any later event touches the same path.
+            if any(p == path for _, p, _ in events[k + 1 :]):
+                stale.add(idx)
+        return stale
+
+    def _plan(self, messages: list[AnyMessage]) -> _Plan:
+        """Plan a sweep over `messages` without mutating the input.
+
+        Args:
+            messages: The full message list from the request.
+
+        Returns:
+            A `_Plan` with the reshaped messages, applied actions, and offloads.
+        """
+        new_messages = list(messages)
+        actions: list[SweepAction] = []
+        offloads: list[tuple[str, str, str]] = []
+
+        eligible_end = len(messages) - self.keep_recent
+        if eligible_end <= 0:
+            return _Plan(new_messages, actions, offloads)
+
+        call_index = self._tool_call_index(messages)
+        stale_indices = self._superseded_read_indices(messages, call_index)
+
+        # Dedup: keep the LAST occurrence of each identical tool-output hash;
+        # stub earlier eligible duplicates. Hash over all messages so a recent
+        # copy outside the window can still "win".
+        last_seen: dict[str, int] = {}
+        for i, msg in enumerate(messages):
+            if isinstance(msg, ToolMessage):
+                text = _content_to_text(msg.content)
+                if text is not None and text.strip():
+                    last_seen[hashlib.sha1(text.encode("utf-8", "ignore")).hexdigest()] = i
+
+        for i in range(eligible_end):
+            msg = messages[i]
+            try:
+                planned = self._plan_one(msg, i, stale_indices, last_seen)
+            except Exception:  # never let planning break the model call
+                logger.debug("street_sweeper: planning failed for message %d", i, exc_info=True)
+                continue
+            if planned is None:
+                continue
+            new_msg, action, offload = planned
+            new_messages[i] = new_msg
+            actions.append(action)
+            if offload is not None:
+                offloads.append(offload)
+
+        return _Plan(new_messages, actions, offloads)
+
+    def _plan_one(
+        self,
+        msg: AnyMessage,
+        index: int,
+        stale_indices: set[int],
+        last_seen: dict[str, int],
+    ) -> tuple[AnyMessage, SweepAction, tuple[str, str, str] | None] | None:
+        """Plan the sweep for a single message.
+
+        Resolution priority: stale_read > dedup > truncate > whitespace.
+        Stubbing techniques (stale_read/dedup) offload the dropped original;
+        whitespace cleanup is lossless and offloads nothing.
+
+        Args:
+            msg: The message to consider.
+            index: Its index in the full list.
+            stale_indices: Indices flagged as superseded reads.
+            last_seen: Map from content hash to the last index it appears at.
+
+        Returns:
+            A `(new_message, action, offload_or_none)` tuple, or `None` if the
+            message is left unchanged.
+        """
+        # Human input and summaries are sacred; only tool output and AI text.
+        if isinstance(msg, HumanMessage):
+            return None
+        text = _content_to_text(msg.content)
+        if text is None or not text.strip():
+            return None
+
+        tool_name = msg.name or "" if isinstance(msg, ToolMessage) else ""
+        before = count_tokens_approximately([msg])
+
+        if isinstance(msg, ToolMessage):
+            marker = msg.tool_call_id or f"idx-{index}"
+            content_hash = hashlib.sha1(text.encode("utf-8", "ignore")).hexdigest()
+
+            if index in stale_indices:
+                stub = f'[stale: this file read was superseded by a later read/edit. Use recall_swept("{marker}") for the original.]'
+                return self._stub(msg, stub, "stale_read", tool_name, before, marker, text)
+
+            if last_seen.get(content_hash, index) > index:
+                stub = f'[duplicate: identical to a later tool result. Use recall_swept("{marker}") for the original.]'
+                return self._stub(msg, stub, "dedup", tool_name, before, marker, text)
+
+            if self.aggressive and text.count("\n") + 1 >= self.truncate_min_lines:
+                truncated = _normalize_text(_truncate_head_tail(text, self.head_lines, self.tail_lines))
+                if truncated != text:
+                    new_msg = msg.model_copy(update={"content": truncated})
+                    after = count_tokens_approximately([new_msg])
+                    action: SweepAction = {"technique": "truncate", "tool_name": tool_name, "tokens_before": before, "tokens_after": after}
+                    header = self._offload_header(marker, tool_name, "truncate")
+                    return new_msg, action, (marker, header, text)
+
+        # Tier 0 lossless cleanup (tool output or AI text).
+        normalized = _normalize_text(text)
+        if normalized == text:
+            return None
+        new_msg = msg.model_copy(update={"content": normalized})
+        after = count_tokens_approximately([new_msg])
+        action = {"technique": "whitespace", "tool_name": tool_name, "tokens_before": before, "tokens_after": after}
+        return new_msg, action, None
+
+    def _stub(
+        self,
+        msg: AnyMessage,
+        stub: str,
+        technique: str,
+        tool_name: str,
+        before: int,
+        marker: str,
+        original: str,
+    ) -> tuple[AnyMessage, SweepAction, tuple[str, str, str]]:
+        """Build the replacement message + action + offload for a stubbing technique.
+
+        Args:
+            msg: The original message.
+            stub: The one-line replacement content.
+            technique: The sweep technique name.
+            tool_name: The originating tool name.
+            before: Pre-sweep token count.
+            marker: The recall marker (tool_call_id).
+            original: The original content to offload.
+
+        Returns:
+            A `(new_message, action, offload)` tuple.
+        """
+        new_msg = msg.model_copy(update={"content": stub})
+        after = count_tokens_approximately([new_msg])
+        action: SweepAction = {"technique": technique, "tool_name": tool_name, "tokens_before": before, "tokens_after": after}
+        return new_msg, action, (marker, self._offload_header(marker, tool_name, technique), original)
+
+    @staticmethod
+    def _offload_header(marker: str, tool_name: str, technique: str) -> str:
+        """Build the markdown section header for an offloaded original.
+
+        Args:
+            marker: The recall marker (tool_call_id).
+            tool_name: The originating tool name.
+            technique: The sweep technique that dropped the content.
+
+        Returns:
+            A markdown `###` header line including a UTC timestamp.
+        """
+        timestamp = datetime.now(UTC).isoformat()
+        return f"### swept {marker} | {tool_name or 'tool'} | {technique} | {timestamp}"
+
+    # ------------------------------------------------------------------ offload
+
+    def _get_thread_id(self) -> str:
+        """Return the current langgraph `thread_id`, or a generated session id.
+
+        Returns:
+            The thread id string.
+        """
+        try:
+            config = get_config()
+            thread_id = config.get("configurable", {}).get("thread_id")
+            if thread_id is not None:
+                return str(thread_id)
+        except RuntimeError:
+            pass
+        return f"session_{uuid.uuid4().hex[:8]}"
+
+    def _history_path(self) -> str:
+        """Return the per-thread offload file path."""
+        return f"{self._history_path_prefix}/{self._get_thread_id()}.md"
+
+    def _resolve_backend(self, state: Any, runtime: Runtime) -> BackendProtocol | None:
+        """Resolve the backend from an instance or factory, mirroring summarization.
+
+        Args:
+            state: The current agent state.
+            runtime: The runtime context (for factory backends).
+
+        Returns:
+            A resolved backend, or `None` when offload is disabled.
+        """
+        if self._backend is None:
+            return None
+        if callable(self._backend):
+            config = cast("RunnableConfig", getattr(runtime, "config", {}))
+            tool_runtime = ToolRuntime(
+                state=state,
+                context=runtime.context,
+                stream_writer=runtime.stream_writer,
+                store=runtime.store,
+                config=config,
+                tool_call_id=None,
+            )
+            return self._backend(tool_runtime)  # ty: ignore[call-top-callable]
+        return self._backend
+
+    def _pending_offloads(self, offloads: list[tuple[str, str, str]]) -> str:
+        """Render not-yet-offloaded sections and mark their markers as written.
+
+        Args:
+            offloads: All offloads planned this turn.
+
+        Returns:
+            The concatenated markdown for sections not previously offloaded
+            (empty string if there is nothing new).
+        """
+        sections: list[str] = []
+        for marker, header, content in offloads:
+            if marker in self._offloaded:
+                continue
+            self._offloaded.add(marker)
+            sections.append(f"{header}\n\n{content}\n\n")
+        return "".join(sections)
+
+    def _offload(self, backend: BackendProtocol, addition: str) -> None:
+        """Append rendered sections to the per-thread offload file (sync, best-effort).
+
+        Args:
+            backend: The resolved backend.
+            addition: The markdown to append.
+        """
+        path = self._history_path()
+        existing = ""
+        try:
+            responses = backend.download_files([path])
+            if responses and responses[0].content is not None and responses[0].error is None:
+                existing = responses[0].content.decode("utf-8")
+        except Exception:
+            logger.debug("street_sweeper: no existing offload file at %s", path, exc_info=True)
+        try:
+            combined = existing + addition
+            if existing:
+                backend.edit(path, existing, combined)
+            else:
+                backend.write(path, combined)
+        except Exception:
+            logger.warning("street_sweeper: failed to offload swept content to %s", path, exc_info=True)
+
+    async def _aoffload(self, backend: BackendProtocol, addition: str) -> None:
+        """Append rendered sections to the per-thread offload file (async, best-effort).
+
+        Args:
+            backend: The resolved backend.
+            addition: The markdown to append.
+        """
+        path = self._history_path()
+        existing = ""
+        try:
+            responses = await backend.adownload_files([path])
+            if responses and responses[0].content is not None and responses[0].error is None:
+                existing = responses[0].content.decode("utf-8")
+        except Exception:
+            logger.debug("street_sweeper: no existing offload file at %s", path, exc_info=True)
+        try:
+            combined = existing + addition
+            if existing:
+                await backend.aedit(path, existing, combined)
+            else:
+                await backend.awrite(path, combined)
+        except Exception:
+            logger.warning("street_sweeper: failed to offload swept content to %s", path, exc_info=True)
+
+    def _commit_actions(self, actions: list[SweepAction]) -> None:
+        """Record actions to the sweep log and emit a debug line.
+
+        Args:
+            actions: The actions applied this turn.
+        """
+        if not actions:
+            return
+        for action in actions:
+            self.sweep_log.record(action)
+        self.sweep_log.record_call()
+        before = sum(a["tokens_before"] for a in actions)
+        after = sum(a["tokens_after"] for a in actions)
+        saved = max(0, before - after)
+        logger.debug("street_sweeper: %d actions this turn, ~%d tokens removed", len(actions), saved)
+        if self.on_commit is not None:
+            delta = {
+                "tokens_before": before,
+                "tokens_after": after,
+                "tokens_saved": saved,
+                "actions": len(actions),
+                "dollars_saved": saved * self.sweep_log.usd_per_input_token,
+            }
+            try:
+                self.on_commit(delta)
+            except Exception:  # a metrics sink must never break the model call
+                logger.debug("street_sweeper: on_commit hook failed", exc_info=True)
+
+    # ------------------------------------------------------------------ hooks
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], ModelResponse],
+    ) -> ModelResponse:
+        """Sweep the request's messages before the model is called (sync).
+
+        Args:
+            request: The model request to reshape.
+            handler: The downstream handler to invoke with the swept request.
+
+        Returns:
+            The model response from the handler.
+        """
+        if not self.enabled:
+            return handler(request)
+        try:
+            plan = self._plan(request.messages)
+        except Exception:
+            logger.warning("street_sweeper: sweep planning failed; passing request through unchanged", exc_info=True)
+            return handler(request)
+        if not plan.actions:
+            return handler(request)
+
+        backend = self._resolve_backend(request.state, request.runtime)
+        if backend is not None and plan.offloads:
+            addition = self._pending_offloads(plan.offloads)
+            if addition:
+                self._offload(backend, addition)
+        self._commit_actions(plan.actions)
+        return handler(request.override(messages=plan.messages))
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        """Sweep the request's messages before the model is called (async).
+
+        Args:
+            request: The model request to reshape.
+            handler: The downstream async handler to invoke with the swept request.
+
+        Returns:
+            The model response from the handler.
+        """
+        if not self.enabled:
+            return await handler(request)
+        try:
+            plan = self._plan(request.messages)
+        except Exception:
+            logger.warning("street_sweeper: sweep planning failed; passing request through unchanged", exc_info=True)
+            return await handler(request)
+        if not plan.actions:
+            return await handler(request)
+
+        backend = self._resolve_backend(request.state, request.runtime)
+        if backend is not None and plan.offloads:
+            addition = self._pending_offloads(plan.offloads)
+            if addition:
+                await self._aoffload(backend, addition)
+        self._commit_actions(plan.actions)
+        return await handler(request.override(messages=plan.messages))
+
+    # ------------------------------------------------------------------ recall tool
+
+    def _build_recall_tool(self) -> BaseTool:
+        """Build the `recall_swept` tool that pulls offloaded originals back.
+
+        Returns:
+            A `StructuredTool` exposing the offloaded content for retrieval.
+        """
+        from langchain_core.tools import StructuredTool
+
+        mw = self
+
+        def _read(runtime: ToolRuntime, marker: str) -> str:
+            backend = mw._resolve_backend(runtime.state, runtime)
+            if backend is None:
+                return "Street sweeper offload is disabled; no swept content is available to recall."
+            path = mw._history_path()
+            try:
+                responses = backend.download_files([path])
+            except Exception:
+                logger.debug("recall_swept: download failed for %s", path, exc_info=True)
+                responses = None
+            if not responses or responses[0].content is None or responses[0].error is not None:
+                return "No swept context has been offloaded yet."
+            content = responses[0].content.decode("utf-8", "ignore")
+            return mw._extract_section(content, marker)
+
+        def sync_recall(runtime: ToolRuntime, marker: str = "") -> str:
+            return _read(runtime, marker)
+
+        async def async_recall(runtime: ToolRuntime, marker: str = "") -> str:
+            backend = mw._resolve_backend(runtime.state, runtime)
+            if backend is None:
+                return "Street sweeper offload is disabled; no swept content is available to recall."
+            path = mw._history_path()
+            try:
+                responses = await backend.adownload_files([path])
+            except Exception:
+                logger.debug("recall_swept: async download failed for %s", path, exc_info=True)
+                responses = None
+            if not responses or responses[0].content is None or responses[0].error is not None:
+                return "No swept context has been offloaded yet."
+            content = responses[0].content.decode("utf-8", "ignore")
+            return mw._extract_section(content, marker)
+
+        return StructuredTool.from_function(
+            name="recall_swept",
+            description=(
+                "Retrieve content the street sweeper pruned from your context. "
+                "Call with no argument to list available markers, or pass a marker "
+                "(the id shown in a [stale]/[duplicate]/elision stub) to get the full original output."
+            ),
+            func=sync_recall,
+            coroutine=async_recall,
+        )
+
+    @staticmethod
+    def _extract_section(content: str, marker: str) -> str:
+        """Return one offloaded section by marker, or an index of all markers.
+
+        Args:
+            content: The full offload file content.
+            marker: The marker to extract, or `""` to list available markers.
+
+        Returns:
+            The requested section, a marker index, or a not-found message.
+        """
+        sections = content.split("### swept ")
+        entries: list[tuple[str, str]] = []
+        for raw in sections[1:]:
+            header, _, body = raw.partition("\n")
+            entry_marker = header.split(" | ", 1)[0].strip()
+            entries.append((entry_marker, body.strip()))
+
+        if not marker:
+            if not entries:
+                return "No swept context has been offloaded yet."
+            listed = "\n".join(f"  - {m}" for m, _ in entries)
+            return f"Available swept markers (pass one to recall_swept):\n{listed}"
+
+        for entry_marker, body in entries:
+            if entry_marker == marker:
+                return body
+        return f"No swept content found for marker '{marker}'."

--- a/libs/bog-agents/tests/unit_tests/test_middleware_canonical_order.py
+++ b/libs/bog-agents/tests/unit_tests/test_middleware_canonical_order.py
@@ -97,6 +97,24 @@ class TestCanonicalMiddlewareOrder:
         assert "CostTrackerMiddleware" in names
         assert names.index("CostTrackerMiddleware") < names.index("_BogAgentsSummarizationMiddleware")
 
+    def test_street_sweeper_position(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Street sweeper wraps inside CostTracker and outside Summarization.
+
+        It only edits message *content* (never count/order), so it must run
+        before the default SummarizationMiddleware (whose cutoff indices then
+        stay aligned) and before PromptCaching (whose prefix it must not
+        invalidate by running afterward). CostTracker stays outermost so its
+        accounting still observes the pre-sweep request.
+        """
+        names = _capture_middleware_list(
+            monkeypatch,
+            config=FeatureConfig(enable_street_sweeper=True, enable_cost_tracking=True),
+        )
+        assert "StreetSweeperMiddleware" in names
+        assert names.index("CostTrackerMiddleware") < names.index("StreetSweeperMiddleware")
+        assert names.index("StreetSweeperMiddleware") < names.index("_BogAgentsSummarizationMiddleware")
+        assert names.index("StreetSweeperMiddleware") < names.index("AnthropicPromptCachingMiddleware")
+
     def test_feature_middleware_runs_before_default_filesystem(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Optional feature middleware are appended before the default tail.
 

--- a/libs/bog-agents/tests/unit_tests/test_street_sweeper.py
+++ b/libs/bog-agents/tests/unit_tests/test_street_sweeper.py
@@ -1,0 +1,305 @@
+"""Unit tests for `StreetSweeperMiddleware` — continuous context pruning.
+
+These exercise the pure planning logic (no model, no network): Tier 0 lossless
+cleanup, Tier 1 stale-read/dedup stubbing, Tier 2 truncation, the
+message-count/order invariant, offload + recall round-trip, and sweep-log
+accounting.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, ToolMessage
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from bog_agents.backends.filesystem import FilesystemBackend
+from bog_agents.middleware.street_sweeper import (
+    StreetSweeperMiddleware,
+    SweepLog,
+    _input_usd_per_token,
+    _normalize_text,
+    _truncate_head_tail,
+)
+
+
+def _read_call(call_id: str, path: str, *, name: str = "read_file") -> AIMessage:
+    return AIMessage(content="", tool_calls=[{"name": name, "args": {"file_path": path}, "id": call_id}])
+
+
+def _tool_result(call_id: str, content: str, *, name: str = "read_file") -> ToolMessage:
+    return ToolMessage(content=content, tool_call_id=call_id, name=name)
+
+
+# --------------------------------------------------------------------------- Tier 0
+
+
+def test_normalize_text_strips_ansi_and_trailing_whitespace() -> None:
+    raw = "hello \x1b[31mred\x1b[0m   \nworld\t\n"
+    out = _normalize_text(raw)
+    assert "\x1b" not in out
+    assert "red" in out
+    assert out == "hello red\nworld\n"  # per-line trailing ws stripped; structure preserved
+
+
+def test_normalize_text_collapses_blank_runs_and_identical_lines() -> None:
+    raw = "a\n\n\n\n\nb\n" + ("frame\n" * 6)
+    out = _normalize_text(raw)
+    assert "\n\n\n" not in out  # blank runs squeezed
+    assert "x6 identical lines" in out
+
+
+def test_normalize_text_is_idempotent() -> None:
+    raw = "x \x1b[1mY\x1b[0m\n\n\n\nz   \n" + ("dup\n" * 8)
+    once = _normalize_text(raw)
+    assert _normalize_text(once) == once  # stable -> cache-friendly
+
+
+def test_truncate_head_tail_keeps_ends_and_elides_middle() -> None:
+    text = "\n".join(str(i) for i in range(100))
+    out = _truncate_head_tail(text, head_lines=3, tail_lines=2)
+    assert out.startswith("0\n1\n2\n")
+    assert out.endswith("98\n99")
+    assert "lines swept" in out
+
+
+# --------------------------------------------------------------------------- invariants
+
+
+def test_plan_preserves_message_count_and_order_and_leaves_humans() -> None:
+    mw = StreetSweeperMiddleware(keep_recent=0)
+    messages: list[AnyMessage] = [
+        HumanMessage(content="do the thing   \n\n\n\nplease"),
+        _read_call("r1", "a.py"),
+        _tool_result("r1", "line\x1b[0m\n\n\n\nmore"),
+    ]
+    plan = mw._plan(messages)
+    assert len(plan.messages) == len(messages)
+    assert [type(m) for m in plan.messages] == [type(m) for m in messages]
+    # Human content is sacred even though it has blank runs.
+    assert plan.messages[0].content == messages[0].content
+
+
+# --------------------------------------------------------------------------- Tier 1
+
+
+def test_stale_read_superseded_by_edit_is_stubbed() -> None:
+    mw = StreetSweeperMiddleware(keep_recent=0)
+    big = "\n".join(f"old content {i}" for i in range(50))
+    messages: list[AnyMessage] = [
+        _read_call("r1", "a.py"),
+        _tool_result("r1", big),
+        _read_call("e1", "a.py", name="edit_file"),
+        _tool_result("e1", "edited ok", name="edit_file"),
+    ]
+    plan = mw._plan(messages)
+    swept_read = plan.messages[1].content
+    assert "stale" in swept_read.lower()
+    assert "recall_swept" in swept_read
+    assert len(swept_read) < len(big)
+    assert any(a["technique"] == "stale_read" for a in plan.actions)
+    # The original is queued for offload under the read's tool_call_id.
+    assert any(marker == "r1" for marker, _, _ in plan.offloads)
+
+
+def test_latest_read_is_kept_when_superseded_one_is_stubbed() -> None:
+    mw = StreetSweeperMiddleware(keep_recent=0)
+    messages: list[AnyMessage] = [
+        _read_call("r1", "a.py"),
+        _tool_result("r1", "VERSION ONE content here"),
+        _read_call("r2", "a.py"),
+        _tool_result("r2", "VERSION TWO content here"),
+    ]
+    plan = mw._plan(messages)
+    assert "stale" in plan.messages[1].content.lower()  # first read stubbed
+    assert plan.messages[3].content == "VERSION TWO content here"  # latest kept
+
+
+def test_duplicate_tool_output_earlier_copy_is_stubbed() -> None:
+    mw = StreetSweeperMiddleware(keep_recent=0)
+    listing = "a.py\nb.py\nc.py"
+    messages: list[AnyMessage] = [
+        _read_call("l1", ".", name="ls"),
+        _tool_result("l1", listing, name="ls"),
+        _read_call("l2", ".", name="ls"),
+        _tool_result("l2", listing, name="ls"),
+    ]
+    plan = mw._plan(messages)
+    assert "duplicate" in plan.messages[1].content.lower()  # earlier copy stubbed
+    assert plan.messages[3].content == listing  # latest kept
+    assert any(a["technique"] == "dedup" for a in plan.actions)
+
+
+# --------------------------------------------------------------------------- Tier 2
+
+
+def test_aggressive_truncates_large_old_output() -> None:
+    mw = StreetSweeperMiddleware(keep_recent=0, aggressive=True, truncate_min_lines=40, head_lines=4, tail_lines=4)
+    big = "\n".join(f"row {i}" for i in range(80))
+    messages: list[AnyMessage] = [_read_call("c1", "log.txt", name="execute"), _tool_result("c1", big, name="execute")]
+    plan = mw._plan(messages)
+    assert "lines swept" in plan.messages[1].content
+    assert any(a["technique"] == "truncate" for a in plan.actions)
+
+
+def test_conservative_mode_does_not_truncate() -> None:
+    mw = StreetSweeperMiddleware(keep_recent=0, aggressive=False, truncate_min_lines=40)
+    # No ANSI / trailing ws / repeats -> Tier 0 leaves it byte-identical.
+    big = "\n".join(f"row {i}" for i in range(80))
+    messages: list[AnyMessage] = [_read_call("c1", "log.txt", name="execute"), _tool_result("c1", big, name="execute")]
+    plan = mw._plan(messages)
+    assert plan.messages[1].content == big
+    assert plan.actions == []
+
+
+def test_recent_window_is_protected() -> None:
+    mw = StreetSweeperMiddleware(keep_recent=2)
+    messages: list[AnyMessage] = [
+        _read_call("r1", "a.py"),
+        _tool_result("r1", "garbage\x1b[0m   \n\n\n\nlots"),  # eligible (old)
+        _read_call("r2", "b.py"),
+        _tool_result("r2", "fresh\x1b[0m   \n\n\n\noutput"),  # within keep_recent=2 -> protected
+    ]
+    plan = mw._plan(messages)
+    assert plan.messages[3].content == messages[3].content  # untouched
+
+
+# --------------------------------------------------------------------------- offload + recall
+
+
+def test_offload_and_recall_roundtrip(tmp_path: Path, monkeypatch: Any) -> None:
+    backend = FilesystemBackend(root_dir=tmp_path)
+    mw = StreetSweeperMiddleware(backend=backend, keep_recent=0)
+    monkeypatch.setattr(mw, "_get_thread_id", lambda: "t1")
+
+    offloads = [("r1", mw._offload_header("r1", "read_file", "stale_read"), "ORIGINAL READ BODY")]
+    addition = mw._pending_offloads(offloads)
+    assert "ORIGINAL READ BODY" in addition
+    mw._offload(backend, addition)
+
+    stored = backend.download_files([mw._history_path()])[0].content.decode("utf-8")
+    assert mw._extract_section(stored, "r1").strip() == "ORIGINAL READ BODY"
+    # No marker -> listing of available markers.
+    assert "r1" in mw._extract_section(stored, "")
+    # Unknown marker -> not-found.
+    assert "No swept content" in mw._extract_section(stored, "nope")
+
+
+def test_pending_offloads_dedupes_by_marker() -> None:
+    mw = StreetSweeperMiddleware(keep_recent=0)
+    offloads = [("r1", "### swept r1 | read_file | stale_read | ts", "body")]
+    first = mw._pending_offloads(offloads)
+    second = mw._pending_offloads(offloads)
+    assert "body" in first
+    assert second == ""  # already offloaded this session
+
+
+# --------------------------------------------------------------------------- accounting + hooks
+
+
+def test_sweep_log_accumulates_savings() -> None:
+    mw = StreetSweeperMiddleware(keep_recent=0)
+    big = "\n".join("noisy   \x1b[0m" for _ in range(20))
+    messages: list[AnyMessage] = [_read_call("r1", "a.py", name="execute"), _tool_result("r1", big, name="execute")]
+    plan = mw._plan(messages)
+    mw._commit_actions(plan.actions)
+    assert mw.sweep_log.actions_total >= 1
+    assert mw.sweep_log.tokens_saved > 0
+    assert mw.sweep_log.by_technique
+    assert mw.sweep_log.calls_swept == 1  # one swept model call
+    assert mw.sweep_log.counts_by_technique  # per-technique action counts populated
+
+
+def test_pricing_resolves_from_cost_table() -> None:
+    # Known model -> its input rate; provider prefix is stripped.
+    assert _input_usd_per_token("anthropic:claude-sonnet-4-6") == 3.0 / 1_000_000
+    # Unknown model -> conservative default; empty -> default.
+    assert _input_usd_per_token("totally-unknown-model") == 5.0 / 1_000_000
+    assert _input_usd_per_token(None) == 5.0 / 1_000_000
+
+
+def test_dollars_and_reduction_metrics() -> None:
+    log = SweepLog(usd_per_input_token=3.0 / 1_000_000)
+    log.record({"technique": "truncate", "tool_name": "execute", "tokens_before": 1000, "tokens_after": 200})
+    log.record_call()
+    assert log.tokens_saved == 800
+    assert log.reduction_pct == 80.0
+    assert log.dollars_saved == 800 * (3.0 / 1_000_000)
+    snapshot = log.to_dict()
+    assert snapshot["tokens_saved"] == 800
+    assert snapshot["dollars_saved"] == 800 * (3.0 / 1_000_000)
+    assert snapshot["calls_swept"] == 1
+    # Empty log is safe (no divide-by-zero).
+    assert SweepLog().reduction_pct == 0.0
+
+
+def test_set_pricing_updates_log_rate() -> None:
+    mw = StreetSweeperMiddleware(keep_recent=0)
+    mw.set_pricing("anthropic:claude-opus-4-6")
+    assert mw.sweep_log.usd_per_input_token == 15.0 / 1_000_000
+
+
+def test_on_commit_hook_fires_with_delta() -> None:
+    deltas: list[dict[str, Any]] = []
+    mw = StreetSweeperMiddleware(keep_recent=0, model_name="claude-sonnet-4-6", on_commit=deltas.append)
+    big = "\n".join(f"old {i}" for i in range(50))
+    messages: list[AnyMessage] = [
+        _read_call("r1", "a.py"),
+        _tool_result("r1", big),
+        _read_call("e1", "a.py", name="edit_file"),
+        _tool_result("e1", "edited", name="edit_file"),
+    ]
+    mw._commit_actions(mw._plan(messages).actions)
+    assert len(deltas) == 1
+    assert deltas[0]["tokens_saved"] > 0
+    assert deltas[0]["dollars_saved"] > 0
+
+
+@dataclass
+class _FakeRequest:
+    """Minimal stand-in for `ModelRequest` for hook tests."""
+
+    messages: list[AnyMessage]
+    state: dict[str, Any] = field(default_factory=dict)
+    runtime: Any = None
+
+    def override(self, *, messages: list[AnyMessage]) -> _FakeRequest:
+        return _FakeRequest(messages=messages, state=self.state, runtime=self.runtime)
+
+
+def test_wrap_model_call_sends_swept_view_to_handler() -> None:
+    mw = StreetSweeperMiddleware(keep_recent=0, backend=None)
+    big = "\n".join(f"old {i}" for i in range(50))
+    messages: list[AnyMessage] = [
+        _read_call("r1", "a.py"),
+        _tool_result("r1", big),
+        _read_call("e1", "a.py", name="edit_file"),
+        _tool_result("e1", "edited", name="edit_file"),
+    ]
+    seen: dict[str, list[AnyMessage]] = {}
+
+    def handler(req: _FakeRequest) -> str:
+        seen["messages"] = req.messages
+        return "RESPONSE"
+
+    result = mw.wrap_model_call(_FakeRequest(messages=messages), handler)  # type: ignore[arg-type]
+    assert result == "RESPONSE"
+    assert len(seen["messages"]) == len(messages)  # count preserved
+    assert "stale" in seen["messages"][1].content.lower()  # model sees the stub
+
+
+def test_disabled_middleware_is_passthrough() -> None:
+    mw = StreetSweeperMiddleware(enabled=False)
+    messages: list[AnyMessage] = [_read_call("r1", "a.py"), _tool_result("r1", "x\x1b[0m   \n\n\n\ny")]
+    seen: dict[str, list[AnyMessage]] = {}
+
+    def handler(req: _FakeRequest) -> str:
+        seen["messages"] = req.messages
+        return "OK"
+
+    mw.wrap_model_call(_FakeRequest(messages=messages), handler)  # type: ignore[arg-type]
+    assert seen["messages"] is messages  # original list passed through untouched
+    assert mw.sweep_log.actions_total == 0

--- a/libs/cli/bog_agents_cli/agent.py
+++ b/libs/cli/bog_agents_cli/agent.py
@@ -1172,6 +1172,9 @@ def create_cli_agent(
                 for execution
             - `composite_backend`: `CompositeBackend` for file operations
     """
+    # Preserve the original model spec string (used to price street-sweeper
+    # savings) before `model` is resolved to a BaseChatModel instance below.
+    model_spec_str = model if isinstance(model, str) else ""
     if isinstance(model, str):
         from bog_agents_cli.config import create_model as _create_model
 
@@ -1694,6 +1697,20 @@ def create_cli_agent(
         agent_middleware.append(
             BedrockRefreshMiddleware(interactive=sys.stdin.isatty())
         )
+
+    # Street sweeper (opt-in) — attach the per-cwd singleton instance, disabled
+    # by default. `/sweep on` flips it live without a rebuild. Pointing it at the
+    # live composite backend enables offload + the recall_swept tool. Wrapped so
+    # an attach failure can never block agent creation.
+    try:
+        from bog_agents_cli.sweep_controller import get_sweep_controller
+
+        sweeper = get_sweep_controller(effective_cwd or Path.cwd()).middleware
+        sweeper.set_backend(composite_backend)
+        sweeper.set_pricing(model_spec_str)
+        agent_middleware.append(sweeper)
+    except Exception:
+        logger.debug("street sweeper attach failed; skipping", exc_info=True)
 
     # Create the agent
     agent = create_agent(

--- a/libs/cli/bog_agents_cli/app.py
+++ b/libs/cli/bog_agents_cli/app.py
@@ -5305,6 +5305,26 @@ class BogAgentsApp(App):
                 AppMessage("Auto mode OFF. Returning to interactive approval.")
             )
 
+    async def _handle_sweep_command(self, command: str) -> None:
+        """/sweep — toggle and inspect Street Sweeper context pruning.
+
+        Street sweeper mode continuously removes dead weight (ANSI/whitespace,
+        duplicate and stale-read tool outputs, and — when aggressive — large old
+        outputs truncated to head+tail) from the messages sent to the model, with
+        originals offloaded for the `recall_swept` tool. Disabled by default.
+
+        See `sweep_controller.SweepController.handle_sweep` for subcommand semantics.
+
+        Usage: /sweep [on|off|status|log|aggressive on|off]
+        """
+        await self._mount_message(UserMessage(command))
+        from bog_agents_cli.sweep_controller import get_sweep_controller
+
+        args = command.strip()[len("/sweep") :].strip()
+        controller = get_sweep_controller(self._cwd)
+        output = controller.handle_sweep(args)
+        await self._mount_message(AppMessage(output))
+
     async def _handle_standing_orders_command(self, command: str) -> None:
         """``/standing-orders`` — curated daemon-job catalog.
 

--- a/libs/cli/bog_agents_cli/commands/general.py
+++ b/libs/cli/bog_agents_cli/commands/general.py
@@ -27,7 +27,10 @@ COMMANDS: tuple[SlashCommand, ...] = (
                 ("on|off", "Toggle continuous context pruning"),
                 ("status", "Show state, mode, and session + lifetime tokens/$ saved"),
                 ("log", "Show recent sweep actions"),
-                ("aggressive on|off", "Toggle Tier 2 head/tail truncation of large old outputs"),
+                (
+                    "aggressive on|off",
+                    "Toggle Tier 2 head/tail truncation of large old outputs",
+                ),
                 ("reset", "Zero the session and lifetime savings counters"),
             ),
         ),

--- a/libs/cli/bog_agents_cli/commands/general.py
+++ b/libs/cli/bog_agents_cli/commands/general.py
@@ -18,6 +18,23 @@ COMMANDS: tuple[SlashCommand, ...] = (
     ),
     SlashCommand(
         spec=SlashCommandSpec(
+            "/sweep",
+            "Street sweeper — continuously prune dead context (whitespace, duplicate/stale tool output) to cut token cost",
+            "sweep street sweeper prune trim context tokens cost compact noise dedupe stale",
+            "general",
+            available=True,
+            subcommands=(
+                ("on|off", "Toggle continuous context pruning"),
+                ("status", "Show state, mode, and session + lifetime tokens/$ saved"),
+                ("log", "Show recent sweep actions"),
+                ("aggressive on|off", "Toggle Tier 2 head/tail truncation of large old outputs"),
+                ("reset", "Zero the session and lifetime savings counters"),
+            ),
+        ),
+        handler_method="_handle_sweep_command",
+    ),
+    SlashCommand(
+        spec=SlashCommandSpec(
             "/build",
             "Interactive wizard — create skills, prompts, and pipelines step by step",
             "wizard create new template scaffold variablize builder",

--- a/libs/cli/bog_agents_cli/sweep_controller.py
+++ b/libs/cli/bog_agents_cli/sweep_controller.py
@@ -1,0 +1,240 @@
+"""Stand-alone controller for the ``/sweep`` command (Street Sweeper mode).
+
+Backs the ``/sweep on|off|status|log|aggressive|reset`` slash commands. The
+controller owns one long-lived :class:`StreetSweeperMiddleware` instance per
+working directory, cached in :data:`_CONTROLLERS`. ``create_cli_agent`` attaches
+that same instance to every agent it builds (pointing it at the live backend and
+model), so toggling ``/sweep on`` takes effect on the next model call without
+rebuilding the graph, and ``/sweep status`` reads the live cumulative log.
+
+The sweeper is **disabled by default** — it is a transparent pass-through until
+the user runs ``/sweep on``.
+
+## Metrics — the "bank account"
+
+Two scopes of savings are tracked:
+
+- **Session**: the live :class:`SweepLog` on the middleware (tokens removed,
+    estimated dollars, % reduction, per-technique breakdown).
+- **Lifetime**: a persistent ledger at ``~/.bog-agents/street_sweeper_ledger.json``
+    that accumulates every per-call delta across all sessions, so the running
+    total of tokens and dollars the sweeper has saved this user only grows over
+    time. The middleware fires an ``on_commit`` hook per swept call; the
+    controller folds that delta into the ledger and writes it atomically.
+
+Dollar figures are estimates priced at the model's input-token rate; they are a
+pre-cache-discount upper bound (cached tokens bill at a fraction of that rate).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from pathlib import Path
+from typing import Any
+
+from bog_agents.middleware.street_sweeper import StreetSweeperMiddleware, SweepLog
+
+from bog_agents_cli.io_utils import atomic_write_text
+
+logger = logging.getLogger(__name__)
+
+_CONTROLLERS: dict[Path, SweepController] = {}
+_CONTROLLERS_LOCK = threading.Lock()
+
+
+def _ledger_path() -> Path:
+    """Return the path to the persistent lifetime-savings ledger."""
+    return Path.home() / ".bog-agents" / "street_sweeper_ledger.json"
+
+
+def get_sweep_controller(working_dir: Path | str) -> SweepController:
+    """Return the (per-cwd) singleton sweep controller.
+
+    Args:
+        working_dir: Project root. Different roots get independent controllers,
+            so hopping between repos via ``/cd`` keeps separate session logs.
+
+    Returns:
+        The cached controller for `working_dir`.
+    """
+    key = Path(working_dir).resolve()
+    with _CONTROLLERS_LOCK:
+        if key not in _CONTROLLERS:
+            _CONTROLLERS[key] = SweepController()
+        return _CONTROLLERS[key]
+
+
+def reset_sweep_controllers() -> None:
+    """Drop every cached controller. Test-only helper."""
+    with _CONTROLLERS_LOCK:
+        _CONTROLLERS.clear()
+
+
+class SweepController:
+    """Slash-command façade around a single :class:`StreetSweeperMiddleware`.
+
+    The owned middleware starts disabled; ``create_cli_agent`` attaches it to the
+    agent graph and the controller flips its `enabled` flag live. The controller
+    also maintains the persistent lifetime ledger via the middleware's
+    ``on_commit`` hook.
+
+    Args:
+        ledger_path: Override for the lifetime-ledger file (tests). Defaults to
+            ``~/.bog-agents/street_sweeper_ledger.json``.
+    """
+
+    _LIFETIME_KEYS = ("tokens_saved", "dollars_saved", "actions", "calls")
+
+    def __init__(self, *, ledger_path: Path | None = None) -> None:
+        self._lock = threading.Lock()
+        self._ledger_path = ledger_path or _ledger_path()
+        self._lifetime = self._load_ledger()
+        self._middleware = StreetSweeperMiddleware(
+            enabled=False, on_commit=self._record_delta
+        )
+
+    @property
+    def middleware(self) -> StreetSweeperMiddleware:
+        """The underlying middleware (attached to the agent by `create_cli_agent`)."""
+        return self._middleware
+
+    # ------------------------------------------------------------------ ledger
+
+    def _load_ledger(self) -> dict[str, float]:
+        """Load the lifetime ledger from disk, or start a fresh one."""
+        base = dict.fromkeys(self._LIFETIME_KEYS, 0.0)
+        try:
+            if self._ledger_path.exists():
+                data = json.loads(self._ledger_path.read_text(encoding="utf-8"))
+                for key in self._LIFETIME_KEYS:
+                    if isinstance(data.get(key), (int, float)):
+                        base[key] = data[key]
+        except Exception:
+            logger.debug(
+                "street sweeper: could not read ledger at %s",
+                self._ledger_path,
+                exc_info=True,
+            )
+        return base
+
+    def _record_delta(self, delta: dict[str, Any]) -> None:
+        """Fold one per-call savings delta into the lifetime ledger and persist it.
+
+        Registered as the middleware's ``on_commit`` hook. Thread-safe — the
+        sweeper can fire from background worker threads sharing this singleton.
+
+        Args:
+            delta: Per-call delta with `tokens_saved`, `dollars_saved`, `actions`.
+        """
+        with self._lock:
+            self._lifetime["tokens_saved"] += float(delta.get("tokens_saved", 0))
+            self._lifetime["dollars_saved"] += float(delta.get("dollars_saved", 0.0))
+            self._lifetime["actions"] += float(delta.get("actions", 0))
+            self._lifetime["calls"] += 1.0
+            try:
+                atomic_write_text(
+                    self._ledger_path, json.dumps(self._lifetime), encoding="utf-8"
+                )
+            except Exception:
+                logger.debug(
+                    "street sweeper: could not persist ledger to %s",
+                    self._ledger_path,
+                    exc_info=True,
+                )
+
+    # ------------------------------------------------------------------ commands
+
+    def handle_sweep(self, args: str) -> str:
+        """Dispatch a ``/sweep`` subcommand and return the message to display.
+
+        Args:
+            args: The text following ``/sweep`` (e.g. ``"on"``, ``"status"``).
+
+        Returns:
+            The human-readable result to show in the CLI.
+        """
+        verb = args.strip().split(maxsplit=1)
+        head = verb[0].strip().lower() if verb else ""
+        rest = verb[1].strip().lower() if len(verb) > 1 else ""
+
+        if head in ("", "status"):
+            return self._status()
+        if head == "on":
+            self._middleware.enabled = True
+            return "Street sweeper ON - pruning dead context from every model call. Originals are recoverable with recall_swept."
+        if head == "off":
+            self._middleware.enabled = False
+            return "Street sweeper OFF - full context is sent to the model unchanged."
+        if head == "log":
+            return self._log()
+        if head == "aggressive":
+            return self._set_aggressive(rest)
+        if head == "reset":
+            return self._reset()
+        return "Usage: /sweep [on|off|status|log|aggressive on|off|reset]"
+
+    def _status(self) -> str:
+        """Render on/off state, mode, and both session and lifetime savings."""
+        mw = self._middleware
+        state = "ON" if mw.enabled else "OFF"
+        mode = "aggressive (Tier 0-2)" if mw.aggressive else "conservative (Tier 0-1)"
+        lines = [
+            f"Street sweeper: {state} | mode: {mode} | keep_recent: {mw.keep_recent}",
+            "",
+            "This session:",
+            "  " + mw.sweep_log.format_summary().replace("\n", "\n  "),
+            "",
+            self._lifetime_summary(),
+        ]
+        return "\n".join(lines)
+
+    def _lifetime_summary(self) -> str:
+        """Render the persistent cross-session ledger."""
+        with self._lock:
+            tokens = int(self._lifetime["tokens_saved"])
+            dollars = self._lifetime["dollars_saved"]
+            calls = int(self._lifetime["calls"])
+        if tokens <= 0:
+            return "Lifetime: nothing saved yet."
+        return f"Lifetime (all sessions): ~{tokens:,} tokens removed over {calls:,} model calls, ~${dollars:,.4f} estimated saved."
+
+    def _log(self) -> str:
+        """Render the most recent sweep actions."""
+        recent = self._middleware.sweep_log.recent
+        if not recent:
+            return "Street sweeper: no actions recorded yet."
+        lines = ["Recent sweep actions (most recent last):"]
+        for action in recent[-20:]:
+            saved = max(0, action["tokens_before"] - action["tokens_after"])
+            tool = action["tool_name"] or "-"
+            lines.append(f"  {action['technique']:<11} {tool:<14} ~{saved} tokens")
+        return "\n".join(lines)
+
+    def _set_aggressive(self, rest: str) -> str:
+        """Toggle Tier 2 (head/tail truncation of large old outputs)."""
+        if rest in ("on", ""):
+            self._middleware.aggressive = True
+            return "Street sweeper: aggressive mode ON (Tier 0-2 - large old tool outputs are truncated to head+tail)."
+        if rest == "off":
+            self._middleware.aggressive = False
+            return "Street sweeper: aggressive mode OFF (Tier 0-1 - only lossless cleanup + stale/duplicate stubbing)."
+        return "Usage: /sweep aggressive [on|off]"
+
+    def _reset(self) -> str:
+        """Zero the session log and the persistent lifetime ledger."""
+        with self._lock:
+            self._lifetime = dict.fromkeys(self._LIFETIME_KEYS, 0.0)
+            try:
+                atomic_write_text(
+                    self._ledger_path, json.dumps(self._lifetime), encoding="utf-8"
+                )
+            except Exception:
+                logger.debug(
+                    "street sweeper: could not persist ledger reset", exc_info=True
+                )
+        self._middleware.sweep_log = SweepLog(
+            usd_per_input_token=self._middleware.sweep_log.usd_per_input_token
+        )
+        return "Street sweeper: session and lifetime savings counters reset to zero."

--- a/libs/cli/tests/unit_tests/test_sweep_controller.py
+++ b/libs/cli/tests/unit_tests/test_sweep_controller.py
@@ -1,0 +1,131 @@
+"""Tests for the `/sweep` controller and its attachment to the CLI agent."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from bog_agents.middleware.street_sweeper import StreetSweeperMiddleware
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage
+
+from bog_agents_cli.sweep_controller import (
+    SweepController,
+    get_sweep_controller,
+    reset_sweep_controllers,
+)
+
+
+def _make_fake_chat_model() -> GenericFakeChatModel:
+    """A fake chat model that satisfies the summarization middleware build."""
+    model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
+    model.profile = {"max_input_tokens": 200000}
+    return model
+
+
+def test_controller_starts_disabled_and_toggles() -> None:
+    reset_sweep_controllers()
+    controller = get_sweep_controller(".")
+    assert controller.middleware.enabled is False
+
+    msg_on = controller.handle_sweep("on")
+    assert controller.middleware.enabled is True
+    assert "ON" in msg_on
+
+    msg_off = controller.handle_sweep("off")
+    assert controller.middleware.enabled is False
+    assert "OFF" in msg_off
+
+
+def test_controller_aggressive_toggle() -> None:
+    reset_sweep_controllers()
+    controller = get_sweep_controller(".")
+    assert controller.middleware.aggressive is True
+    controller.handle_sweep("aggressive off")
+    assert controller.middleware.aggressive is False
+    controller.handle_sweep("aggressive on")
+    assert controller.middleware.aggressive is True
+
+
+def test_controller_status_and_log_are_safe_when_empty() -> None:
+    reset_sweep_controllers()
+    controller = get_sweep_controller(".")
+    assert "Street sweeper" in controller.handle_sweep("status")
+    assert "no actions" in controller.handle_sweep("log").lower()
+    assert "Usage" in controller.handle_sweep("bogus")
+
+
+def test_lifetime_ledger_persists_and_reloads(tmp_path: Path) -> None:
+    """Per-call deltas accumulate into a ledger that survives a new controller."""
+    ledger = tmp_path / "ledger.json"
+    controller = SweepController(ledger_path=ledger)
+
+    # Simulate two swept model calls firing the on_commit hook.
+    controller.middleware.on_commit(
+        {"tokens_saved": 500, "dollars_saved": 0.0015, "actions": 3}
+    )
+    controller.middleware.on_commit(
+        {"tokens_saved": 250, "dollars_saved": 0.0007, "actions": 1}
+    )
+
+    assert ledger.exists()
+    status = controller.handle_sweep("status")
+    assert "Lifetime" in status
+    assert "750" in status  # 500 + 250 tokens
+
+    # A fresh controller pointed at the same ledger reloads the running total.
+    reloaded = SweepController(ledger_path=ledger)
+    assert int(reloaded._lifetime["tokens_saved"]) == 750
+    assert reloaded._lifetime["calls"] == 2
+
+    # Reset zeros it on disk too.
+    reloaded.handle_sweep("reset")
+    assert int(reloaded._lifetime["tokens_saved"]) == 0
+    assert SweepController(ledger_path=ledger)._lifetime["tokens_saved"] == 0
+
+
+def test_singleton_is_per_cwd() -> None:
+    reset_sweep_controllers()
+    a = get_sweep_controller(".")
+    b = get_sweep_controller(".")
+    assert a is b
+
+
+def test_create_cli_agent_attaches_disabled_sweeper(tmp_path: Path) -> None:
+    """`create_cli_agent` attaches the controller's sweeper, pointed at the backend."""
+    reset_sweep_controllers()
+    from bog_agents_cli.agent import create_cli_agent
+
+    fake_model = _make_fake_chat_model()
+    captured: dict[str, object] = {}
+
+    def _capture_create_agent(**kwargs: object) -> Mock:
+        captured.update(kwargs)
+        return Mock()
+
+    with (
+        patch("bog_agents_cli.agent.LocalShellBackend"),
+        patch("bog_agents_cli.agent.FilesystemBackend"),
+        patch("bog_agents_cli.agent.create_agent", side_effect=_capture_create_agent),
+        patch(
+            "bog_agents_cli.config.create_model", return_value=Mock(model=fake_model)
+        ),
+        patch("bog_agents_cli.agent.get_system_prompt", return_value=""),
+    ):
+        create_cli_agent(
+            model="fake-model",
+            assistant_id="test",
+            enable_memory=False,
+            enable_skills=False,
+            enable_shell=False,
+            interactive=False,
+            cwd=str(tmp_path),
+        )
+
+    middleware = captured.get("middleware") or []
+    sweepers = [m for m in middleware if isinstance(m, StreetSweeperMiddleware)]
+    assert len(sweepers) == 1
+    # Same instance the controller owns, and disabled by default (opt-in).
+    assert sweepers[0] is get_sweep_controller(tmp_path).middleware
+    assert sweepers[0].enabled is False
+    assert sweepers[0]._backend is not None  # backend was attached


### PR DESCRIPTION
Street Sweeper is an opt-in, disabled-by-default mode that continuously prunes dead weight from each model request — ANSI/whitespace cleanup, duplicate + stale-read tool-output stubbing, and (aggressive) head/tail truncation of large old outputs — cutting input tokens and cost on every API call. It reshapes only the per-call view (never mutating state or message count/order), so it composes safely with summarization and keeps the prompt-cache prefix stable. Dropped originals are offloaded to the backend and recoverable via a recall_swept tool.

SDK:
- StreetSweeperMiddleware (Tier 0-2) with SweepLog metrics: tokens saved, estimated USD (priced from cost_tracker._MODEL_COSTS), % reduction, and per-technique + per-call counts; plus an on_commit hook for sinks.
- FeatureConfig.enable_street_sweeper (+ aggressive / keep_recent knobs), gated in graph.py outer-of-summarization / inner-of-cost-tracker.
- Lazy-import registration; canonical-order test updated for its position.

CLI:
- /sweep on|off|status|log|aggressive|reset slash command + controller.
- Persistent lifetime savings ledger at ~/.bog-agents/street_sweeper_ledger.json accumulating tokens + dollars across sessions (the "bank account").
- Sweeper attached (disabled) inside create_cli_agent so every build site is covered; toggled live without a rebuild.

Tests: 20 SDK + 9 CLI unit tests. Full SDK unit suite green; ruff + ty clean.