### PR TITLE
feat(cli): resilient Bedrock fallback and hittable-model auto-default

### DIFF
--- a/libs/cli/bog_agents_cli/_bedrock.py
+++ b/libs/cli/bog_agents_cli/_bedrock.py
@@ -30,7 +30,7 @@ from enum import StrEnum
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterator, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -703,7 +703,7 @@ _FIX_ACTIONS: dict[BedrockErrorKind, tuple[str, tuple[str, ...]]] = {
         "The model id was rejected — try the cross-region inference profile id.",
         (
             "# Claude 4.x on Bedrock requires a prefix: us. / eu. / apac.",
-            "/model bedrock_converse:us.anthropic.claude-opus-4-7",
+            "/model bedrock_converse:us.anthropic.claude-opus-4-8",
             "# or list what your account can invoke:",
             "bog-agents test-bedrock",
         ),
@@ -839,12 +839,92 @@ def render_fix_report(steps: list[ProbeStep]) -> str:
     return "\n".join(lines)
 
 
+# ---------------------------------------------------------------------------
+# Probe-and-pick — choose a model the account can actually invoke
+# ---------------------------------------------------------------------------
+
+
+def pick_hittable_bedrock_model(
+    candidates: Sequence[str],
+    region: str | None = None,
+    *,
+    max_attempts: int = 5,
+) -> tuple[str | None, BedrockError | None]:
+    """Return the first candidate Bedrock model id the account can invoke.
+
+    Each candidate is tested with a tiny (1-token) ``converse`` call in
+    preference order; the first that succeeds is returned. This is what lets
+    a fresh user "default to a model we KNOW is hittable" instead of being
+    pinned to the most access-gated model and seeing an opaque error on their
+    first prompt.
+
+    Account-wide failures (missing/expired credentials, no region, network,
+    package missing) abort the probe early — no candidate could overcome them
+    — and the categorized error is returned so the caller can show the real
+    next step. Per-model failures (access not granted, invalid id, throttled,
+    unknown) skip to the next candidate.
+
+    Args:
+        candidates: Ordered Bedrock model ids, most preferred first (e.g.
+            ``("us.anthropic.claude-opus-4-8", "us.amazon.nova-lite-v1:0")``).
+        region: AWS region for the probe. When ``None``, falls back to
+            ``AWS_REGION`` / ``AWS_DEFAULT_REGION``.
+        max_attempts: Cap on how many candidates to probe (bounds latency and
+            cost on a fully locked-down account).
+
+    Returns:
+        ``(model_id, None)`` for the first invokable candidate, or
+        ``(None, BedrockError)`` when none are reachable. Account-wide errors
+        take precedence over the first per-model failure in the returned
+        error.
+    """
+    try:
+        import boto3
+    except ImportError as exc:
+        return None, categorize_bedrock_error(exc)
+
+    resolved = (
+        region or os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
+    )
+    try:
+        client = boto3.client("bedrock-runtime", region_name=resolved)
+    except Exception as exc:  # diagnostic — never raise out of the probe
+        return None, categorize_bedrock_error(exc)
+
+    account_wide = {
+        BedrockErrorKind.CREDENTIALS_MISSING,
+        BedrockErrorKind.CREDENTIALS_EXPIRED,
+        BedrockErrorKind.REGION_INVALID,
+        BedrockErrorKind.NETWORK,
+        BedrockErrorKind.PACKAGE_MISSING,
+    }
+    first_error: BedrockError | None = None
+    for model_id in list(candidates)[:max_attempts]:
+        try:
+            client.converse(
+                modelId=model_id,
+                messages=[{"role": "user", "content": [{"text": "hi"}]}],
+                inferenceConfig={"maxTokens": 1, "temperature": 0.0},
+            )
+        except Exception as exc:
+            err = categorize_bedrock_error(exc)
+            if first_error is None:
+                first_error = err
+            if err.kind in account_wide:
+                return None, err
+            continue
+        else:
+            return model_id, None
+    return None, first_error
+
+
 __all__ = [
     "BedrockError",
     "BedrockErrorKind",
     "ProbeStep",
     "categorize_bedrock_error",
     "iter_probe_lines",
+    "pick_hittable_bedrock_model",
     "probe_bedrock",
     "render_fix_report",
     "render_probe_report",

--- a/libs/cli/bog_agents_cli/agent.py
+++ b/libs/cli/bog_agents_cli/agent.py
@@ -1708,8 +1708,7 @@ def create_cli_agent(
     from bog_agents_cli.bedrock_resilience import is_bedrock_chat_model
 
     model_is_bedrock = (
-        isinstance(model, str)
-        and model.startswith(("bedrock:", "bedrock_converse:"))
+        isinstance(model, str) and model.startswith(("bedrock:", "bedrock_converse:"))
     ) or (not isinstance(model, str) and is_bedrock_chat_model(model))
     if model_is_bedrock:
         from bog_agents_cli.bedrock_refresh import BedrockRefreshMiddleware

--- a/libs/cli/bog_agents_cli/agent.py
+++ b/libs/cli/bog_agents_cli/agent.py
@@ -1698,16 +1698,36 @@ def create_cli_agent(
 
     agent_middleware.append(NotificationsMiddleware())
 
-    # Bedrock credential auto-refresh — only attached when a Bedrock
-    # model is in use, to keep the middleware list lean for everyone
-    # else. Detects ExpiredTokenException / SSOTokenLoadError on model
-    # calls and runs `aws sso login` to refresh, then retries. See
-    # docs/providers/bedrock.md and bog_agents_cli.bedrock_refresh.
-    if isinstance(model, str) and model.startswith(("bedrock:", "bedrock_converse:")):
-        from bog_agents_cli.bedrock_refresh import BedrockRefreshMiddleware
+    # Bedrock resilience — only attached when a Bedrock model is in use, to
+    # keep the middleware list lean for everyone else. NOTE: by this point
+    # `model` has already been resolved from a `provider:model` string to a
+    # `BaseChatModel` instance (above), so an `isinstance(model, str)` check
+    # is always False on the live path — detect Bedrock from the resolved
+    # model instead. (Previously the string check meant NEITHER Bedrock
+    # middleware ever attached on the live server path.)
+    from bog_agents_cli.bedrock_resilience import is_bedrock_chat_model
 
+    model_is_bedrock = (
+        isinstance(model, str)
+        and model.startswith(("bedrock:", "bedrock_converse:"))
+    ) or (not isinstance(model, str) and is_bedrock_chat_model(model))
+    if model_is_bedrock:
+        from bog_agents_cli.bedrock_refresh import BedrockRefreshMiddleware
+        from bog_agents_cli.bedrock_resilience import BedrockResilienceMiddleware
+
+        bedrock_interactive = sys.stdin.isatty()
+        # Order is load-bearing: earlier in the list == OUTER wrapper.
+        # Resilience (outer) categorizes any failure and falls back to a
+        # hittable model / emits a friendly diagnosis. Refresh (inner) gets
+        # first crack at an expired-SSO failure (runs `aws sso login` and
+        # retries) before resilience would otherwise surface it. See
+        # docs/providers/bedrock.md, bog_agents_cli.bedrock_resilience, and
+        # bog_agents_cli.bedrock_refresh.
         agent_middleware.append(
-            BedrockRefreshMiddleware(interactive=sys.stdin.isatty())
+            BedrockResilienceMiddleware(interactive=bedrock_interactive)
+        )
+        agent_middleware.append(
+            BedrockRefreshMiddleware(interactive=bedrock_interactive)
         )
 
     # Street sweeper (opt-in) — attach the per-cwd singleton instance, disabled

--- a/libs/cli/bog_agents_cli/bedrock_refresh.py
+++ b/libs/cli/bog_agents_cli/bedrock_refresh.py
@@ -173,7 +173,7 @@ class BedrockRefreshMiddleware(AgentMiddleware[Any, Any, Any]):
         from bog_agents_cli.bedrock_refresh import BedrockRefreshMiddleware
 
         agent = create_agent(
-            model="bedrock_converse:us.anthropic.claude-opus-4-7",
+            model="bedrock_converse:us.anthropic.claude-opus-4-8",
             middleware=[BedrockRefreshMiddleware(interactive=True)],
         )
 

--- a/libs/cli/bog_agents_cli/bedrock_resilience.py
+++ b/libs/cli/bog_agents_cli/bedrock_resilience.py
@@ -1,0 +1,666 @@
+"""Live-turn Bedrock resilience: categorize failures + auto-fallback.
+
+The motivating bug: a fresh user with AWS credentials is auto-defaulted
+to a heavily access-gated Bedrock model (Claude Opus). The model client
+builds fine — no network call happens at construction — so nothing fails
+until the first real ``.invoke()`` when the user types "hi". At that
+point boto3 raises ``AccessDeniedException``. Crucially, that exception is
+raised *inside the langgraph dev server subprocess*, where langgraph's
+serde replaces the detail with a generic "An internal error occurred"
+before it crosses the SSE boundary. The user sees a bare "internal server
+error" ~10-15s later, with none of the rich, actionable diagnosis that
+``bog_agents_cli._bedrock`` already knows how to produce.
+
+This middleware closes that gap. It wraps the model call **in-process**,
+where the original botocore ``ClientError`` is still live, and:
+
+- For "a different model would work" failures — model access not granted
+  to *this* model, *this* model id invalid, or *this* model throttled —
+  it descends a fallback ladder (the configured ``[models].fallbacks``
+  first, then Claude Opus -> Sonnet -> Haiku -> Amazon Nova), announces
+  the switch, and returns the first hittable model's real response. The
+  working model is remembered for the rest of the session so the dead
+  primary is not re-tried on every subsequent step of the turn.
+- For everything else — no region, missing/expired credentials, network,
+  package-missing, unknown — and when the ladder is exhausted, it returns
+  a synthetic ``AIMessage`` carrying the categorized, region-named
+  diagnosis. Because that is *normal stream content* it survives the
+  subprocess boundary intact, so the user finally sees "Bedrock model
+  access NOT granted ... grant it in the console for region us-east-1"
+  instead of "internal server error".
+
+Ordering: attach this OUTSIDE ``BedrockRefreshMiddleware`` (earlier in the
+middleware list) so credential-refresh gets first crack at an expired-SSO
+failure; only if refresh declines/fails does this middleware produce the
+terminal diagnosis. See ``bog_agents_cli.agent.create_cli_agent``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import TYPE_CHECKING, Any
+
+from langchain.agents.middleware.types import AgentMiddleware, ModelResponse
+from langchain_core.messages import AIMessage
+
+from bog_agents_cli._bedrock import (
+    BedrockError,
+    BedrockErrorKind,
+    categorize_bedrock_error,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from langchain.agents.middleware.types import ModelRequest
+    from langchain_core.language_models import BaseChatModel
+
+logger = logging.getLogger(__name__)
+
+
+# Kinds where a *different model* might succeed where this one failed:
+# access not granted to THIS model, THIS model id invalid, or THIS model
+# throttled (a different family carries separate quota). Region / credential
+# / network / package failures are account-wide — switching models won't
+# help, so those get a direct diagnosis instead of a ladder walk.
+_FALLBACKABLE_KINDS: frozenset[BedrockErrorKind] = frozenset(
+    {
+        BedrockErrorKind.MODEL_ACCESS_DENIED,
+        BedrockErrorKind.MODEL_ID_INVALID,
+        BedrockErrorKind.THROTTLED,
+    }
+)
+
+# Hard cap on fallback hops so a fully-locked-down account doesn't spend a
+# dozen model builds + calls before surfacing the diagnosis. Set high enough
+# to walk past the premium tiers (Opus/Sonnet/Haiku + premium Nova) and reach
+# the broadly-available Nova Lite/Micro models, since an access-denied probe
+# fails fast (Bedrock returns 4xx immediately, no tokens generated).
+_DEFAULT_MAX_FALLBACK_HOPS = 6
+
+# Exception type names that signal an AWS/botocore-origin failure. Used to
+# avoid converting an unrelated bug (which should keep its traceback) into a
+# friendly-but-misleading Bedrock diagnosis.
+_AWS_FAILURE_TYPE_NAMES: frozenset[str] = frozenset(
+    {
+        "ClientError",
+        "BotoCoreError",
+        "NoCredentialsError",
+        "NoRegionError",
+        "EndpointConnectionError",
+        "ConnectTimeoutError",
+        "ReadTimeoutError",
+        "ParamValidationError",
+        "ValidationError",
+        "TokenRetrievalError",
+        "ExpiredTokenException",
+        "SSOTokenLoadError",
+        "UnauthorizedSSOTokenError",
+        "ThrottlingException",
+        "AccessDeniedException",
+        "ValidationException",
+        "ResourceNotFoundException",
+    }
+)
+
+_AWS_FAILURE_SUBSTRINGS: tuple[str, ...] = (
+    "bedrock",
+    "botocore",
+    "boto3",
+    "accessdenied",
+    "validationexception",
+    "could not connect to the endpoint",
+    "unable to locate credentials",
+    "aws_default_region",
+    "you must specify a region",
+    "security token",
+    "expiredtoken",
+    "throttl",
+)
+
+# Providers whose ``provider:model`` specs we recognise so a bare Bedrock id
+# (which itself contains ':' in the ``…-v1:0`` suffix) isn't mis-split.
+_KNOWN_PROVIDERS: frozenset[str] = frozenset(
+    {
+        "bedrock",
+        "bedrock_converse",
+        "anthropic",
+        "openai",
+        "azure_openai",
+        "google_genai",
+        "google_vertexai",
+        "ollama",
+        "mistralai",
+        "cohere",
+        "groq",
+        "deepseek",
+        "xai",
+        "openrouter",
+        "nvidia",
+        "together",
+        "fireworks",
+        "perplexity",
+    }
+)
+
+
+# Cross-region inference-profile prefixes (us./eu./apac./jp./sa./global.).
+_REGION_PREFIXES: tuple[str, ...] = ("us.", "eu.", "apac.", "jp.", "sa.", "global.")
+
+
+def _bare_model_id(spec: str) -> str:
+    """Return the model id from a ``provider:model`` spec or bare id.
+
+    Bedrock ids embed a colon in their ``…-v1:0`` version suffix, so a naive
+    ``split(':')`` would corrupt them. We only strip a leading token when it
+    is a recognised provider name.
+    """
+    s = (spec or "").strip().lower()
+    if ":" in s:
+        provider, _, rest = s.partition(":")
+        if provider in _KNOWN_PROVIDERS and rest:
+            return rest
+    return s
+
+
+def _split_region(model_id: str) -> tuple[str, str]:
+    """Split a Bedrock id into ``(region_prefix, core)``.
+
+    ``us.anthropic.claude-opus-4-8`` -> ``("us", "anthropic.claude-opus-4-8")``.
+    A bare id with no cross-region prefix yields ``("", id)``.
+    """
+    low = model_id.lower()
+    for prefix in _REGION_PREFIXES:
+        if low.startswith(prefix):
+            return prefix.rstrip("."), model_id[len(prefix) :]
+    return "", model_id
+
+
+def _model_family(core: str) -> str:
+    """Coarse model-family key for diversity dedup (region-agnostic).
+
+    ``anthropic.claude-sonnet-4-6`` -> ``anthropic.claude-sonnet``;
+    ``amazon.nova-lite-v1:0`` -> ``amazon.nova-lite``;
+    ``meta.llama4-maverick-17b-instruct-v1:0`` -> ``meta.llama4-maverick``.
+    Used so the fallback ladder prefers a genuinely *different* model rather
+    than the same model in another region / at another version.
+    """
+    c = core.lower()
+    vendor, _, model = c.partition(".")
+    parts = [p for p in model.split("-") if p]
+    family = "-".join(parts[:2]) if parts else model
+    return f"{vendor}.{family}"
+
+
+def _region_prefix(region: str | None) -> str:
+    """Map an AWS region to its Bedrock inference-profile prefix.
+
+    ``us-east-1`` -> ``us``, ``eu-west-1`` -> ``eu``, ``ap-northeast-1`` ->
+    ``jp``, other ``ap-*`` -> ``apac``, ``sa-*`` -> ``sa``. Unknown / unset
+    falls back to ``us`` (broadest profile coverage). Mirrors the resolver in
+    ``bog_agents._models``.
+    """
+    if not region:
+        return "us"
+    r = region.lower().strip()
+    if r.startswith("ap-northeast-1"):
+        return "jp"
+    if r.startswith("ap"):
+        return "apac"
+    if r.startswith("eu"):
+        return "eu"
+    if r.startswith("sa"):
+        return "sa"
+    return "us"
+
+
+def _diverse_candidates(region_prefix: str, *, exclude_family: str = "") -> list[str]:
+    """One Bedrock id per model family, preferring ``region_prefix``.
+
+    Walks the ``bedrock_converse`` catalog keeping the first id seen for each
+    coarse model family, so the result spans Opus/Sonnet/Haiku/Nova/... rather
+    than three regions and two versions of the same model. Same-region ids
+    claim each family before any cross-region variant.
+    """
+    try:
+        from bog_agents_cli.provider_catalog import get_default_model_candidates
+
+        catalog = [
+            str(m).strip() for m in get_default_model_candidates("bedrock_converse")
+        ]
+    except Exception:
+        logger.debug("could not load bedrock catalog candidates", exc_info=True)
+        return []
+
+    region_prefix = (region_prefix or "").lower()
+    seen: set[str] = set()
+    in_region: list[str] = []
+    other: list[str] = []
+
+    def _collect(mids: list[str], target: list[str]) -> None:
+        for mid in mids:
+            family = _model_family(_split_region(mid)[1])
+            if exclude_family and family == exclude_family:
+                continue
+            if family in seen:
+                continue
+            seen.add(family)
+            target.append(mid)
+
+    in_mids = [
+        m for m in catalog if region_prefix and _split_region(m)[0] == region_prefix
+    ]
+    out_mids = [
+        m
+        for m in catalog
+        if not (region_prefix and _split_region(m)[0] == region_prefix)
+    ]
+    _collect(in_mids, in_region)
+    _collect(out_mids, other)
+    return in_region + other
+
+
+def diverse_bedrock_candidates(region: str | None) -> list[str]:
+    """Family-deduped Bedrock model ids, preferring the profile region for ``region``.
+
+    Used to seed the first-run probe so it samples Opus -> Sonnet -> Haiku ->
+    Nova (one id per family) instead of burning attempts on the same model in
+    multiple regions / versions.
+    """
+    return _diverse_candidates(_region_prefix(region))
+
+
+def is_bedrock_chat_model(model: Any) -> bool:  # noqa: ANN401 — duck-typed chat model
+    """Return whether a resolved chat model is an AWS Bedrock model.
+
+    The CLI resolves a ``provider:model`` string to a ``BaseChatModel``
+    *before* middleware is attached, so an ``isinstance(model, str)`` check
+    is always False on the live server path. Detect by class name first
+    (cheap, no model introspection), then fall back to the LangSmith
+    provider tag.
+    """
+    name = type(model).__name__
+    if name in ("ChatBedrock", "ChatBedrockConverse"):
+        return True
+    try:
+        from bog_agents._models import get_model_provider  # noqa: PLC2701
+
+        provider = get_model_provider(model) or ""
+    except Exception:
+        return False
+    return provider in ("amazon_bedrock", "bedrock", "bedrock_converse")
+
+
+def _current_model_id(model: Any) -> str:  # noqa: ANN401 — duck-typed chat model
+    """Best-effort native model id (e.g. ``us.anthropic.claude-opus-4-8``)."""
+    try:
+        from bog_agents._models import get_model_identifier  # noqa: PLC2701
+
+        return (get_model_identifier(model) or "").strip()
+    except Exception:
+        return ""
+
+
+def _looks_like_bedrock_failure(exc: BaseException) -> bool:
+    """Heuristically decide whether ``exc`` came from the AWS/Bedrock layer.
+
+    Guards against swallowing an unrelated bug into a friendly Bedrock
+    diagnosis: only AWS-shaped exceptions are converted; anything else is
+    re-raised so its traceback survives.
+    """
+    response = getattr(exc, "response", None)
+    if isinstance(response, dict) and isinstance(response.get("Error"), dict):
+        return True
+    if type(exc).__name__ in _AWS_FAILURE_TYPE_NAMES:
+        return True
+    low = str(exc).lower()
+    return any(s in low for s in _AWS_FAILURE_SUBSTRINGS)
+
+
+def bedrock_fallback_specs(current_model_id: str) -> list[str]:
+    """Ordered alternate model specs to try when the current model fails.
+
+    The ladder is built for *diversity within a small hop budget* — after,
+    say, Opus is access-denied, we want to reach a genuinely different and
+    less-gated model (Sonnet, then Haiku, then Amazon Nova) quickly rather
+    than burning hops on the same model in other regions / at other versions.
+
+    Order:
+
+    1. ``[models].fallbacks`` from config (explicit user intent, any provider).
+    2. Catalog ``bedrock_converse`` candidates in the SAME region as the
+       failed model, one per model family, excluding the failed model's own
+       family (its access grant / id problem almost certainly applies to its
+       other versions too).
+    3. The same, for other regions, as a last resort.
+
+    Args:
+        current_model_id: The native id of the model that just failed.
+
+    Returns:
+        A de-duplicated, ordered list of ``provider:model`` specs.
+    """
+    config_specs: list[str] = []
+    try:
+        from bog_agents_cli.model_config import ModelConfig
+
+        config_specs = [
+            str(s).strip() for s in ModelConfig.load().fallbacks if str(s).strip()
+        ]
+    except Exception:
+        logger.debug(
+            "could not load [models].fallbacks for bedrock ladder", exc_info=True
+        )
+
+    cur_region, cur_core = _split_region(_bare_model_id(current_model_id))
+    cur_family = _model_family(cur_core) if cur_core else ""
+    catalog_specs = [
+        f"bedrock_converse:{mid}"
+        for mid in _diverse_candidates(cur_region, exclude_family=cur_family)
+    ]
+
+    out: list[str] = []
+    seen: set[str] = set()
+    for spec in (*config_specs, *catalog_specs):
+        if not spec or spec in seen:
+            continue
+        seen.add(spec)
+        out.append(spec)
+    return out
+
+
+class BedrockResilienceMiddleware(AgentMiddleware[Any, Any, Any]):
+    """Categorize live Bedrock model failures and auto-fall-back.
+
+    Attached automatically by the CLI when a Bedrock model is in use, and
+    placed OUTSIDE ``BedrockRefreshMiddleware`` so credential refresh runs
+    first. SDK callers can opt in by adding it to their middleware list.
+
+    Args:
+        interactive: Whether the session is interactive (reserved for future
+            prompts; currently only recorded).
+        announce: When True (default), prepend a one-line note to the first
+            answer produced after a fallback so the user knows the model was
+            swapped. Disable for a silent fallback.
+        max_hops: Maximum number of alternate models to try before giving up
+            and emitting the diagnosis.
+    """
+
+    def __init__(
+        self,
+        *,
+        interactive: bool = True,
+        announce: bool = True,
+        max_hops: int = _DEFAULT_MAX_FALLBACK_HOPS,
+    ) -> None:
+        super().__init__()
+        self._interactive = interactive
+        self._announce = announce
+        self._max_hops = max(0, int(max_hops))
+        # Once an alternate model works, stick to it for the rest of the
+        # session so the dead primary isn't re-tried on every model call of a
+        # multi-step turn. Lives for the process (the graph is built once).
+        self._sticky_alt: BaseChatModel | None = None
+
+    # -- async path (the live CLI server path) -----------------------------
+
+    async def awrap_model_call(  # type: ignore[override]
+        self,
+        request: ModelRequest,
+        call_next: Any,  # noqa: ANN401 — langchain middleware contract
+    ) -> ModelResponse:
+        """Async-wrap the model call: categorize Bedrock failures + fall back.
+
+        Raises:
+            KeyboardInterrupt: Propagated unchanged.
+            SystemExit: Propagated unchanged.
+            asyncio.CancelledError: Propagated unchanged.
+        """
+        if self._sticky_alt is not None:
+            request = request.override(model=self._sticky_alt)
+        try:
+            return await call_next(request)
+        except (KeyboardInterrupt, SystemExit, asyncio.CancelledError):
+            raise
+        except BaseException as exc:
+            handled = await self._ahandle(exc, request, call_next)
+            if handled is None:
+                raise
+            return handled
+
+    async def _ahandle(
+        self,
+        exc: BaseException,
+        request: ModelRequest,
+        call_next: Any,  # noqa: ANN401
+    ) -> ModelResponse | None:
+        if not _looks_like_bedrock_failure(exc):
+            return None
+        err = self._categorize(exc)
+        if err is None:
+            return None
+        region = self._region()
+        current_id = _current_model_id(request.model)
+        if err.kind in _FALLBACKABLE_KINDS and self._max_hops > 0:
+            tried: list[str] = []
+            for spec in bedrock_fallback_specs(current_id)[: self._max_hops]:
+                alt = self._build_model(spec)
+                if alt is None:
+                    continue
+                try:
+                    resp = await call_next(request.override(model=alt))
+                except (KeyboardInterrupt, SystemExit, asyncio.CancelledError):
+                    raise
+                except BaseException as alt_exc:
+                    tried.append(spec)
+                    logger.info("bedrock fallback %s also failed: %s", spec, alt_exc)
+                    continue
+                self._sticky_alt = alt
+                logger.info(
+                    "bedrock: fell back from %s to %s", current_id or "primary", spec
+                )
+                return self._annotate(
+                    resp, primary=current_id, used=spec, err=err, region=region
+                )
+            return self._diagnosis_response(
+                err, region, current_id=current_id, tried=tried
+            )
+        return self._diagnosis_response(err, region, current_id=current_id)
+
+    # -- sync path (tests / non-streaming callers) -------------------------
+
+    def wrap_model_call(  # type: ignore[override]
+        self,
+        request: ModelRequest,
+        call_next: Any,  # noqa: ANN401 — langchain middleware contract
+    ) -> ModelResponse:
+        """Sync-wrap the model call: categorize Bedrock failures + fall back.
+
+        Raises:
+            KeyboardInterrupt: Propagated unchanged.
+            SystemExit: Propagated unchanged.
+        """
+        if self._sticky_alt is not None:
+            request = request.override(model=self._sticky_alt)
+        try:
+            return call_next(request)
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except BaseException as exc:
+            handled = self._handle(exc, request, call_next)
+            if handled is None:
+                raise
+            return handled
+
+    def _handle(
+        self,
+        exc: BaseException,
+        request: ModelRequest,
+        call_next: Any,  # noqa: ANN401
+    ) -> ModelResponse | None:
+        if not _looks_like_bedrock_failure(exc):
+            return None
+        err = self._categorize(exc)
+        if err is None:
+            return None
+        region = self._region()
+        current_id = _current_model_id(request.model)
+        if err.kind in _FALLBACKABLE_KINDS and self._max_hops > 0:
+            tried: list[str] = []
+            for spec in bedrock_fallback_specs(current_id)[: self._max_hops]:
+                alt = self._build_model(spec)
+                if alt is None:
+                    continue
+                try:
+                    resp = call_next(request.override(model=alt))
+                except (KeyboardInterrupt, SystemExit):
+                    raise
+                except BaseException as alt_exc:
+                    tried.append(spec)
+                    logger.info("bedrock fallback %s also failed: %s", spec, alt_exc)
+                    continue
+                self._sticky_alt = alt
+                logger.info(
+                    "bedrock: fell back from %s to %s", current_id or "primary", spec
+                )
+                return self._annotate(
+                    resp, primary=current_id, used=spec, err=err, region=region
+                )
+            return self._diagnosis_response(
+                err, region, current_id=current_id, tried=tried
+            )
+        return self._diagnosis_response(err, region, current_id=current_id)
+
+    # -- shared helpers ----------------------------------------------------
+
+    @staticmethod
+    def _categorize(exc: BaseException) -> BedrockError | None:
+        try:
+            return categorize_bedrock_error(exc)
+        except Exception:
+            logger.debug("bedrock categorization failed", exc_info=True)
+            return None
+
+    @staticmethod
+    def _region() -> str | None:
+        try:
+            from bog_agents_cli.model_config import resolve_aws_region
+
+            return resolve_aws_region(fallback="us-east-1")
+        except Exception:
+            return os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
+
+    @staticmethod
+    def _build_model(spec: str) -> BaseChatModel | None:
+        try:
+            from bog_agents_cli.config import create_model
+
+            return create_model(spec).model
+        except Exception:
+            logger.info("bedrock fallback: could not build %s", spec, exc_info=True)
+            return None
+
+    def _diagnosis_response(
+        self,
+        err: BedrockError,
+        region: str | None,
+        *,
+        current_id: str = "",
+        tried: Sequence[str] = (),
+    ) -> ModelResponse:
+        text = self._diagnosis_text(err, region, current_id=current_id, tried=tried)
+        msg = AIMessage(
+            content=text,
+            response_metadata={"bog_agents_bedrock_diagnosis": err.kind.value},
+        )
+        return ModelResponse(result=[msg])
+
+    @staticmethod
+    def _diagnosis_text(
+        err: BedrockError,
+        region: str | None,
+        *,
+        current_id: str = "",
+        tried: Sequence[str] = (),
+    ) -> str:
+        parts: list[str] = [err.banner().rstrip("\n")]
+        if current_id:
+            parts.append(f"[model]  {current_id}")
+        if region:
+            parts.append(f"[region] Bedrock used AWS region: {region}")
+            if err.kind == BedrockErrorKind.MODEL_ACCESS_DENIED:
+                parts.append(
+                    f"         Model access is per-region — grant it for {region} "
+                    "in the console, or set AWS_REGION to a region where you "
+                    "already have access."
+                )
+        if tried:
+            parts.append("[fallback] also tried (all failed): " + ", ".join(tried))
+        parts.append(
+            "Next: run `bog-agents test-bedrock` for a full probe, or `/model` "
+            "to switch to a model you can reach."
+        )
+        return "\n".join(parts)
+
+    def _annotate(
+        self,
+        resp: ModelResponse,
+        *,
+        primary: str,
+        used: str,
+        err: BedrockError,
+        region: str | None,
+    ) -> ModelResponse:
+        if not self._announce:
+            return resp
+        try:
+            note = self._switch_note(primary=primary, used=used, err=err, region=region)
+            new_result = list(resp.result)
+            for i, m in enumerate(new_result):
+                if isinstance(m, AIMessage):
+                    new_result[i] = self._prepend_note(m, note)
+                    break
+            else:
+                new_result.insert(0, AIMessage(content=note))
+            return ModelResponse(
+                result=new_result, structured_response=resp.structured_response
+            )
+        except Exception:
+            logger.debug("bedrock fallback annotation failed", exc_info=True)
+            return resp
+
+    @staticmethod
+    def _switch_note(
+        *, primary: str, used: str, err: BedrockError, region: str | None
+    ) -> str:
+        region_suffix = f" in {region}" if region else ""
+        used_id = _bare_model_id(used)
+        primary_label = primary or "the configured model"
+        # ASCII-only: this string may be written to a cp1252 console / log on
+        # non-en-US Windows; a stray non-ASCII glyph there raises (see the
+        # encoding guidance in CLAUDE.md).
+        return (
+            f"_Bedrock note: `{primary_label}` was not usable "
+            f"({err.title.lower()}{region_suffix}); answered with `{used_id}` "
+            "instead. Use `/model` to set a permanent choice._\n\n"
+        )
+
+    @staticmethod
+    def _prepend_note(msg: AIMessage, note: str) -> AIMessage:
+        content = msg.content
+        if isinstance(content, str):
+            return msg.model_copy(update={"content": note + content})
+        if isinstance(content, list):
+            return msg.model_copy(
+                update={"content": [{"type": "text", "text": note}, *content]}
+            )
+        return msg
+
+
+__all__ = [
+    "BedrockResilienceMiddleware",
+    "bedrock_fallback_specs",
+    "is_bedrock_chat_model",
+]

--- a/libs/cli/bog_agents_cli/config.py
+++ b/libs/cli/bog_agents_cli/config.py
@@ -1549,7 +1549,9 @@ def _pick_default_bedrock_spec() -> str | None:
             save_default_model,
         )
     except Exception:
-        logger.debug("bedrock probe imports failed; using static default", exc_info=True)
+        logger.debug(
+            "bedrock probe imports failed; using static default", exc_info=True
+        )
         return static
 
     region = resolve_aws_region()  # us-east-1 fallback (broadest model set)
@@ -1582,8 +1584,12 @@ def _pick_default_bedrock_spec() -> str | None:
             save_default_model(spec)
         except Exception:
             logger.debug("could not persist auto-picked bedrock default", exc_info=True)
-        console.print(f"[green]Bedrock ready: using {picked} (region {region}).[/green]")
-        logger.info("Auto-picked hittable Bedrock model: %s (region %s)", picked, region)
+        console.print(
+            f"[green]Bedrock ready: using {picked} (region {region}).[/green]"
+        )
+        logger.info(
+            "Auto-picked hittable Bedrock model: %s (region %s)", picked, region
+        )
         return spec
 
     # Nothing invokable yet — show the real reason, return a best-effort spec.

--- a/libs/cli/bog_agents_cli/config.py
+++ b/libs/cli/bog_agents_cli/config.py
@@ -1512,6 +1512,94 @@ def detect_provider(model_name: str) -> str | None:
     return None
 
 
+def _pick_default_bedrock_spec() -> str | None:
+    """Pick a Bedrock model the account can actually invoke (first run).
+
+    AWS Bedrock gates each model behind a per-account, per-region access
+    grant, so there is no single id we can hardcode that is guaranteed
+    hittable. Instead we probe the catalog's Claude-first -> Amazon-Nova
+    ladder against the live account and return the first invokable
+    `bedrock_converse:<id>` spec, persisting it as the default so later
+    launches are instant.
+
+    When nothing is reachable yet, the categorized reason is surfaced (e.g.
+    "model access not granted") and we fall back to the top catalog
+    candidate — the live-turn resilience middleware will diagnose again if
+    the user proceeds, so they are never left with a bare "internal server
+    error". Set `BOG_AGENTS_BEDROCK_NO_PROBE=1` to skip the probe and use the
+    static top candidate.
+
+    Returns:
+        A `bedrock_converse:<id>` spec, or `None` only if the catalog is
+        empty (callers treat `None` as "keep looking").
+    """
+    static = _get_recommended_model_spec("bedrock_converse")
+    if os.environ.get("BOG_AGENTS_BEDROCK_NO_PROBE", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+    ):
+        return static
+
+    try:
+        from bog_agents_cli._bedrock import pick_hittable_bedrock_model
+        from bog_agents_cli.bedrock_resilience import diverse_bedrock_candidates
+        from bog_agents_cli.model_config import (
+            resolve_aws_region,
+            save_default_model,
+        )
+    except Exception:
+        logger.debug("bedrock probe imports failed; using static default", exc_info=True)
+        return static
+
+    region = resolve_aws_region()  # us-east-1 fallback (broadest model set)
+    region_unset = resolve_aws_region(fallback=None) is None
+
+    # Family-diverse, region-preferred order (Opus -> Sonnet -> Haiku -> Nova,
+    # one per family) so the probe samples real alternatives instead of burning
+    # attempts on the same model in three regions / two versions.
+    candidates = diverse_bedrock_candidates(region)
+    if not candidates:
+        return static
+
+    try:
+        picked, err = pick_hittable_bedrock_model(candidates, region, max_attempts=8)
+    except Exception:
+        logger.debug(
+            "bedrock probe-and-pick failed; using static default", exc_info=True
+        )
+        return static
+
+    if region_unset and region:
+        console.print(
+            f"[yellow]No AWS region configured - using {region} for Bedrock. "
+            "Set AWS_REGION (or a profile region) to change it.[/yellow]"
+        )
+
+    if picked:
+        spec = f"bedrock_converse:{picked}"
+        try:
+            save_default_model(spec)
+        except Exception:
+            logger.debug("could not persist auto-picked bedrock default", exc_info=True)
+        console.print(f"[green]Bedrock ready: using {picked} (region {region}).[/green]")
+        logger.info("Auto-picked hittable Bedrock model: %s (region %s)", picked, region)
+        return spec
+
+    # Nothing invokable yet — show the real reason, return a best-effort spec.
+    if err is not None:
+        try:
+            console.print(f"[red]{err.banner()}[/red]")
+        except Exception:
+            logger.debug("bedrock banner render failed", exc_info=True)
+    console.print(
+        "[yellow]No Bedrock model was invokable yet. Grant model access in the "
+        "AWS console (per region), then restart — bog-agents will pick a "
+        "working model automatically.[/yellow]"
+    )
+    return static or f"bedrock_converse:{candidates[0]}"
+
+
 def _get_default_model_spec() -> str:
     """Get default model specification based on available credentials.
 
@@ -1557,7 +1645,13 @@ def _get_default_model_spec() -> str:
     for provider, is_available in provider_checks:
         if not is_available():
             continue
-        preferred = _get_recommended_model_spec(provider)
+        # Bedrock gates models behind per-account/per-region access grants,
+        # so probe the account and pick one we can actually invoke instead of
+        # blindly returning the most access-gated catalog entry.
+        if provider == "bedrock_converse":
+            preferred = _pick_default_bedrock_spec()
+        else:
+            preferred = _get_recommended_model_spec(provider)
         if preferred:
             return preferred
 
@@ -2037,9 +2131,21 @@ def _create_model_via_init(
             "ollama": "langchain-ollama",
         }
         package = package_map.get(provider, f"langchain-{provider}")
-        msg = (
-            f"Missing package for provider '{provider}'. Install: pip install {package}"
-        )
+        if provider in ("bedrock", "bedrock_converse"):
+            # Point CLI users at the packaged extra (which pulls langchain-aws
+            # AND boto3) rather than the bare SDK package. The phrase "Missing
+            # package for provider" is kept so _bedrock.categorize_bedrock_error
+            # still classifies this as PACKAGE_MISSING.
+            msg = (
+                f"Missing package for provider '{provider}'. Install the AWS "
+                "extra: pip install 'bog-agents-cli[bedrock]'  "
+                "(or: pip install langchain-aws)"
+            )
+        else:
+            msg = (
+                f"Missing package for provider '{provider}'. "
+                f"Install: pip install {package}"
+            )
         raise ModelConfigError(msg) from e
     except (ValueError, TypeError) as e:
         spec = f"{provider}:{model_name}" if provider else model_name

--- a/libs/cli/bog_agents_cli/provider_catalog.py
+++ b/libs/cli/bog_agents_cli/provider_catalog.py
@@ -82,11 +82,11 @@ DEFAULT_MODEL_CANDIDATES: Mapping[str, tuple[str, ...]] = MappingProxyType(
             "gpt-5",
         ),
         "bedrock": (
-            # AWS Bedrock model IDs, refreshed 2026-05-19.
+            # AWS Bedrock model IDs, refreshed 2026-06-17.
             #
             # Anthropic Claude 4.x on Bedrock REQUIRES a cross-region
             # inference profile prefix (us./eu./apac./...); the bare
-            # `anthropic.claude-opus-4-7` IDs return AccessDenied even
+            # `anthropic.claude-opus-4-8` IDs return AccessDenied even
             # when the account has model access granted. The auto-
             # resolver in `bog_agents._models` rewrites bare→regional
             # based on AWS_REGION as a safety net, but the catalog lists
@@ -94,6 +94,9 @@ DEFAULT_MODEL_CANDIDATES: Mapping[str, tuple[str, ...]] = MappingProxyType(
             # them as first-class entries. See docs/providers/bedrock.md.
             #
             # ─── ANTHROPIC CLAUDE (inference profiles required) ─────
+            "us.anthropic.claude-opus-4-8",
+            "eu.anthropic.claude-opus-4-8",
+            "apac.anthropic.claude-opus-4-8",
             "us.anthropic.claude-opus-4-7",
             "eu.anthropic.claude-opus-4-7",
             "apac.anthropic.claude-opus-4-7",
@@ -123,6 +126,9 @@ DEFAULT_MODEL_CANDIDATES: Mapping[str, tuple[str, ...]] = MappingProxyType(
         # IDs as bedrock (above) plus DeepSeek which is converse-only.
         "bedrock_converse": (
             # ─── ANTHROPIC CLAUDE (inference profiles required) ─────
+            "us.anthropic.claude-opus-4-8",
+            "eu.anthropic.claude-opus-4-8",
+            "apac.anthropic.claude-opus-4-8",
             "us.anthropic.claude-opus-4-7",
             "eu.anthropic.claude-opus-4-7",
             "apac.anthropic.claude-opus-4-7",

--- a/libs/cli/tests/unit_tests/test_bedrock_resilience.py
+++ b/libs/cli/tests/unit_tests/test_bedrock_resilience.py
@@ -9,6 +9,8 @@ faked, and the model call is a local callable.
 
 from __future__ import annotations
 
+import sys
+import types
 from typing import Any
 
 import pytest
@@ -92,7 +94,9 @@ class TestHelpers:
         assert is_bedrock_chat_model(ChatBedrockConverse()) is True
 
     def test_is_bedrock_chat_model_false_for_other(self) -> None:
-        assert is_bedrock_chat_model(_FakeModel("us.anthropic.claude-opus-4-8")) is False
+        assert (
+            is_bedrock_chat_model(_FakeModel("us.anthropic.claude-opus-4-8")) is False
+        )
 
     def test_bare_model_id_preserves_version_colon(self) -> None:
         # The ``…-v1:0`` suffix must NOT be treated as a provider separator.
@@ -264,6 +268,19 @@ class TestAsyncResilience:
         assert seen[0] == _OPUS
 
 
+def _install_fake_boto3(monkeypatch: pytest.MonkeyPatch, runtime: object) -> None:
+    """Inject a fake ``boto3`` module whose ``client()`` returns ``runtime``.
+
+    ``pick_hittable_bedrock_model`` does ``import boto3`` internally, but boto3
+    is only present with the ``[bedrock]`` extra (not in the base test env / CI).
+    Injecting a stub into ``sys.modules`` lets these tests run anywhere and also
+    overrides a real boto3 when present.
+    """
+    fake = types.ModuleType("boto3")
+    fake.client = lambda *_a, **_k: runtime  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "boto3", fake)
+
+
 class TestPickHittableModel:
     def test_returns_first_invokable_candidate(
         self, monkeypatch: pytest.MonkeyPatch
@@ -278,9 +295,7 @@ class TestPickHittableModel:
                     return {"usage": {"totalTokens": 1}}
                 raise _access_denied()
 
-        import boto3
-
-        monkeypatch.setattr(boto3, "client", lambda *a, **k: _FakeRuntime())
+        _install_fake_boto3(monkeypatch, _FakeRuntime())
         picked, err = pick_hittable_bedrock_model(
             ["us.anthropic.claude-opus-4-8", "us.amazon.nova-lite-v1:0"],
             "us-east-1",
@@ -299,9 +314,7 @@ class TestPickHittableModel:
                 calls.append(modelId)
                 raise Exception("Unable to locate credentials")  # noqa: TRY002
 
-        import boto3
-
-        monkeypatch.setattr(boto3, "client", lambda *a, **k: _FakeRuntime())
+        _install_fake_boto3(monkeypatch, _FakeRuntime())
         picked, err = pick_hittable_bedrock_model(
             ["us.anthropic.claude-opus-4-8", "us.amazon.nova-lite-v1:0"],
             "us-east-1",

--- a/libs/cli/tests/unit_tests/test_bedrock_resilience.py
+++ b/libs/cli/tests/unit_tests/test_bedrock_resilience.py
@@ -1,0 +1,342 @@
+"""Tests for live-turn Bedrock resilience: categorization + auto-fallback.
+
+These lock in the fix for the fresh-user "internal server error" symptom: a
+Bedrock model failure on a live turn must surface a categorized, region-named
+diagnosis (or transparently fall back to a hittable model) instead of an
+opaque error. No real AWS calls are made — botocore ``ClientError`` shapes are
+faked, and the model call is a local callable.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from langchain.agents.middleware.types import ModelResponse
+from langchain_core.messages import AIMessage
+
+from bog_agents_cli._bedrock import BedrockErrorKind, pick_hittable_bedrock_model
+from bog_agents_cli.bedrock_resilience import (
+    BedrockResilienceMiddleware,
+    _bare_model_id,
+    _model_family,
+    bedrock_fallback_specs,
+    is_bedrock_chat_model,
+)
+
+
+class _FakeClientError(Exception):
+    """Stand-in for a botocore ``ClientError`` (carries a ``.response``)."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(f"An error occurred ({code}): {message}")
+        self.response = {"Error": {"Code": code, "Message": message}}
+
+
+class _FakeModel:
+    """Minimal chat-model stand-in exposing ``model_dump`` for id extraction."""
+
+    def __init__(self, model_id: str) -> None:
+        self._id = model_id
+
+    def model_dump(self) -> dict[str, str]:
+        return {"model_name": self._id}
+
+
+class _FakeRequest:
+    """Minimal ``ModelRequest`` stand-in: just ``.model`` + ``.override``."""
+
+    def __init__(self, model: object) -> None:
+        self.model = model
+
+    def override(self, *, model: object = None, **_kw: object) -> _FakeRequest:
+        return _FakeRequest(model if model is not None else self.model)
+
+
+_OPUS = "us.anthropic.claude-opus-4-8"
+_SONNET = "us.anthropic.claude-sonnet-4-6"
+
+
+def _access_denied() -> _FakeClientError:
+    return _FakeClientError(
+        "AccessDeniedException",
+        "You don't have access to the model with the specified model ID.",
+    )
+
+
+@pytest.fixture
+def patched_mw(monkeypatch: pytest.MonkeyPatch) -> BedrockResilienceMiddleware:
+    """A middleware whose region is fixed and whose model builder is faked.
+
+    Keeps the ladder offline: ``_build_model`` returns a ``_FakeModel`` tagged
+    with the bare id, so the test's ``call_next`` can tell which rung it is on.
+    """
+    monkeypatch.setattr(
+        BedrockResilienceMiddleware,
+        "_region",
+        staticmethod(lambda: "us-east-1"),
+    )
+    monkeypatch.setattr(
+        BedrockResilienceMiddleware,
+        "_build_model",
+        staticmethod(lambda spec: _FakeModel(_bare_model_id(spec))),
+    )
+    return BedrockResilienceMiddleware(interactive=False)
+
+
+class TestHelpers:
+    def test_is_bedrock_chat_model_by_class_name(self) -> None:
+        class ChatBedrockConverse:
+            pass
+
+        assert is_bedrock_chat_model(ChatBedrockConverse()) is True
+
+    def test_is_bedrock_chat_model_false_for_other(self) -> None:
+        assert is_bedrock_chat_model(_FakeModel("us.anthropic.claude-opus-4-8")) is False
+
+    def test_bare_model_id_preserves_version_colon(self) -> None:
+        # The ``…-v1:0`` suffix must NOT be treated as a provider separator.
+        spec = "bedrock_converse:us.anthropic.claude-haiku-4-5-20251001-v1:0"
+        assert _bare_model_id(spec) == "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+
+    def test_model_family_groups_versions(self) -> None:
+        assert _model_family("anthropic.claude-sonnet-4-6") == "anthropic.claude-sonnet"
+        assert _model_family("amazon.nova-lite-v1:0") == "amazon.nova-lite"
+
+
+class TestFallbackLadder:
+    def test_ladder_is_diverse_and_excludes_failed_family(self) -> None:
+        ladder = bedrock_fallback_specs(_OPUS)
+        # Never retries the same model family in another region/version.
+        assert all("claude-opus" not in spec for spec in ladder)
+        # Leads with a different Claude tier, same region.
+        assert ladder[0] == f"bedrock_converse:{_SONNET}"
+        # Reaches a broadly-available Amazon Nova model within the hop budget.
+        assert any("amazon.nova" in spec for spec in ladder[:6])
+
+    def test_ladder_prefers_same_region(self) -> None:
+        ladder = bedrock_fallback_specs("eu.anthropic.claude-opus-4-8")
+        # Same-region (eu.) alternates come before any cross-region ones.
+        first = _bare_model_id(ladder[0])
+        assert first.startswith("eu."), ladder
+
+
+class TestSyncResilience:
+    def test_access_denied_falls_back_and_announces(
+        self, patched_mw: BedrockResilienceMiddleware
+    ) -> None:
+        seen: list[str] = []
+
+        def call_next(req: _FakeRequest) -> ModelResponse:
+            mid = req.model._id
+            seen.append(mid)
+            if "opus" in mid:
+                raise _access_denied()
+            return ModelResponse(result=[AIMessage(content=f"hi from {mid}")])
+
+        result = patched_mw.wrap_model_call(
+            request=_FakeRequest(_FakeModel(_OPUS)), call_next=call_next
+        )
+        assert isinstance(result, ModelResponse)
+        content = result.result[0].content
+        assert f"hi from {_SONNET}" in content  # answered by the fallback model
+        assert "Bedrock" in content and _SONNET in content  # announced the switch
+        # Primary tried once, then exactly one fallback hop succeeded.
+        assert seen[0] == _OPUS
+        assert seen[1] == _SONNET
+
+    def test_access_denied_all_fail_yields_diagnosis(
+        self, patched_mw: BedrockResilienceMiddleware
+    ) -> None:
+        def call_next(req: _FakeRequest) -> ModelResponse:
+            raise _access_denied()
+
+        result = patched_mw.wrap_model_call(
+            request=_FakeRequest(_FakeModel(_OPUS)), call_next=call_next
+        )
+        msg = result.result[0]
+        assert isinstance(msg, AIMessage)
+        text = msg.content.lower()
+        assert "access" in text  # the real cause, not "internal server error"
+        assert "us-east-1" in text  # region named (per the region decision)
+        assert msg.response_metadata.get("bog_agents_bedrock_diagnosis") == (
+            BedrockErrorKind.MODEL_ACCESS_DENIED.value
+        )
+
+    def test_region_error_is_diagnosed_not_swapped(
+        self, patched_mw: BedrockResilienceMiddleware
+    ) -> None:
+        calls = {"n": 0}
+
+        def call_next(req: _FakeRequest) -> ModelResponse:
+            calls["n"] += 1
+            raise Exception("You must specify a region.")  # noqa: TRY002
+
+        result = patched_mw.wrap_model_call(
+            request=_FakeRequest(_FakeModel(_OPUS)), call_next=call_next
+        )
+        # Account-wide failure: no model swap attempted, just a diagnosis.
+        assert calls["n"] == 1
+        text = result.result[0].content.lower()
+        assert "region" in text
+
+    def test_expired_credentials_diagnosed(
+        self, patched_mw: BedrockResilienceMiddleware
+    ) -> None:
+        def call_next(req: _FakeRequest) -> ModelResponse:
+            raise Exception(  # noqa: TRY002
+                "The security token included in the request is expired"
+            )
+
+        result = patched_mw.wrap_model_call(
+            request=_FakeRequest(_FakeModel(_OPUS)), call_next=call_next
+        )
+        text = result.result[0].content.lower()
+        assert "expired" in text or "sso login" in text
+
+    def test_non_bedrock_error_propagates(
+        self, patched_mw: BedrockResilienceMiddleware
+    ) -> None:
+        # An unrelated bug must keep its traceback, not be swallowed into a
+        # friendly-but-wrong Bedrock diagnosis.
+        def call_next(req: _FakeRequest) -> ModelResponse:
+            raise ValueError("totally unrelated programming bug")
+
+        with pytest.raises(ValueError, match="unrelated programming bug"):
+            patched_mw.wrap_model_call(
+                request=_FakeRequest(_FakeModel(_OPUS)), call_next=call_next
+            )
+
+    def test_keyboard_interrupt_propagates(
+        self, patched_mw: BedrockResilienceMiddleware
+    ) -> None:
+        def call_next(req: _FakeRequest) -> ModelResponse:
+            raise KeyboardInterrupt
+
+        with pytest.raises(KeyboardInterrupt):
+            patched_mw.wrap_model_call(
+                request=_FakeRequest(_FakeModel(_OPUS)), call_next=call_next
+            )
+
+    def test_fallback_is_sticky_for_session(
+        self, patched_mw: BedrockResilienceMiddleware
+    ) -> None:
+        def first_turn(req: _FakeRequest) -> ModelResponse:
+            if "opus" in req.model._id:
+                raise _access_denied()
+            return ModelResponse(result=[AIMessage(content="ok")])
+
+        patched_mw.wrap_model_call(
+            request=_FakeRequest(_FakeModel(_OPUS)), call_next=first_turn
+        )
+
+        # Second turn: the dead primary must NOT be re-tried — the working
+        # alternate is used directly.
+        used: list[str] = []
+
+        def second_turn(req: _FakeRequest) -> ModelResponse:
+            used.append(req.model._id)
+            return ModelResponse(result=[AIMessage(content="ok2")])
+
+        patched_mw.wrap_model_call(
+            request=_FakeRequest(_FakeModel(_OPUS)), call_next=second_turn
+        )
+        assert used == [_SONNET]
+
+
+class TestAsyncResilience:
+    async def test_async_access_denied_falls_back(
+        self, patched_mw: BedrockResilienceMiddleware
+    ) -> None:
+        seen: list[str] = []
+
+        async def call_next(req: _FakeRequest) -> ModelResponse:
+            mid = req.model._id
+            seen.append(mid)
+            if "opus" in mid:
+                raise _access_denied()
+            return ModelResponse(result=[AIMessage(content=f"hi from {mid}")])
+
+        result = await patched_mw.awrap_model_call(
+            request=_FakeRequest(_FakeModel(_OPUS)), call_next=call_next
+        )
+        assert f"hi from {_SONNET}" in result.result[0].content
+        assert seen[0] == _OPUS
+
+
+class TestPickHittableModel:
+    def test_returns_first_invokable_candidate(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        granted = {"us.amazon.nova-lite-v1:0"}
+        calls: list[str] = []
+
+        class _FakeRuntime:
+            def converse(self, *, modelId: str, **_kw: Any) -> dict[str, Any]:  # noqa: N803
+                calls.append(modelId)
+                if modelId in granted:
+                    return {"usage": {"totalTokens": 1}}
+                raise _access_denied()
+
+        import boto3
+
+        monkeypatch.setattr(boto3, "client", lambda *a, **k: _FakeRuntime())
+        picked, err = pick_hittable_bedrock_model(
+            ["us.anthropic.claude-opus-4-8", "us.amazon.nova-lite-v1:0"],
+            "us-east-1",
+        )
+        assert picked == "us.amazon.nova-lite-v1:0"
+        assert err is None
+        assert calls == ["us.anthropic.claude-opus-4-8", "us.amazon.nova-lite-v1:0"]
+
+    def test_account_wide_failure_aborts_early(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[str] = []
+
+        class _FakeRuntime:
+            def converse(self, *, modelId: str, **_kw: Any) -> dict[str, Any]:  # noqa: N803
+                calls.append(modelId)
+                raise Exception("Unable to locate credentials")  # noqa: TRY002
+
+        import boto3
+
+        monkeypatch.setattr(boto3, "client", lambda *a, **k: _FakeRuntime())
+        picked, err = pick_hittable_bedrock_model(
+            ["us.anthropic.claude-opus-4-8", "us.amazon.nova-lite-v1:0"],
+            "us-east-1",
+        )
+        assert picked is None
+        assert err is not None
+        assert err.kind == BedrockErrorKind.CREDENTIALS_MISSING
+        # Stopped after the first probe — no point trying more models.
+        assert calls == ["us.anthropic.claude-opus-4-8"]
+
+
+class TestCatalogRefresh:
+    def test_bedrock_leads_with_current_opus(self) -> None:
+        from bog_agents_cli.provider_catalog import DEFAULT_MODEL_CANDIDATES
+
+        for provider in ("bedrock", "bedrock_converse"):
+            ids = list(DEFAULT_MODEL_CANDIDATES[provider])
+            assert ids[0] == "us.anthropic.claude-opus-4-8", provider
+            # 4-7 retained as a probe fallback (its Bedrock-id validity vs 4-8
+            # is account-dependent; the probe self-corrects either way), but
+            # after the current 4-8.
+            joined = " ".join(ids)
+            assert "claude-opus-4-7" in joined
+            assert joined.index("claude-opus-4-8") < joined.index("claude-opus-4-7")
+
+    def test_diverse_candidates_one_per_family(self) -> None:
+        from bog_agents_cli.bedrock_resilience import (
+            _model_family,
+            _split_region,
+            diverse_bedrock_candidates,
+        )
+
+        cands = diverse_bedrock_candidates("us-east-1")
+        families = [_model_family(_split_region(c)[1]) for c in cands]
+        assert len(families) == len(set(families))  # no family repeated
+        # Opus first (Claude-first), Nova reachable within the probe budget.
+        assert cands[0] == "us.anthropic.claude-opus-4-8"
+        assert any("amazon.nova" in c for c in cands[:8])


### PR DESCRIPTION
## Problem

Fresh users who configure AWS Bedrock (via `~/.aws` creds or `aws configure sso`) launch the CLI, type "hi", and ~10-15s later get a generic **"internal server error"**.

## Root causes (4 compounding bugs)

1. **Worst-possible default.** A fresh Bedrock user auto-resolves to `bedrock_converse:us.anthropic.claude-opus-4-7` — Opus is the *most* access-gated model and a fresh account almost never has it granted, so the first invoke returns `AccessDeniedException`.
2. **Diagnosis never reached the live turn.** The model call runs inside the `langgraph dev` subprocess, where langgraph genericizes the botocore error to *"An internal error occurred"* before it crosses to the CLI. The rich `categorize_bedrock_error`/banner was only wired into `test-bedrock` / `/bedrock test`, never the live agent turn.
3. **The Bedrock middleware never attached.** Its `isinstance(model, str)` gate is always `False` on the live path (the model is already resolved to a `ChatBedrockConverse`), so even the existing credential-refresh middleware was dead code.
4. **No automatic model fallback.** `provider_retry` correctly skips 4xx; `[models].fallbacks` only guards model *construction*, which never fails for Bedrock (no network at build time).

## What changed (all in `libs/cli/`)

- **`bedrock_resilience.py` — new `BedrockResilienceMiddleware`** wraps the model call *in-process*, where the original `ClientError` is still live:
  - On `AccessDenied` / `InvalidModelId` / `Throttling` it descends a **family-diverse, region-preferred** fallback ladder (Opus → Sonnet → Haiku → Nova, one id per family), sticky for the session, and answers with the first hittable model.
  - On account-wide failures (no region, missing/expired credentials, network) it returns a **categorized, region-named diagnosis** as a synthetic `AIMessage` — which survives the subprocess boundary as normal stream content. **Never a bare "internal server error".**
- **First-run probe-and-pick** (`config._pick_default_bedrock_spec` + `_bedrock.pick_hittable_bedrock_model`): probes which models the account can actually invoke (tiny 1-token `converse`, Claude-first → Nova) and persists the first hittable one as the default. Opt out with `BOG_AGENTS_BEDROCK_NO_PROBE=1`.
- **Attach fix** in `agent.create_cli_agent`: detect Bedrock from the *resolved* model and attach resilience (outer) + the now-reachable credential refresh (inner).
- **Catalog / messaging**: lead the Bedrock lists with current `us.anthropic.claude-opus-4-8` (keep `-4-7` as a probe fallback); region defaults to `us-east-1`, now **named in every error** and warned when auto-picked; missing-package message points at `pip install 'bog-agents-cli[bedrock]'`.

The `anthropic` catalog default and the `_models` inference-profile resolver are intentionally **left untouched** (out of scope; the investigation adversarially refuted several tempting "fixes" there).

## Product decisions baked in

- **Default model:** probe-and-pick, Claude-first (Opus → Sonnet → Haiku → Nova), persisted once.
- **On failure:** categorize the real cause **and** auto-descend the ladder.
- **Region:** default `us-east-1` but name it in errors and warn when auto-picked.

## Live validation (real Bedrock account)

- Real probe: `opus-4-8` → **AccessDenied** ("not available for this account"); `sonnet-4-6`, `haiku-4-5`, `nova-lite` → hittable. Probe correctly picks **Sonnet**.
- Full headless CLI forcing the denied Opus — server log shows the fix end-to-end:
  ```
  bedrock fallback ...opus-4-8 also failed: AccessDeniedException ... not available for this account
  bedrock: fell back from primary to bedrock_converse:us.anthropic.claude-sonnet-4-6
  ```
  → returns the real answer, **exit 0, 6.1s** (the old path here was "internal server error").
- Account-wide region error → the categorized banner with a copy-paste fix, no pointless model swap.

## Tests & gates

- New `tests/unit_tests/test_bedrock_resilience.py` (faux `ClientError`, no sockets): live-turn categorization, region naming, diverse fallback ladder, sticky fallback, account-wide diagnosis (no swap), non-Bedrock errors propagate, probe pick + early-abort, catalog freshness.
- Existing Bedrock / catalog / model-config / smoketest suites green (~340 passing), `ruff` clean, `ty` clean. No SDK files touched.

## Known minor gaps (cosmetic, not blocking)

- The auto-fallback "switched to X" note is best-effort in the streaming render (reliably shown for the diagnosis case; `--no-stream` may show just the answer). Can be promoted to a custom stream event in a follow-up.
- Usage stats attribute to the *configured* model rather than the *fallback* that actually ran (`cost_tracker` keys off the spec string).
