### PR TITLE
feat(sdk,cli): document and release /update, PDF read_file, and review-cycle cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ bog-agents -p "explain this module" < src/agent.py   # one-shot
 No key handy? Point it at a local [Ollama](https://ollama.com/) model and
 nothing leaves the machine.
 
+Keep current with `/update` inside the TUI — it checks PyPI, shows what will
+download, asks before installing, and upgrades the way you installed (uv tool /
+pipx / pip).
+
 ### Daemon (ambient runner)
 
 ```bash

--- a/libs/bog-agents/README.md
+++ b/libs/bog-agents/README.md
@@ -60,6 +60,10 @@ pip install "bog-agents[ollama]"         # local models
 
 Or all of them: `pip install "bog-agents[all-providers]"`.
 
+Other extras: `pip install "bog-agents[pdf]"` enables the `read_file` tool to
+extract text from `.pdf` files, and `pip install "bog-agents[serve]"` exposes
+the agent over HTTP.
+
 ---
 
 ## 30-second Quick Start

--- a/libs/cli/README.md
+++ b/libs/cli/README.md
@@ -125,6 +125,7 @@ Informational and configuration slash commands run without booting the TUI:
 bog-agents command "/help"          # full command reference
 bog-agents command "/commands"      # list commands; * marks headless-capable
 bog-agents command "/version" --json
+bog-agents command "/update"        # report whether a newer release is available
 bog-agents command "/model"         # show the configured model
 bog-agents command "/config"        # resolved config + file path
 ```
@@ -143,6 +144,14 @@ modal interactions, snapshots, assertions — see [Drive](#bog-agents-drive-exam
 ## What's new in 0.9.x
 
 - **0.10 — Claude-Code-style auto mode + self-verification.**
+  - **`/update`** — checks PyPI for a newer release, shows what you have vs.
+    what will download, asks y/n, then runs the right upgrade for how you
+    installed (uv tool / pipx / pip) and prompts a restart. Resilient by
+    design: source checkouts are detected and never auto-upgraded, and a
+    failed check or upgrade leaves your install untouched.
+  - **Select-to-copy** now runs the clipboard write off the UI thread, so
+    selecting text no longer briefly freezes the app and the "Copied" toast
+    shows immediately.
   - **Permission modes:** Shift+Tab cycles `default → accept-edits → plan`,
     Ctrl+T toggles bypass, with a live status indicator and a
     `--permission-mode {default,acceptEdits,plan,bypass,paranoid}` flag (and
@@ -334,7 +343,7 @@ respective extras; see the SDK docs for credentials and limits.
 | `-p MSG` | Same as `-n` but quiet — clean stdout for pipes. |
 | `--json` | Emit the result as a single JSON envelope (text + tool calls). |
 | `--jsonl` | Stream one JSON event per line (start / text / tool_call / tool_result / final). |
-| `command "/…"` | Run a headless-capable slash command (`/help`, `/version`, `/model`, `/config`, `/commands`, `/changelog`). |
+| `command "/…"` | Run a headless-capable slash command (`/help`, `/version`, `/update`, `/model`, `/config`, `/commands`, `/changelog`). |
 | `--prompt NAME` | Run a saved prompt from your prompt library. |
 | `--prompt-vars JSON` | Pass variable bindings to a saved prompt. |
 | `--pipeline NAME` | Run a saved pipeline from `.bog-agents/pipelines/`. |


### PR DESCRIPTION
## Why

The features below were merged in #150, but that PR squash-merged with a
non-conventional subject, so **release-please created no release**. This PR
carries the proper `feat(...)` prefix (and documents the features in the
READMEs) to cut the release for the already-merged work — the same pattern as
#134 / the prior "document and release" commits.

## What it changes

README-only diff (the feature code already shipped in #150):
- **Root + CLI README** — the `/update` command (review → y/n → install-method-
  aware upgrade → restart) and its headless twin; a note on the off-thread
  select-to-copy fix.
- **SDK README** — the `pdf` extra that lets `read_file` extract text from PDFs.

## Released work (from #150, now getting a version)

- CLI: resilient `/update`; select-to-copy lag fix; folded `update_check` into
  `update_manager`; fixed orchestrator-timeout / version-compare / `uvx` bugs;
  removed verified-dead code.
- SDK: PDF reading wired into `read_file` (+ `pdf` extra); `with_multi_agent`
  repointed to `ParallelAgentsMiddleware`; corrected `create_agent` docstring.

## Test plan

No code changes here (docs only). The underlying work was validated before #150:
CLI 4490 passed / SDK 1630 passed; ruff + ruff format + ty clean; lockfiles
consistent on both packages.