### PR TITLE
feat: document 0.10 features + consolidate Dependabot into one grouped PR per package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,99 +1,108 @@
-# Dependabot configuration (V3-9).
+# Dependabot configuration.
 #
-# Keeps the hand-maintained transitive-CVE floors (cryptography, urllib3,
-# requests, pyasn1, pygments, aiohttp, pillow, langsmith, python-multipart,
-# pyjwt, ...) self-sustaining across all Python packages + GitHub Actions,
-# instead of requiring a manual re-audit each cycle. Uses the native `uv`
-# ecosystem so uv.lock files are updated alongside pyproject.toml.
+# Goal: keep dependencies + the hand-maintained CVE floors current WITHOUT PR
+# spam. Each package/ecosystem produces at most ONE grouped PR per run — every
+# update (major, minor, patch) for that directory is bundled together — on a
+# monthly cadence. (Security advisories may still open their own PRs
+# immediately, by design, regardless of grouping.)
 #
-# Minor/patch bumps are grouped per package to keep PR noise low; majors come
-# as individual PRs so breaking changes are reviewed in isolation.
+# NOTE: Dependabot's parser does not support YAML anchors/merge keys, so each
+# block is written out in full.
 version: 2
 
 updates:
-  # ---- Python packages (uv) ----
   - package-ecosystem: "uv"
     directory: "/libs/bog-agents"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
+      interval: "monthly"
+    open-pull-requests-limit: 1
     groups:
-      minor-and-patch:
-        update-types: ["minor", "patch"]
+      all-dependencies:
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
     commit-message:
       prefix: "chore(deps)"
 
   - package-ecosystem: "uv"
     directory: "/libs/cli"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
+      interval: "monthly"
+    open-pull-requests-limit: 1
     groups:
-      minor-and-patch:
-        update-types: ["minor", "patch"]
+      all-dependencies:
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
     commit-message:
       prefix: "chore(deps)"
 
   - package-ecosystem: "uv"
     directory: "/libs/daemon"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
+      interval: "monthly"
+    open-pull-requests-limit: 1
     groups:
-      minor-and-patch:
-        update-types: ["minor", "patch"]
+      all-dependencies:
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
     commit-message:
       prefix: "chore(deps)"
 
   - package-ecosystem: "uv"
     directory: "/libs/acp"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
+      interval: "monthly"
+    open-pull-requests-limit: 1
     groups:
-      minor-and-patch:
-        update-types: ["minor", "patch"]
+      all-dependencies:
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
     commit-message:
       prefix: "chore(deps)"
 
   - package-ecosystem: "uv"
     directory: "/libs/harbor"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
+      interval: "monthly"
+    open-pull-requests-limit: 1
     groups:
-      minor-and-patch:
-        update-types: ["minor", "patch"]
+      all-dependencies:
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
     commit-message:
       prefix: "chore(deps)"
 
   - package-ecosystem: "uv"
     directory: "/libs/partners/daytona"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
+      interval: "monthly"
+    open-pull-requests-limit: 1
     groups:
-      minor-and-patch:
-        update-types: ["minor", "patch"]
+      all-dependencies:
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
     commit-message:
       prefix: "chore(deps)"
 
-  # ---- npm (VS Code extension) ----
   - package-ecosystem: "npm"
     directory: "/libs/vscode-extension"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
+      interval: "monthly"
+    open-pull-requests-limit: 1
     groups:
-      minor-and-patch:
-        update-types: ["minor", "patch"]
+      all-dependencies:
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
     commit-message:
       prefix: "chore(deps)"
 
-  # ---- GitHub Actions ----
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    open-pull-requests-limit: 1
+    groups:
+      all-actions:
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
     commit-message:
       prefix: "chore(ci)"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > *Pass through in harmony. Opinionated where it matters.*
 
-**v0.9.4** — a production-ready AI agent framework built on LangGraph.
+**v0.10** — a production-ready AI agent framework built on LangGraph.
 Patient by design, watchful by default. It does the careful work so you
 don't have to wire it up yourself.
 
@@ -10,7 +10,7 @@ Three packages, one philosophy:
 
 - **[`bog-agents`](libs/bog-agents)** — the Python SDK. `create_agent()` returns a
   compiled LangGraph agent with file tools, a shell, git, sub-agents, plan mode,
-  retry-with-backoff, and ~80 composable middlewares. Drop-in
+  retry-with-backoff, and 90+ composable middlewares. Drop-in
   [deepagents](https://github.com/langchain-ai/deepagents) compatibility, too —
   `create_deep_agent`, `DeepAgentState`, filesystem permissions, harness/provider
   profiles.
@@ -45,7 +45,7 @@ asks for.
 - **No ceremony.** `pipx install bog-agents-cli && bog-agents` and you have a
   working agent in under a minute. `pip install bog-agents` and one function
   call gets you a compiled agent.
-- **Composable.** 80+ middlewares snap on or off. Subagents nest. Backends
+- **Composable.** 90+ middlewares snap on or off. Subagents nest. Backends
   swap. The framework gets out of your way.
 
 The bog is calm, deep, and unhurried. So is the agent.
@@ -121,6 +121,30 @@ deepagents compatibility, and the full provider matrix.
 The 0.9 line is the run from a credible flagship toward 1.0. Each release
 hardened a different stretch of trail.
 
+- **0.10 — Claude-Code-style auto mode, MCP server, self-verification, and
+  two new SDK primitives.** The marquee batch:
+  - **Permission modes (auto mode).** Shift+Tab cycles `default → accept-edits
+    → plan`; Ctrl+T toggles bypass; a live status indicator; a
+    `--permission-mode {default,acceptEdits,plan,bypass,paranoid}` flag (plus
+    `--dangerously-skip-permissions`).
+  - **`bog-agents mcp-server`.** Expose the agent *as* an MCP server, so Claude
+    Desktop, Cursor, Zed, or Copilot can delegate a whole coding task to it.
+  - **`/self-review`.** Fan five reviewer lenses (correctness, security,
+    maintainability, tests, over-claims) over your own diff → `SHIP` /
+    `FIX-FIRST` verdict; `--fix` loops until clean.
+  - **`/ci-fix`.** Read the branch's CI via `gh`, ingest the failing-job logs,
+    and diagnose + fix.
+  - **`@codebase`** semantic search, **repo-committed `.prompt.md`** files that
+    auto-register as slash commands, **agent-written auto-memories** (a
+    `remember` tool that persists conventions/gotchas to the AGENTS.md cascade),
+    and **shell pass-through** (`!command` output now enters the agent's
+    context so it can see what you ran).
+  - **SDK:** `bog_agents.evals` (Dataset / scorers / `run_evals` /
+    `assert_pass_rate`) and `bog_agents.guardrails` (composable input/output
+    tripwire guardrails + `create_agent(guardrails=[...])`), plus a declarative
+    `.bog-agents/sandbox.toml`. Hardened by a fresh Senior-Principal-Engineer
+    audit (see [REVIEW.md](REVIEW.md)) and a competitive roadmap
+    ([ROADMAP.md](ROADMAP.md)).
 - **0.9.4 — deepagents parity, headless driving, provider resilience.**
   A first-class [deepagents](https://github.com/langchain-ai/deepagents)
   compatibility surface — `create_deep_agent`, `DeepAgentState`,
@@ -197,7 +221,7 @@ discord, kubernetes, datadog, sentry, and more.
 
 | Path | What |
 |---|---|
-| `libs/bog-agents/` | The Python SDK. Compiled LangGraph agents, ~80 middlewares, pluggable backends, tool bundles, deepagents compatibility. |
+| `libs/bog-agents/` | The Python SDK. Compiled LangGraph agents, 90+ middlewares, pluggable backends, tool bundles, deepagents compatibility. |
 | `libs/cli/` | The terminal CLI. Textual TUI, 120+ slash commands, MCP marketplace, headless command surface, `bog-agents drive` scripted runner. |
 | `libs/daemon/` | The ambient daemon. Cron / file-watch / webhook / git-push triggers, REST API. |
 | `libs/acp/` | Agent Client Protocol bridge for the Zed editor. |

--- a/libs/bog-agents/README.md
+++ b/libs/bog-agents/README.md
@@ -8,7 +8,7 @@ SDK in its own right when you want to build agents that aren't a CLI.
 
 One `create_agent()` call gets you a compiled LangGraph agent with file tools, a shell,
 git, sub-agents, plan mode, auto-quality checks, retry-with-backoff against transient
-provider failures, and ~80 composable middlewares. Pluggable backends. Tool bundles
+provider failures, and 90+ composable middlewares. Pluggable backends. Tool bundles
 for callers who don't want middleware overhead. Drop-in
 [deepagents](https://github.com/langchain-ai/deepagents) compatibility. Any
 tool-calling LLM. The defaults are deliberate — you ship something that works on
@@ -33,7 +33,7 @@ away or bolt on layers as you understand what the job actually asks for.
   vault, structured logging at every chokepoint, panic dumps on uncaught exceptions.
 - **No ceremony.** `create_agent()` returns a compiled `CompiledStateGraph` you can
   invoke. Plug it into your app. Done.
-- **Composable.** ~80 middlewares snap on or off. Subagents nest. Backends swap. The
+- **Composable.** 90+ middlewares snap on or off. Subagents nest. Backends swap. The
   framework gets out of your way. **Tool bundles** — free-function factories
   that return `list[BaseTool]` — serve callers who only want a set of tools
   without the middleware machinery.
@@ -245,6 +245,18 @@ Streaming is supported via the standard LangGraph stream APIs.
 
 ## What's new in 0.9.x
 
+- **0.10** — two new first-class primitives + safer middleware ordering:
+  - **`bog_agents.evals`** — evaluation as an importable primitive: `Dataset`,
+    rule-based + LLM-as-judge `Scorer`s, `run_evals(...)`, and
+    `EvalReport.assert_pass_rate()` to gate releases in CI.
+  - **`bog_agents.guardrails`** — composable input/output guardrails with
+    fail-fast tripwire semantics (`Blocklist` / `MaxLength` / `NoSecrets` /
+    `LLMGuardrail`), plus `create_agent(guardrails=[...])`.
+  - A declarative **`.bog-agents/sandbox.toml`** (preinstall / runner size /
+    snapshot / network egress allowlist) loader.
+  - Correctness fixes from a fresh SPE audit (see `REVIEW.md`): `MemoryMiddleware`
+    now runs before prompt caching (was defeating the cache) and `DLPMiddleware`
+    before `AuditTrailMiddleware` (was logging unredacted values).
 - **0.9.4** — **deepagents parity**: `create_deep_agent`, `DeepAgentState`
   (with an O(N) `DeltaChannel` messages reducer), `FilesystemPermission`,
   `RubricMiddleware`, `HarnessProfile` / `ProviderProfile`, plus

--- a/libs/cli/README.md
+++ b/libs/cli/README.md
@@ -142,6 +142,19 @@ modal interactions, snapshots, assertions — see [Drive](#bog-agents-drive-exam
 
 ## What's new in 0.9.x
 
+- **0.10 — Claude-Code-style auto mode + self-verification.**
+  - **Permission modes:** Shift+Tab cycles `default → accept-edits → plan`,
+    Ctrl+T toggles bypass, with a live status indicator and a
+    `--permission-mode {default,acceptEdits,plan,bypass,paranoid}` flag (and
+    `--dangerously-skip-permissions`).
+  - **`bog-agents mcp-server`** — serve the agent over MCP so any MCP client
+    (Claude Desktop, Cursor, Zed, Copilot) can delegate a coding task to it.
+  - **`/self-review`** (five reviewer lenses over your own diff → SHIP/FIX-FIRST,
+    `--fix` to loop) and **`/ci-fix`** (read the branch's CI via `gh`, diagnose
+    and fix failures).
+  - **`@codebase`** semantic search, **repo `.bog-agents/prompts/*.prompt.md`**
+    that auto-register as slash commands, **auto-memories** (a `remember` tool),
+    and **shell pass-through** — `!command` output now enters the agent's context.
 - **0.9.4 — headless driving + provider resilience.** A headless
   slash-command surface (`bog-agents command "/help"`), `--jsonl`
   structured streaming with tool-call events, and deepagents parity


### PR DESCRIPTION
## Why
Two fixes after #99 merged:

1. **Dependabot was opening ~25 PRs.** The old config only grouped minor/patch, so every *major* bump came as its own PR. This config groups **all** update types (major+minor+patch) per ecosystem/directory and moves to a **monthly** cadence → at most one grouped PR per package. (Security advisories may still open immediately, by design.) Written without YAML anchors since Dependabot's parser rejects merge keys.

2. **READMEs didn't reflect the 0.10 features**, and **release-please cut no release** — because #99 was *squash-merged with a non-conventional title* ('Hardening + …'), so release-please saw nothing releasable. This PR documents the shipped features in the root + CLI + SDK READMEs and lands them under a `feat:` commit so **release-please will open a 0.10 release PR** (squash-merge this PR with its `feat:` title, or use a merge commit, to keep that working).

## What's documented
Auto mode (Shift+Tab permission-mode cycle + `--permission-mode`), `bog-agents mcp-server`, `/self-review`, `/ci-fix`, `@codebase`, repo `.prompt.md` commands, agent-written auto-memories, shell pass-through, and the SDK's `bog_agents.evals` + `bog_agents.guardrails` + `.bog-agents/sandbox.toml`. Also corrects the stale middleware count.

## Note
The 25 individual Dependabot PRs were closed; once this config lands on main, future runs produce the consolidated grouped PRs.